### PR TITLE
370 long urls dont wrap

### DIFF
--- a/webapp/assets/css/base.css
+++ b/webapp/assets/css/base.css
@@ -105,7 +105,9 @@ a img {
 .container_24 .grid_6  { width: 230px; }
 .container_24 .grid_7  { width: 270px; }
 .container_24 .grid_8  { width: 310px; }
-.container_24 .grid_9  { width: 350px; }
+/* grid_9 contains the tweet/status content. Word wrapping and overflow handling
+are in place to stop long URLs or words from overflowing. */
+.container_24 .grid_9  { width: 350px; word-wrap: break-word; overflow: auto; }
 .container_24 .grid_10 { width: 390px; }
 .container_24 .grid_11 { width: 430px; }
 .container_24 .grid_12 { width: 470px; }


### PR DESCRIPTION
Added 2 new properties to the grid_9 class, "word-wrap: break-word;" which is non standard and only works in a few browsers. As a fall back, "overflow: auto;" has been added so that any overflow scrolls and the overflow property is supported in all major browsers (http://w3schools.com/css/pr_pos_overflow.asp).

I tested how it looked as it degraded and the overflow: auto; isn't as glamorous as the word wrapping but I can't think of any ways to support word wrapping without the word-wrap CSS property. 

I tested that the word-wrap property works in Opera 10.63, Firefox 3.6.10 and Chromium 6. It does.

World's smallest commit? :p
