### PR TITLE
Makes it easier to hit the links in the webapp's UI.

### DIFF
--- a/webapp/assets/css/style.css
+++ b/webapp/assets/css/style.css
@@ -86,8 +86,8 @@ ul.user-accounts li ul li {margin-left:2em;}
 
 #menu-bar {float: right;margin:20px 0 20px 0;}
 #menu-bar ul {}
-#menu-bar li {display: inline;background-color: #222;padding: 15px 10px;margin: 0 1px 0 0;font-size: 1.2em;float: left;}
-#menu-bar li a:link, #menu-bar li a:visited {color: #FFF;text-decoration: none;}
+#menu-bar li {display: inline;background-color: #222;padding: 0;margin: 0 1px 0 0;font-size: 1.2em;float: left;}
+#menu-bar li a:link, #menu-bar li a:visited {color: #FFF;display: block;padding: 15px 10px;text-decoration: none;}
 
 
 /*


### PR DESCRIPTION
The current #menu-bar links are simply the word (e.g. "Configuration"), but they're sitting inside a big rounded box. This change adjusts that code, so the entire rounded box acts as a target, and if you hit it, the link gets called.

This doesn't change the functionality or the look of the service. It just makes it easier to use.

In usability terms, making the target easier to hit gives it a "greater affordance".

http://en.wikipedia.org/wiki/Affordance

http://en.wikipedia.org/wiki/Fitts%27s_Law
