### PR TITLE
223 auto update database migrations rc1

### DIFF
--- a/tests/TestOfTestController.php
+++ b/tests/TestOfTestController.php
@@ -135,6 +135,20 @@ class TestOfTestController extends ThinkUpUnitTestCase {
     }
 
     /**
+     * Test app upgrade status
+     */
+    public function testUpgradeStatus() {
+        $config = Config::getInstance();
+        $upgrade_status_file =
+        $config->getValue('source_root_path') . 'webapp/' . UpgradeController::UPGRADE_IN_PROGRESS_FILE;
+        touch( $upgrade_status_file );
+        $controller = new TestController(true);
+        $results = $controller->go();
+        $this->assertPattern('/<!--  we are upgrading -->/', $results);
+        unlink($upgrade_status_file);
+    }
+
+    /**
      * Test exception handling
      */
     public function testExceptionHandling() {

--- a/tests/TestOfUpgradeController.php
+++ b/tests/TestOfUpgradeController.php
@@ -1,0 +1,114 @@
+<?php
+require_once dirname(__FILE__).'/init.tests.php';
+require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
+require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
+
+class TestOfUpgradeController extends ThinkUpUnitTestCase {
+
+    public function __construct() {
+        $this->UnitTestCase('UpgradeController class test');
+    }
+
+    public function setUp(){
+        parent::setUp();
+        $webapp = Webapp::getInstance();
+        $webapp->registerPlugin('twitter', 'TwitterPlugin');
+    }
+
+    public function tearDown(){
+        parent::tearDown();
+        if(file_exists(THINKUP_WEBAPP_PATH . UpgradeController::UPGRADE_IN_PROGRESS_FILE)) {
+            unlink( THINKUP_WEBAPP_PATH . UpgradeController::UPGRADE_IN_PROGRESS_FILE );
+        }
+    }
+
+    public function testConstructor() {
+        $controller = new UpgradeController(true);
+        $this->assertTrue(isset($controller));
+    }
+
+    public function testNotLoggedIn() {
+        $controller = new UpgradeController(true);
+        $results = $controller->go();
+        $v_mgr = $controller->getViewManager();
+        $config = Config::getInstance();
+        $this->assertEqual('You must <a href="'.$config->getValue('site_root_path').
+        'session/login.php">log in</a> to do this.', $v_mgr->getTemplateDataItem('errormsg'));
+    }
+
+    public function testNoMigrationNeeded() {
+        $this->simulateLogin('me@example.com');
+        $controller = new UpgradeController(true);
+        $results = $controller->go();
+        $this->assertPattern('/<!-- no upgrade needed -->/', $results);
+    }
+
+    public function testOneDatabaseMigrationNeeded() {
+        $this->simulateLogin('me@example.com');
+        $this->db->exec('alter table tu_owners drop index email');
+        $controller = new UpgradeController(true);
+        $results = $controller->go();
+        $this->assertPattern('/1 database migration to run/', $results);
+        $v_mgr = $controller->getViewManager();
+        $queries = $v_mgr->getTemplateDataItem('migrations');
+        $this->assertEqual(1, count($queries), 'one migration query');
+        $this->assertEqual('ALTER TABLE tu_owners ADD UNIQUE KEY email (email)', $queries[0]);
+        $this->assertTrue(file_exists(THINKUP_WEBAPP_PATH . UpgradeController::UPGRADE_IN_PROGRESS_FILE));
+    }
+
+    public function testTwoDatabaseMigrationNeeded() {
+        $this->simulateLogin('me@example.com');
+        $this->db->exec('alter table tu_owners drop index email');
+        $this->db->exec('alter table tu_owners drop column full_name');
+        $controller = new UpgradeController(true);
+        $results = $controller->go();
+        $this->assertPattern('/2 database migrations to run/', $results);
+        $v_mgr = $controller->getViewManager();
+        $queries = $v_mgr->getTemplateDataItem('migrations');
+        $this->assertEqual(2, count($queries), 'two migration queries');
+        $this->assertEqual('ALTER TABLE tu_owners ADD COLUMN full_name varchar(200) NOT NULL', $queries[0]);
+        $this->assertEqual('ALTER TABLE tu_owners ADD UNIQUE KEY email (email)', $queries[1]);
+        $this->assertTrue(file_exists(THINKUP_WEBAPP_PATH . UpgradeController::UPGRADE_IN_PROGRESS_FILE));
+    }
+
+    public function testProcessMigrationsBadSQL() {
+        $this->simulateLogin('me@example.com');
+        $this->db->exec('alter table tu_owners drop index email');
+        $this->db->exec('alter table tu_owners drop column full_name');
+        $controller = new UpgradeController(true);
+        $results = $controller->go();
+        $this->assertPattern('/2 database migrations to run/', $results);
+        $v_mgr = $controller->getViewManager();
+        $queries = $v_mgr->getTemplateDataItem('migrations');
+
+        // bad sql
+        $controller = new UpgradeController(true);
+        $_GET['process_sql'] = 'drop table tu_users';
+        $results = $controller->go();
+        $obj = json_decode($results);
+        $this->assertFalse($obj->processed);
+    }
+
+    public function testProcessMigrationsGoodSQL() {
+        $this->simulateLogin('me@example.com');
+        $this->db->exec('alter table tu_owners drop index email');
+        $this->db->exec('alter table tu_owners drop column full_name');
+        $query1 = 'ALTER TABLE tu_owners ADD COLUMN full_name varchar(200) NOT NULL';
+        $controller = new UpgradeController(true);
+        $_GET['process_sql'] = $query1;
+        $results = $controller->go();
+        $obj = json_decode($results);
+        $this->assertTrue($obj->processed);
+        $this->assertEqual($obj->sql, $query1);
+    }
+
+    public function testMigrationDone() {
+        $this->simulateLogin('me@example.com');
+        touch( THINKUP_WEBAPP_PATH . UpgradeController::UPGRADE_IN_PROGRESS_FILE );
+        $this->assertTrue(file_exists(THINKUP_WEBAPP_PATH . UpgradeController::UPGRADE_IN_PROGRESS_FILE));
+        $controller = new UpgradeController(true);
+        $_GET['migration_done'] = true;
+        $results = $controller->go();
+        $this->assertFalse(file_exists(THINKUP_WEBAPP_PATH . UpgradeController::UPGRADE_IN_PROGRESS_FILE));
+    }
+}

--- a/tests/all_controller_tests.php
+++ b/tests/all_controller_tests.php
@@ -59,4 +59,5 @@ $controller_test->addTestCase(new TestOfUserController());
 $controller_test->addTestCase(new TestOfPluginOptionController());
 $controller_test->addTestCase(new TestOfTestAuthAPIController());
 $controller_test->addTestCase(new TestOfRSSController());
+$controller_test->addTestCase(new TestOfUpgradeController());
 $controller_test->run( new TextReporter());

--- a/webapp/_lib/controller/class.ThinkUpController.php
+++ b/webapp/_lib/controller/class.ThinkUpController.php
@@ -278,19 +278,27 @@ abstract class ThinkUpController {
      */
     public function go() {
         try {
-            $this->initalizeApp();
-            $results = $this->control();
-            if ($this->profiler_enabled && !isset($this->json_data) && strpos($this->content_type, 'text/javascript') === false) {
-                $end_time = microtime(true);
-                $total_time = $end_time - $this->start_time;
-                $profiler = Profiler::getInstance();
-                $this->disableCaching();
-                $profiler->add($total_time, "total page execution time, running ".$profiler->total_queries." queries.");
-                $this->setViewTemplate('_profiler.tpl');
-                $this->addToView('profile_items',$profiler->getProfile());
-                return  $results . $this->generateView();
-            } else  {
-                return $results;
+            if(file_exists(THINKUP_WEBAPP_PATH . UpgradeController::UPGRADE_IN_PROGRESS_FILE)
+            && get_class($this) != 'UpgradeController')
+            {
+                //we are upgrading/running a db migration
+                $this->setViewTemplate('upgrade.running.tpl');
+                return $this->generateView();
+            } else {
+                $this->initalizeApp();
+                $results = $this->control();
+                if ($this->profiler_enabled && !isset($this->json_data) && strpos($this->content_type, 'text/javascript') === false) {
+                    $end_time = microtime(true);
+                    $total_time = $end_time - $this->start_time;
+                    $profiler = Profiler::getInstance();
+                    $this->disableCaching();
+                    $profiler->add($total_time, "total page execution time, running ".$profiler->total_queries." queries.");
+                    $this->setViewTemplate('_profiler.tpl');
+                    $this->addToView('profile_items',$profiler->getProfile());
+                    return  $results . $this->generateView();
+                } else  {
+                    return $results;
+                }
             }
         } catch (Exception $e) {
             date_default_timezone_set('America/Los_Angeles'); //Temporary fix to avoid Smarty warning

--- a/webapp/_lib/controller/class.UpgradeController.php
+++ b/webapp/_lib/controller/class.UpgradeController.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Upgrade Controller
+ *
+ * Runs DB migrations
+ *
+ * @author Mark Wilkie <mwilkie[at]gmail[dot]com>
+ *
+ */
+class UpgradeController extends ThinkUpAuthController {
+
+    /**
+     * Upgrade status file. Disables all controllers but UpgradeController
+     * if this file exists.
+     */
+    const UPGRADE_IN_PROGRESS_FILE = '_lib/view/compiled_view/upgrade-in-progress';
+
+    /**
+     * Constructor
+     * @param bool $session_started
+     * @return UpgradeController
+     */
+    public function __construct($session_started=false) {
+        parent::__construct($session_started);
+    }
+
+
+    public function authControl() {
+
+        $build_sql_file = THINKUP_WEBAPP_PATH . 'install/sql/build-db_mysql.sql';
+        $install_dao = DAOFactory::getDAO('InstallerDAO');
+        $build_sql_string = file_get_contents($build_sql_file);
+
+        if(! $build_sql_string) {
+            throw new OpenFileException("Unable to open file: " + $build_sql_file);
+        }
+        $tables = $install_dao->getTables();
+
+        // clean up primary key sql
+        $build_sql_string = str_replace('PRIMARY KEY ', 'PRIMARY KEY  ', $build_sql_string);
+        // pull out insert after dump data
+        $build_sql_string = preg_replace('/-- Dump completed.*/s', '', $build_sql_string);
+        $migrate_sql_array = $install_dao->diffDataStructure($build_sql_string, $tables);
+        if(isset($_GET['process_sql'])) {
+            sleep(1); // just so we can see what is happening...
+            $process_sql  = stripslashes($_GET['process_sql']);
+            $processed = false;
+            foreach($migrate_sql_array['queries'] as $sql) {
+                if($sql == $process_sql) {
+                    $install_dao->runMigrationSQL($process_sql);
+                    $processed = true;
+                }
+            }
+            $this->setJsonData( array( 'processed' => $processed, 'sql' => $process_sql) );
+        } else if (isset($_GET['migration_done'])) {
+            unlink(THINKUP_WEBAPP_PATH . self::UPGRADE_IN_PROGRESS_FILE);
+        } else {
+            $this->setPageTitle('Upgrade...');
+            $this->setViewTemplate('upgrade.index.tpl');
+            $this->addToView('migrations',$migrate_sql_array['queries']);
+            $this->addToView('migrations_json', json_encode($migrate_sql_array['queries']));
+            // do we need to do a migration?
+            if(count( $migrate_sql_array['queries'] ) > 0) {
+                // disable all controller bu upgrade
+                touch(THINKUP_WEBAPP_PATH . self::UPGRADE_IN_PROGRESS_FILE);
+            }
+        }
+
+        return $this->generateView();
+
+    }
+}

--- a/webapp/_lib/model/class.InstallerMySQLDAO.php
+++ b/webapp/_lib/model/class.InstallerMySQLDAO.php
@@ -66,6 +66,11 @@ class InstallerMySQLDAO extends PDODAO implements InstallerDAO  {
         return $this->getDataRowsAsArrays($ps);
     }
 
+    public function runMigrationSQL($sql) {
+        $ps = $this->execute($sql);
+        $result = $this->getUpdateCount($ps);
+    }
+
     public function diffDataStructure($desired_structure_sql_string = '', $existing_tables = array()) {
         $queries = explode(';', $desired_structure_sql_string);
         if ( $queries[count($queries)-1] == '' ) {

--- a/webapp/_lib/model/exceptions/class.OpenFileException.php
+++ b/webapp/_lib/model/exceptions/class.OpenFileException.php
@@ -1,0 +1,2 @@
+<?php 
+class OpenFileException extends Exception {}

--- a/webapp/_lib/view/upgrade.index.tpl
+++ b/webapp/_lib/view/upgrade.index.tpl
@@ -1,0 +1,58 @@
+{include file="_header.tpl"}
+{include file="_statusbar.tpl"}
+<div class="container_24 thinkup-canvas round-all">
+  <div class="prepend_20">
+    <h1>Upgrade</h1>
+  </div>
+  <div class="clearfix prepend_20">
+    <div class="grid_17 prefix_3 left">
+    {include file="_usermessage.tpl"}
+    </div>
+  </div>
+
+    <div class="ui-state-highlight ui-corner-all" style="margin: 20px 0px; padding: 0.5em 0.7em;">
+    {if ! $migrations[0]}
+    
+    <!-- no upgrade needed -->
+    <p>Your database is up to date. There is no upgrade needed.</p>
+    {else}
+        <div style="text-align: center;" id="migration-info">
+        There {if $migrations|@count gt 1}are{else}is{/if}
+        {$migrations|@count} database migration{if $migrations|@count gt 1}s{/if} to run
+        </div>
+        <script type="text/javascript">
+        var sql_array = {$migrations_json};
+        </script>
+    {/if}
+    </div>
+    {if $migrations[0]}
+    <div class="clearfix">
+        <div class="grid_10 prefix_9 left">
+        <form name="upgrade" method="get" action="" id="upgrade-form" onsubmit="return false;">
+        <input id="migration-submit" 
+        name="Submit" class="tt-button ui-state-default ui-priority-secondary ui-corner-all" 
+        value="Run Migrations" type="submit" style="font-size:24px;line-height:2.2em;">
+        </form>
+        </div>
+     </div>
+     
+     <div id="upgrade-error" class="ui-state-error ui-corner-all" 
+     style="margin: 20px 0px; padding: 0.5em 0.7em; display: none;">
+     Error...
+     </div>
+     <div style="text-align:center; height: 31px;">
+        <img src="{$site_root_path}assets/img/loading.gif" style="display: none;" 
+        id="migrate_spinner" width="31" height="31">
+     </div>
+     <div id="migration-status" style="margin: 20px;">
+     </div>
+    {/if}
+
+<br />&nbsp;<br />
+    
+</div>
+
+<script type="text/javascript" src="{$site_root_path}assets/js/upgrade.js"></script>
+
+
+{include file="_footer.tpl"}

--- a/webapp/_lib/view/upgrade.running.tpl
+++ b/webapp/_lib/view/upgrade.running.tpl
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+<meta charset="utf-8">
+<title>ThinkUp: Upgrading</title>
+<link rel="shortcut icon" type="image/x-icon"
+    href="/assets/img/favicon.ico">
+<!-- jquery -->
+<link type="text/css" rel="stylesheet"
+    href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8/themes/base/jquery-ui.css">
+<script type="text/javascript"
+    src="http://ajax.googleapis.com/ajax/libs/jquery/1.4/jquery.min.js"></script>
+<script type="text/javascript"
+    src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8/jquery-ui.min.js"></script>
+<!-- custom css -->
+<link type="text/css" rel="stylesheet"
+    href="{$site_root_path}assets/css/base.css">
+<link type="text/css" rel="stylesheet"
+    href="{$site_root_path}assets/css/positioning.css">
+<link type="text/css" rel="stylesheet"
+    href="{$site_root_path}assets/css/style.css">
+<link type="text/css" rel="stylesheet"
+    href="{$site_root_path}assets/css/installer.css">
+</head>
+
+<body>
+
+<div id="status-bar" class="clearfix">
+
+<div class="status-bar-left"><!-- the user has not selected an instance -->
+</div>
+<!-- end .status-bar-left -->
+
+<div class="status-bar-right">
+<ul>
+    <li>&nbsp;</li>
+</ul>
+</div>
+<!-- end .status-bar-right --></div>
+<!-- end #status-bar -->
+
+<div class="container clearfix">
+
+<div id="app-title"><a href="{$site_root_path}index.php">
+<h1><span class="bold">Think</span><span class="gray">Up</span></h1>
+<h2>New ideas</h2>
+</a></div>
+<!-- end #app-title -->
+
+<div id="menu-bar">
+<ul>
+    <li class="round-tr round-br round-tl round-bl"><a
+        href="http://thinkupapp.com/">Get ThinkUp</a></li>
+</ul>
+</div>
+<!-- end #menu-bar --></div>
+<!-- end .container -->
+<div class="container_24 thinkup-canvas clearfix">
+<div class="grid_22 prefix_1 alpha omega prepend_20 append_20 clearfix">
+<div class="ui-state-error ui-corner-all" style="margin: 20px 0px; padding: 0.5em 0.7em;">
+<!--  we are upgrading -->
+<p>
+ThinkUp is currently in the process of upgrading. Please try back again in a little while.
+</p>
+</div>
+</div>
+</div>
+
+<div class="container small center">
+
+<div id="ft" role="contentinfo">
+<p>It is nice to be nice.</p>
+</div>
+<!-- #ft --></div>
+<!-- .content -->
+
+</body>
+
+</html>

--- a/webapp/assets/js/upgrade.js
+++ b/webapp/assets/js/upgrade.js
@@ -1,0 +1,126 @@
+/**
+ * Upgrade db Migration object for migrating db updates...
+ */
+var TU_Update = function() {
+
+    /**
+     * current position for sql_array
+     */
+    this.position = 0;
+
+    /**
+     * our json sql array count
+     */
+    this.count = 0;
+    /**
+     * @var boolean Enable for console logging
+     */
+    this.DEBUG = false;
+
+    /**
+     * Init our update form
+     */
+    this.init = function() {
+        // gen count for our json array (since the normal array.lenght does not
+        // work on json structures
+        if (typeof (sql_array) != 'undefined') {
+            for (_obj in sql_array)
+                this.count++;
+        }
+
+        // register on submit event on our form
+        $(document).ready(function() {
+            $("#upgrade-form").submit(function(event) {
+                if (tu_update.DEBUG) {
+                    console.debug("upgrade form submitted");
+                }
+                if (!tu_update.submitting) {
+                    $('#migration-submit').hide();
+                    tu_update.prependStatus("Starting database migration...");
+                    tu_update.submitForm();
+                }
+            });
+        });
+    };
+
+    /**
+     * Process next upgrade sql in list
+     */
+    this.submitForm = function() {
+        if (tu_update.submitting)
+            return;
+        sql_num = tu_update.position + 1;
+        sql = sql_array[tu_update.position];
+        tu_update.prependStatus("processing sql migration " + sql_num + " of "
+                + tu_update.count + ": " + '<i>' + sql + '</i>');
+        tu_update.position++;
+        if (sql.match(/key/i)) {
+            tu_update
+                    .prependStatus("&nbsp; <b>note:</b> Adding an index, this may take some time");
+        }
+        controller_uri = site_root_path + 'install/upgrade.php';
+        tu_update.submitting = true;
+        $('#migrate_spinner').show();
+        $ajax_data = {
+            url : controller_uri,
+            data : {
+                process_sql : sql
+            },
+            error : function(data) {
+                tu_update.submitting = false;
+                $('#migrate_spinner').hide();
+                $('#upgrade-error')
+                        .html(
+                                'Sorry, but we are unable to process your request at this time.');
+                $('#upgrade-error').show();
+            },
+            success : function(data) {
+                tu_update.submitting = false;
+                $('#migrate_spinner').hide();
+                if (data && data.processed) {
+                    tu_update.prependStatus("Complete");
+                    if (tu_update.position <= tu_update.count - 1) {
+                        tu_update.prependStatus("<br />");
+                        tu_update.submitForm();
+                    } else {
+                        tu_update.prependStatus("<br />");
+                        tu_update.prependStatus("<b>Migration Complete!</b>");
+                        $('#migration-info').html('<b>Migration Complete!</b>');
+                        $('#migrate_spinner').hide();
+                        $done_ajax_data = {
+                            url : controller_uri,
+                            data : {
+                                migration_done : true
+                            },
+                            error : function() {
+                                $('#migrate_spinner').hide();
+                                $('#upgrade-error')
+                                        .html(
+                                                'Sorry, but we are unable to process your request.');
+                                $('#upgrade-error').show();
+                            }
+                        }
+                        $.ajax($done_ajax_data);
+                    }
+                } else {
+                    $('#upgrade-error')
+                            .html(
+                                    'Sorry, but we are unable to process your request at this time.');
+                    $('#upgrade-error').show();
+                }
+            }
+        }
+        $.ajax($ajax_data);
+    }
+
+    /**
+     * prepend text to migration status div
+     */
+    this.prependStatus = function(status) {
+        status = '<div>' + status + '</div>';
+        $('#migration-status').prepend(status);
+    }
+}
+
+var tu_update = new TU_Update();
+tu_update.init();

--- a/webapp/install/upgrade.php
+++ b/webapp/install/upgrade.php
@@ -1,0 +1,10 @@
+<?php
+chdir("..");
+require_once '_lib/model/class.Loader.php';
+Loader::register();
+
+Utils::defineConstants();
+
+$controller = new UpgradeController();
+echo $controller->go();
+


### PR DESCRIPTION
this is looking pretty good. as i mentioned, only really supports added indexes and columns right now.

also, I didn't add the gpl header. do we have a script to gen that bit, or do I need to add manually? let me know if i need to add.

to test, drop a column from the db, ie: _'alter table tu_owners drop column activation_code;'_

and then go to **install/upgrade.php** when logged in as an admin.

finally, as always, could probably do with some real stylin', but I do what I can ;)
