### PR TITLE
Twitter plugin config

### DIFF
--- a/webapp/plugins/twitter/controller/class.TwitterAuthController.php
+++ b/webapp/plugins/twitter/controller/class.TwitterAuthController.php
@@ -68,7 +68,8 @@ class TwitterAuthController extends ThinkUpAuthController {
 
             if (isset($tok['oauth_token']) && isset($tok['oauth_token_secret'])) {
                 $api = new TwitterAPIAccessorOAuth($tok['oauth_token'], $tok['oauth_token_secret'],
-                $options['oauth_consumer_key']->option_value, $options['oauth_consumer_secret']->option_value);
+                $options['oauth_consumer_key']->option_value, $options['oauth_consumer_secret']->option_value,
+                $options['num_twitter_errors']->option_value);
 
                 $u = $api->verifyCredentials();
 

--- a/webapp/plugins/twitter/controller/class.TwitterPluginConfigurationController.php
+++ b/webapp/plugins/twitter/controller/class.TwitterPluginConfigurationController.php
@@ -50,13 +50,17 @@ class TwitterPluginConfigurationController extends PluginConfigurationController
         $oauth_consumer_key = $this->getPluginOption('oauth_consumer_key');
         $oauth_consumer_secret = $this->getPluginOption('oauth_consumer_secret');
         $archive_limit = $this->getPluginOption('archive_limit');
+        $num_twitter_errors = $this->getPluginOption('num_twitter_errors');
         //Add public user instance
         if (isset($_GET['twitter_username'])) { // if form was submitted
             $logger = Logger::getInstance();
 
             //Check user exists and is public
+            // aju -- passing of archive limit into this constructor was a bug? [constructor does not use it]
             $api = new TwitterAPIAccessorOAuth('NOAUTH', 'NOAUTH', $oauth_consumer_key, $oauth_consumer_secret,
-            $archive_limit);
+              $num_twitter_errors);
+            // $api = new TwitterAPIAccessorOAuth('NOAUTH', 'NOAUTH', $oauth_consumer_key, $oauth_consumer_secret,
+              // $archive_limit);
             $api_call = str_replace("[id]", $_GET['twitter_username'], $api->cURL_source['show_user']);
             list($cURL_status, $data) = $api->apiRequestFromWebapp($api_call);
             if ($cURL_status == 200) {
@@ -145,6 +149,11 @@ class TwitterPluginConfigurationController extends PluginConfigurationController
         $archive_limit = array('name' => 'archive_limit',
                                'label' => $archive_limit_label, 'default_value' => '3200');
         $this->addPluginOption(self::FORM_TEXT_ELEMENT, $archive_limit);
+        // aju
+        $num_twitter_errors_label = 'Number of Twitter Errors Tolerated';
+        $num_twitter_errors = array('name' => 'num_twitter_errors',
+                               'label' => $num_twitter_errors_label, 'default_value' => '5');
+        $this->addPluginOption(self::FORM_TEXT_ELEMENT, $num_twitter_errors);
 
     }
 }

--- a/webapp/plugins/twitter/model/class.TwitterPlugin.php
+++ b/webapp/plugins/twitter/model/class.TwitterPlugin.php
@@ -54,6 +54,8 @@ class TwitterPlugin implements CrawlerPlugin, WebappPlugin {
             $logger->setUsername($instance->network_username);
             $tokens = $oid->getOAuthTokens($instance->id);
             $noauth = true;
+            $num_twitter_errors = 
+              isset($options['num_twitter_errors']) ? $options['num_twitter_errors']->option_value : null;
             if (isset($tokens['oauth_access_token']) && $tokens['oauth_access_token'] != ''
             && isset($tokens['oauth_access_token_secret']) && $tokens['oauth_access_token_secret'] != '') {
                 $noauth = false;
@@ -63,12 +65,14 @@ class TwitterPlugin implements CrawlerPlugin, WebappPlugin {
                 $api = new CrawlerTwitterAPIAccessorOAuth('NOAUTH', 'NOAUTH',
                 $options['oauth_consumer_key']->option_value,
                 $options['oauth_consumer_secret']->option_value,
-                $instance, $options['archive_limit']->option_value);
+                $instance, $options['archive_limit']->option_value,
+                $num_twitter_errors);
             } else {
                 $api = new CrawlerTwitterAPIAccessorOAuth($tokens['oauth_access_token'],
                 $tokens['oauth_access_token_secret'], $options['oauth_consumer_key']->option_value,
                 $options['oauth_consumer_secret']->option_value,
-                $instance, $options['archive_limit']->option_value);
+                $instance, $options['archive_limit']->option_value,
+                $num_twitter_errors);
             }
 
             $crawler = new TwitterCrawler($instance, $api);

--- a/webapp/plugins/twitter/tests/TestOfTwitterAPIAccessorOAuth.php
+++ b/webapp/plugins/twitter/tests/TestOfTwitterAPIAccessorOAuth.php
@@ -75,7 +75,7 @@ class TestOfTwitterAPIAccessorOAuth extends ThinkUpBasicUnitTestCase {
         $this->assertWantedPattern('/A or B/', $result);
 
         $api = new CrawlerTwitterAPIAccessorOAuth('111', '222', 1234,
-        1234, $this->getTestInstance(), 3200);
+          1234, $this->getTestInstance(), 3200, 5);
         $users = $api->parseXML($result);
         $next_cursor = $api->getNextCursor();
         //echo 'Next cursor is ' . $next_cursor;
@@ -89,7 +89,7 @@ class TestOfTwitterAPIAccessorOAuth extends ThinkUpBasicUnitTestCase {
         $result = $to->oAuthRequest('https://twitter.com/followers/ids.xml', 'GET', array());
 
         $api = new CrawlerTwitterAPIAccessorOAuth('111', '222', 1234,
-        1234, $this->getTestInstance(), 3200);
+          1234, $this->getTestInstance(), 3200, 5);
         $users = $api->parseXML($result);
         $next_cursor = $api->getNextCursor();
         //echo 'Next cursor is ' . $next_cursor;
@@ -103,7 +103,7 @@ class TestOfTwitterAPIAccessorOAuth extends ThinkUpBasicUnitTestCase {
         $twitter_data = $to->http('http://search.twitter.com/search.json?q=%40whitehouse&result_type=recent');
 
         $api = new CrawlerTwitterAPIAccessorOAuth('111', '222', 1234,
-        1234, $this->getTestInstance(), 3200);
+          1234, $this->getTestInstance(), 3200, 5);
 
         $results = $api->parseJSON($twitter_data);
 
@@ -124,7 +124,7 @@ class TestOfTwitterAPIAccessorOAuth extends ThinkUpBasicUnitTestCase {
  </body>
 </document>
 XML;
-        $api = new TwitterAPIAccessorOAuth('111', '222', 'test-oauth_consumer_key', 'test-oauth_consumer_secret');
+        $api = new TwitterAPIAccessorOAuth('111', '222', 'test-oauth_consumer_key', 'test-oauth_consumer_secret', 5);
 
         $this->assertFalse($api->createParserFromString(utf8_encode($data)));
     }

--- a/webapp/plugins/twitter/tests/TestOfTwitterAuthController.php
+++ b/webapp/plugins/twitter/tests/TestOfTwitterAuthController.php
@@ -115,6 +115,8 @@ class TestOfTwitterAuthController extends ThinkUpUnitTestCase {
         'option_name'=>'oauth_consumer_key', 'option_value'=>'XXX'));
         $plugn_opt_builder2 = FixtureBuilder::build('plugin_options', array('plugin_id'=>'1',
         'option_name'=>'oauth_consumer_secret', 'option_value'=>'YYY'));
+        $plugn_opt_builder3 = FixtureBuilder::build('plugin_options', array('plugin_id'=>'1',
+        'option_name'=>'num_twitter_errors', 'option_value'=>'5'));
 
         $controller = new TwitterAuthController(true);
         $results = $controller->go();

--- a/webapp/plugins/twitter/tests/TestOfTwitterCrawler.php
+++ b/webapp/plugins/twitter/tests/TestOfTwitterCrawler.php
@@ -87,7 +87,7 @@ class TestOfTwitterCrawler extends ThinkUpUnitTestCase {
         $this->instance = new Instance($r);
 
         $this->api = new CrawlerTwitterAPIAccessorOAuth('111', '222', 'fake_key',
-        'fake_secret', $this->instance, 1234);
+        'fake_secret', $this->instance, 1234, 5);
 
         $this->api->available = true;
         $this->api->available_api_calls_for_crawler = 20;
@@ -106,7 +106,7 @@ class TestOfTwitterCrawler extends ThinkUpUnitTestCase {
         $this->instance = new Instance($r);
 
         $this->api = new CrawlerTwitterAPIAccessorOAuth('111', '222', 'fake_key',
-        'fake_secret', $this->instance, 1234);
+        'fake_secret', $this->instance, 1234, 5);
         $this->api->available = true;
         $this->api->available_api_calls_for_crawler = 20;
         $this->instance->is_archive_loaded_follows = true;


### PR DESCRIPTION
This adds config of number of twitter API errors tolerated, to the set of twitter plugin options.
The default plugin option value is 5 (obvs change to what you think makes sense), and if the plugin option is not defined in the database (which will be the case if the user updates their code but does not re-submit the plugin config page), the code falls back to using the original 
$total_errors_to_tolerate = 3 .

Also included in these mods is retry of a failed request, where $num_retries is set in the code to 2 (not currently configurable via the UI).
