### PR TITLE
support for instagr.am images (issue #495)

### DIFF
--- a/webapp/assets/css/base.css
+++ b/webapp/assets/css/base.css
@@ -301,6 +301,7 @@ img.service-icon2 {left: 32px;}
 
 /* .pic {border: 1px solid #CCC;padding: 5px 0px 0px 5px;} */
 /*.pic {float:right;margin:10px 0 10px 10px;border:1px solid #CCC;padding:5px 5px 0 5px;}*/
+.pic img {max-height: 150px; }
 
 .promo-thumb {float:left;width:113px;height:150px;margin-top: 13px;margin-left:15px;}
 .promo-thumb .pic img {height:100px;width:100px;}

--- a/webapp/plugins/twitter/model/class.URLProcessor.php
+++ b/webapp/plugins/twitter/model/class.URLProcessor.php
@@ -58,6 +58,10 @@ class URLProcessor {
                 $is_image = 1;
             } elseif (substr($u, 0, strlen('http://flic.kr/')) == 'http://flic.kr/') {
                 $is_image = 1;
+            } elseif (substr($u, 0, strlen('http://instagr.am/')) == 'http://instagr.am/') {
+                $logger->logInfo("processing instagram url: $u", __METHOD__.','.__LINE__);
+                $html = (string) Utils::getURLContents($u);
+                list($eurl, $is_image) = self::extractInstagramImageURL($logger, $html);
             }
             if ($link_dao->insert($u, $eurl, $title, $tweet['post_id'], 'twitter', $is_image)) {
                 $logger->logSuccess("Inserted ".$u." (".$eurl.", ".$is_image."), into links table",
@@ -66,5 +70,19 @@ class URLProcessor {
                 $logger->logError("Did NOT insert ".$u." (".$eurl.") into links table", __METHOD__.','.__LINE__);
             }
         }
+    }
+    
+    public static function extractInstagramImageURL($logger, $html) {
+        $eurl = '';
+        $is_image = 0;
+        if ($html) {
+            preg_match('/<meta property="og:image" content="[^"]+"\/>/i', $html, $matches);
+            if (isset($matches[0])) {
+                $eurl = substr($matches[0], 35, -3);
+                $logger->logDebug("got instagram eurl: $eurl", __METHOD__.','.__LINE__);
+                $is_image = 1;
+            }
+        }
+        return array($eurl, $is_image);
     }
 }

--- a/webapp/plugins/twitter/tests/testdata/URLProcessor/instagr_am_p_oyQ6
+++ b/webapp/plugins/twitter/tests/testdata/URLProcessor/instagr_am_p_oyQ6
@@ -1,0 +1,128 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+   "http://www.w3.org/TR/html4/loose.dtd">
+
+<html lang="en">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+	<meta name = "viewport" content = "width = 480">
+	<title>instagr.am</title>
+	<link rel="shortcut icon" href="/static/images/favicon.ico">
+	<link rel="stylesheet" href="/static/styles/reset.css" type="text/css" media="screen" title="no title" charset="utf-8">
+	<link rel="stylesheet" href="/static/styles/master.css?r=1" type="text/css" media="screen" title="no title" charset="utf-8">
+	
+	
+    <link rel="stylesheet" href="/static/styles/waitlist.css" type="text/css" media="screen" title="no title" charset="utf-8">
+    <link rel="stylesheet" href="/static/media/styles/detail.css?v=2" type="text/css" media="screen" title="no title" charset="utf-8">
+
+	<script src="/static/scripts/jquery.js" type="text/javascript" charset="utf-8"></script>
+    <script type="text/javascript">
+      var _gaq = _gaq || [];
+      _gaq.push(['_setAccount', 'UA-18105282-1']);
+      _gaq.push(['_trackPageview']);
+      (function() {
+        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+      })();
+    </script>
+    
+    <script type="text/javascript" charset="utf-8">
+        $(document).ready(function(){
+            var agent = navigator.userAgent.toLowerCase();
+            var is_iphone = agent.indexOf('iphone') != -1;
+            if (is_iphone) {
+                $('#download-banner').show();
+                window.scrollTo(0, 0);
+            }
+        });
+    </script>
+
+    
+    <meta property="og:title" content="thespambot's photo"/>
+    <meta property="og:image" content="http://distillery.s3.amazonaws.com/media/2010/12/20/f0f411210cc54353be07cf74ceb79f3b_7.jpg"/>
+    <meta property="og:site_name" content="Instagram">
+    
+    <meta property="og:description" content="Railroad Crossing"/>
+    
+
+</head>
+<body>
+    
+    <div id="download-banner">
+        <p>Want to take pictures like this? <a href="http://itunes.com/apps/instagram/">Try the free app</a></p>
+    </div>
+
+    <div id="wrap" class="group">
+        <div id="content">
+            
+    <div id="photo" >
+            <div class="group frame">
+                    <img src="http://distillery.s3.amazonaws.com/media/2010/12/20/f0f411210cc54353be07cf74ceb79f3b_7.jpg" class="photo" />
+                    <div class="photo-info">
+                        <img src="http://distillery.s3.amazonaws.com/profiles/profile_626603_75sq_1289545248.jpg" class="profile-photo"/>
+                        <div class="profile-info">
+                            <h1>thespambot</h1>
+                            <span class="number-statistic">31</span> photos
+                             &middot;
+                            <span class="number-statistic">7</span> followers
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="promo">
+                <img src="http://distillery.s3.amazonaws.com/static/images/logoCamera.png" class="logo-camera"/>
+                <table class="promo-table">
+                    <tr class="top-spacer-row">
+                        <td><!-- not empty --></td>
+                    </tr>
+                    <tr class="bottom-spacer-row">
+                        <td><!-- not empty --></td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p class="description">
+                                Jonah is using Instagram - a fun &amp; quirky way to share your life with friends through a series of pictures. Snap a photo, then choose a filter to transform the look and feel of the shot into a memory to keep around forever.
+                                <span style="font-weight:bold;">It's free!</span>
+                            </p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="text-align:center;">
+                            <a href="http://itunes.com/apps/instagram/"><img src="/static/images/appStoreBadge.png" alt="Available on the App Store"/></a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="text-align:center;">
+                        <!-- AddThis Button BEGIN -->
+                        <div class="addthis_toolbox addthis_default_style" style="padding-left:4em; padding-top:3em;">
+                        <a class="addthis_button_facebook_like" fb:like:layout="button_count"></a>
+                        <a class="addthis_button_tweet"></a>
+                        <a class="addthis_counter addthis_pill_style"></a>
+                        </div>
+                        <script type="text/javascript">var addthis_config = {"data_track_clickback":true};</script>
+                        <script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#username=burbn"></script>
+                        <!-- AddThis Button END -->
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+        </div>
+    </div>
+    
+    <div id="footer" class="group">
+        
+        <p style="color:#999; margin:1em 0; text-align:center; font-size:1.2em;">
+            <a href="/accounts/edit/">Edit Account</a>
+        </p>
+        
+        <span id="footer-links">
+            <a href="/about/">About us</a> | <a href="/blog/">Blog</a> | <a href="/about/faq">FAQ</a> | <a href="/about/jobs/">Jobs</a> <br/>
+        </span>         
+        Copyright 2010, Burbn, Inc. contact@instagr.am
+    </div>
+    
+    
+
+</body>
+</html>


### PR DESCRIPTION
hi Gina,

This is the instagr.am support.  

As you'll notice, I added a style rule which ensures that no images of class 'pic' are over 150px in height.  It looks like the style rule for .pic itself was recently (?) commented out.  However, I see the class itself is still used and the rule seems to work fine. It's necessary because the instagram images will be a bit larger than thumbnails (but not huge).

With the tests, there are two tests which use a live URL (one good, one bad), and one test which checks the the regexp processing using local data.

For these first two-- I know that going to a live site kind of runs counter to the idea of unit testing.  We can just remove these tests if you like.  I was thinking that with screen scraping it might not hurt to keep tabs on the actual live page content, since instagr.am could change page structure and break the extraction.

For the latter test: I made the URLProcessor::extractInstagramImageURL method public s.t. it could be accessed by this test, otherwise it would make sense to keep it private. 

