### PR TITLE
240 pdo data is returned update

### DIFF
--- a/webapp/_lib/model/class.PDODAO.php
+++ b/webapp/_lib/model/class.PDODAO.php
@@ -228,12 +228,11 @@ abstract class PDODAO {
      * @return bool True if row(s) are returned
      */
     protected final function getDataIsReturned($ps){
-        $count = $ps->rowCount();
+        $row = $ps->fetch();
         $ps->closeCursor();
-        if ($count > 0) {
+        $ret = false;
+        if ($row && count($row) > 0) {
             $ret = true;
-        } else {
-            $ret = false;
         }
         return $ret;
     }


### PR DESCRIPTION
this should fix Su's problem, and even if not, we should update re the PHP Docs:

 PDOStatement::rowCount() returns the number of rows affected by the last DELETE, INSERT, or UPDATE statement executed by the corresponding PDOStatement object.

If the last SQL statement executed by the associated PDOStatement was a SELECT statement, some databases may return the number of rows returned by that statement. However, this behavior is not guaranteed for all databases and should not be relied on for portable applications. 
