### PR TITLE
Link UI - typo in link template

### DIFF
--- a/webapp/_lib/view/_link.tpl
+++ b/webapp/_lib/view/_link.tpl
@@ -18,7 +18,9 @@
       <a href="{$l->url}"><div class="pic"><img src="{$l->expanded_url}" /></div></a>
     {else}
       {if $l->expanded_url}
-        <a href="{$l->expanded_url}" title="{$l->expanded_url}">{$l->title}</a>
+      <small>
+        <a href="{$l->expanded_url}" title="{$l->expanded_url}">{$l->expanded_url}</a>
+      </small>
       {/if}
     {/if}
     <div class="post">


### PR DESCRIPTION
The issue with the expanded links not showing up in the 'links' views was just a simple typo.  This is part of what I'd mentioned in issue #501.  The other part (adding pagination) I'll do separately.

I made the expanded link 'small' as is done in the post template, but feel free to remove that. Also, I kept the links template essentially as is, but I am wondering whether the expanded link should be below the post content as is done in the post template, for a consistent look.
