### PR TITLE
Pdo config - added THINKUP_CFG var, which if set, sets PDO connection charset

### DIFF
--- a/webapp/_lib/model/class.PDODAO.php
+++ b/webapp/_lib/model/class.PDODAO.php
@@ -90,6 +90,10 @@ abstract class PDODAO {
             $this->config->getValue('db_password')
             );
             self::$PDO->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+            // if  THINKUP_CFG var 'set_pdo_charset' is set to true, set the connection charset to utf8.
+            if ($this->config->getValue('set_pdo_charset')) {
+                self::$PDO->exec('SET CHARACTER SET utf8');
+            }
         }
     }
 

--- a/webapp/config.sample.inc.php
+++ b/webapp/config.sample.inc.php
@@ -63,3 +63,7 @@ $THINKUP_CFG['slow_query_log_threshold']  = 2.0;
 $THINKUP_CFG['debug']                     = true;
 
 $THINKUP_CFG['enable_profiler']           = false;
+
+// Set this to true if you want your PDO object's database connection's charset to be explicitly set to utf8.
+// If false (or unset), the database connection's charset will not be explicitly set.
+$THINKUP_CFG['set_pdo_charset']           = false;


### PR DESCRIPTION
added THINKUP_CFG var, which if set, causes PDO connection charset to be specified as utf8.
I believe this is all that we need.
