### PR TITLE
355 explicit instructions public account

### DIFF
--- a/tests/TestOfDashboardController.php
+++ b/tests/TestOfDashboardController.php
@@ -59,7 +59,11 @@ class TestOfDashboardController extends ThinkUpUnitTestCase {
 
         $v_mgr = $controller->getViewManager();
         $this->assertEqual($v_mgr->getTemplateDataItem('infomsg'),
-        "There are no public accounts set up in this ThinkUp installation.");
+        'There are no public accounts set up in this ThinkUp installation.<br /><br />
+To make a current account public you need to first log in, then once you are logged
+in click on "Configuration" button in the top right hand side of the screen.
+Then click on one of the plugins that contain accounts (Facebook, Twitter, etc.) and click
+"Set Public" next to the account you wish to make public.');
     }
 
     public function testNoInstancesLoggedIn() {

--- a/webapp/_lib/controller/class.DashboardController.php
+++ b/webapp/_lib/controller/class.DashboardController.php
@@ -55,7 +55,11 @@ class DashboardController extends ThinkUpController {
             $this->loadView();
         } else {
             if (!Session::isLoggedIn()) {
-                $this->addInfoMessage('There are no public accounts set up in this ThinkUp installation.');
+                $this->addInfoMessage('There are no public accounts set up in this ThinkUp installation.<br /><br />
+To make a current account public you need to first log in, then once you are logged
+in click on "Configuration" button in the top right hand side of the screen.
+Then click on one of the plugins that contain accounts (Facebook, Twitter, etc.) and click
+"Set Public" next to the account you wish to make public.');
             } else  {
                 $config = Config::getInstance();
                 $this->addInfoMessage('You have no accounts configured. <a href="'.$config->getValue('site_root_path').


### PR DESCRIPTION
Another small commit.

Very simply changed the message that appears when you have no public accounts set. Got some strange test errors on my end and I have no idea why... I'm almost certain I couldn't have caused them so I'm hoping it's something I've done wrong somewhere else outside of this commit.
