### PR TITLE
295 facebook gather all replies

### DIFF
--- a/webapp/plugins/facebook/model/class.FacebookGraphAPIAccessor.php
+++ b/webapp/plugins/facebook/model/class.FacebookGraphAPIAccessor.php
@@ -45,4 +45,17 @@ class FacebookGraphAPIAccessor {
         $result = Utils::getURLContents($url);
         return json_decode($result);
     }
+    /**
+     * Make a Graph API request with the absolute URL. This URL needs to
+     * include the https://graph.facebook.com/ at the start and the
+     * access token at the end as well as everything in between. It is
+     * literally the raw URL that needs to be passed in.
+     *
+     * @param str $path
+     * @return array Decoded JSON response
+     */
+    public static function rawApiRequest($path) {
+        $result = Utils::getURLContents($path);
+        return json_decode($result);
+    }
 }

--- a/webapp/plugins/facebook/tests/TestOfFacebookCrawler.php
+++ b/webapp/plugins/facebook/tests/TestOfFacebookCrawler.php
@@ -136,4 +136,13 @@ class TestOfFacebookCrawler extends ThinkUpUnitTestCase {
         $user = $ud->getUserByName('Matthew Fleisher', 'facebook page');
         $this->assertEqual($user, null);
     }
+
+    public function testPostReplyPaging() {
+        $fbc = new FacebookCrawler($this->instance, 'fauxaccesstoken');
+
+        $fbc->fetchPagePostsAndReplies('133954286636768');
+        $pd = new PostMySQLDAO();
+        $post = $pd->getPost('144568048938151', 'facebook page');
+        $this->assertEqual($post->reply_count_cache, 70);
+    }
 }

--- a/webapp/plugins/facebook/tests/classes/mock.FacebookGraphAPIAccessor.php
+++ b/webapp/plugins/facebook/tests/classes/mock.FacebookGraphAPIAccessor.php
@@ -50,4 +50,28 @@ class FacebookGraphAPIAccessor {
         $result=  file_get_contents($FAUX_DATA_PATH.$url);
         return json_decode($result);
     }
+    
+    /**
+     * Make a Graph API request with the absolute URL. This URL needs to
+     * include the https://graph.facebook.com/ at the start and the
+     * access token at the end as well as everything in between. It is
+     * literally the raw URL that needs to be passed in.
+     *
+     * @param str $path
+     * @return array Decoded JSON response
+     */
+    public static function rawApiRequest($path) {
+        $url = $path;//.'?access_token='.$access_token;
+
+        $FAUX_DATA_PATH = THINKUP_ROOT_PATH . 'webapp/plugins/facebook/tests/testdata/';
+        $url = str_replace('https://graph.facebook.com/', '', $url);
+        $url = str_replace('?access_token=fauxaccesstoken', '', $url);
+        $url = str_replace('/', '_', $url);
+        $url = str_replace('&', '-', $url);
+        $url = str_replace('?', '-', $url);
+        //echo "READING LOCAL DATA FILE: ".$FAUX_DATA_PATH.$url. '
+        //';
+        $result=  file_get_contents($FAUX_DATA_PATH.$url);
+        return json_decode($result);
+    }
 }

--- a/webapp/plugins/facebook/tests/testdata/133954286636768
+++ b/webapp/plugins/facebook/tests/testdata/133954286636768
@@ -1,0 +1,14 @@
+{
+   "id": "133954286636768",
+   "name": "Facebook Hacker Cup",
+   "picture": "http://profile.ak.fbcdn.net/hprofile-ak-snc4/hs571.ash1/174680_133954286636768_5653639_s.jpg",
+   "link": "http://www.facebook.com/hackercup",
+   "category": "Website",
+   "website": "http://www.facebook.com/hackercup/",
+   "username": "hackercup",
+   "founded": "2011",
+   "company_overview": "The Facebook Hacker Cup is an annual Facebook programming competition where hackers compete against each other for fame, fortune, glory and a shot at the coveted Hacker Cup.",
+   "mission": "Many will enter... only one will emerge as world champion.",
+   "products": "www.facebook.com/careers",
+   "likes": 124755
+}

--- a/webapp/plugins/facebook/tests/testdata/133954286636768_144568048938151_comments
+++ b/webapp/plugins/facebook/tests/testdata/133954286636768_144568048938151_comments
@@ -1,0 +1,243 @@
+{
+   "data": [
+      {
+         "id": "144568048938151_1230814",
+         "from": {
+            "name": "Brian Poole",
+            "id": "510971571"
+         },
+         "message": "Congrats to all and happy hacking!",
+         "created_time": "2011-02-06T00:06:11+0000"
+      },
+      {
+         "id": "144568048938151_1230823",
+         "from": {
+            "name": "Aditya Permana",
+            "id": "1302210867"
+         },
+         "message": "first",
+         "created_time": "2011-02-06T00:07:23+0000"
+      },
+      {
+         "id": "144568048938151_1230826",
+         "from": {
+            "name": "Imen En Tu Estereo",
+            "id": "100000576705814"
+         },
+         "message": "yeah\u00a1\u00a1",
+         "created_time": "2011-02-06T00:07:32+0000"
+      },
+      {
+         "id": "144568048938151_1230836",
+         "from": {
+            "name": "Jarrod Parker",
+            "id": "24409159"
+         },
+         "message": "lmao only 150 made it out of 1673 or whatever it was",
+         "created_time": "2011-02-06T00:08:49+0000"
+      },
+      {
+         "id": "144568048938151_1230837",
+         "from": {
+            "name": "Jarrod Parker",
+            "id": "24409159"
+         },
+         "message": "well, got one right",
+         "created_time": "2011-02-06T00:09:00+0000"
+      },
+      {
+         "id": "144568048938151_1230852",
+         "from": {
+            "name": "Ville Hellman",
+            "id": "517413587"
+         },
+         "message": "Congrats to the top 150 for correct solutions, disappointed that some problem definitions changed halfway through the competition...",
+         "created_time": "2011-02-06T00:11:16+0000",
+         "likes": 2
+      },
+      {
+         "id": "144568048938151_1230861",
+         "from": {
+            "name": "Gutzsu Lyla Yusuf",
+            "id": "100000058303131"
+         },
+         "message": "prettttttt",
+         "created_time": "2011-02-06T00:12:25+0000"
+      },
+      {
+         "id": "144568048938151_1230878",
+         "from": {
+            "name": "Steve Wallis",
+            "id": "818460536"
+         },
+         "message": "It would be nice if they could give us the stats on how many qualified people actually participated in each round. (e.g. this round had 1,673 qualified people. How many of them actually participated during the 3-hour duration? It's obviously more than the 364 people who submitted something.)",
+         "created_time": "2011-02-06T00:14:42+0000",
+         "likes": 3
+      },
+      {
+         "id": "144568048938151_1230880",
+         "from": {
+            "name": "Andre Holzner",
+            "id": "100000773664809"
+         },
+         "message": "interesting.. I see one O(N *M) solution for problem 1 which has passed...",
+         "created_time": "2011-02-06T00:15:35+0000",
+         "likes": 2
+      },
+      {
+         "id": "144568048938151_1230886",
+         "from": {
+            "name": "Brian Poole",
+            "id": "510971571"
+         },
+         "message": "So I've got a biased idea! How about everyone who participated in round 2 gets a tshirt.  I mean.. it's only 64 more tshirts than anticipated!",
+         "created_time": "2011-02-06T00:16:09+0000",
+         "likes": 1
+      },
+      {
+         "id": "144568048938151_1230887",
+         "from": {
+            "name": "Audrey Pierrot",
+            "id": "667404345"
+         },
+         "message": "I can't :(((",
+         "created_time": "2011-02-06T00:16:13+0000"
+      },
+      {
+         "id": "144568048938151_1230888",
+         "from": {
+            "name": "Francisco Fernandez Berrocal",
+            "id": "1452734980"
+         },
+         "message": "Too brutal questions!",
+         "created_time": "2011-02-06T00:16:26+0000",
+         "likes": 5
+      },
+      {
+         "id": "144568048938151_1230890",
+         "from": {
+            "name": "Arnab Bose",
+            "id": "665721288"
+         },
+         "message": "Andre - Interesting... where?",
+         "created_time": "2011-02-06T00:16:53+0000",
+         "likes": 1
+      },
+      {
+         "id": "144568048938151_1230891",
+         "from": {
+            "name": "Daniel Saunders",
+            "id": "1123122807"
+         },
+         "message": "Google chrome ......your mine",
+         "created_time": "2011-02-06T00:17:07+0000"
+      },
+      {
+         "id": "144568048938151_1230894",
+         "from": {
+            "name": "Eric Alejandro Destefanis",
+            "id": "1123359465"
+         },
+         "message": "Hey! somehow, my source is in the place  of my output (and the output in the place of my source)... does anyone know if this is rejudgable? Or who may I email?",
+         "created_time": "2011-02-06T00:18:09+0000"
+      },
+      {
+         "id": "144568048938151_1230907",
+         "from": {
+            "name": "Hongliang Liu",
+            "id": "682021444"
+         },
+         "message": "\u0040Eric, just forget about it. Have fun in your weekend.",
+         "created_time": "2011-02-06T00:20:44+0000",
+         "likes": 1
+      },
+      {
+         "id": "144568048938151_1230919",
+         "from": {
+            "name": "Arnab Bose",
+            "id": "665721288"
+         },
+         "message": "Eric, I'd say it should definitely be considered (though that's my personal opinion). Hopefully the organizers will see your post here!",
+         "created_time": "2011-02-06T00:22:58+0000",
+         "likes": 1
+      },
+      {
+         "id": "144568048938151_1230928",
+         "from": {
+            "name": "Kamil Sadkowski",
+            "id": "100000694633914"
+         },
+         "message": "\u0040Andre Holzner I see even more than one.",
+         "created_time": "2011-02-06T00:25:56+0000",
+         "likes": 1
+      },
+      {
+         "id": "144568048938151_1230935",
+         "from": {
+            "name": "Arnab Bose",
+            "id": "665721288"
+         },
+         "message": "\u0040Andre, Kamil - I wonder what computer / language they were using. In my system, which is fairly modern, running _empty_ nested loop of 250000 iterations each takes (estimated) 30-40 minutes.",
+         "created_time": "2011-02-06T00:27:58+0000"
+      },
+      {
+         "id": "144568048938151_1230936",
+         "from": {
+            "name": "Greg Knox",
+            "id": "510782039"
+         },
+         "message": "After looking at some of these solutions, don't feel so bad about not getting any of them right -- Well done anyone who actually got any of these things :)",
+         "created_time": "2011-02-06T00:28:14+0000",
+         "likes": 1
+      },
+      {
+         "id": "144568048938151_1230946",
+         "from": {
+            "name": "Jozef Vodicka",
+            "id": "1240057308"
+         },
+         "message": "Congrats guys, enjoy Palo Alto & Hacker Cup T-Shirt :)",
+         "created_time": "2011-02-06T00:30:37+0000"
+      },
+      {
+         "id": "144568048938151_1230952",
+         "from": {
+            "name": "Erik Ramsgaard Wognsen",
+            "id": "738668796"
+         },
+         "message": "\u0040Brian Poole: 364 is the number of people who uploaded anything; the number of participants is larger. But yeah, t-shirts ftw :-P",
+         "created_time": "2011-02-06T00:31:20+0000"
+      },
+      {
+         "id": "144568048938151_1230956",
+         "from": {
+            "name": "Robert Burke",
+            "id": "23917679"
+         },
+         "message": "\u0040Brian: No, a lot of people did the contest and got 0 correct answers and 0 wrong answers.  364 is only the number of people who got 1 or more answers.",
+         "created_time": "2011-02-06T00:32:08+0000"
+      },
+      {
+         "id": "144568048938151_1230959",
+         "from": {
+            "name": "Steve Wallis",
+            "id": "818460536"
+         },
+         "message": "\u0040Andre, Kamil, Arnab... perhaps they knew a way to download the source file without starting the timer, like in previous rounds?",
+         "created_time": "2011-02-06T00:33:55+0000"
+      },
+      {
+         "id": "144568048938151_1230965",
+         "from": {
+            "name": "Edward T. Tonai",
+            "id": "520613319"
+         },
+         "message": "I think that the 5 people who solved 2 problems who weren't in the top 25 should get invited to the finals anyway.  I wasn't one of them, btw.  Considering how many people failed at every stage, and how we weren't even close to 3000 in round 2, and only 150 are getting a T-Shirt.  I think solving 2 is a major major accomplishment!",
+         "created_time": "2011-02-06T00:37:01+0000",
+         "likes": 10
+      }
+   ],
+   "paging": {
+      "next": "https://graph.facebook.com/144568048938151/comments?limit=25&offset=25"
+   }
+}

--- a/webapp/plugins/facebook/tests/testdata/133954286636768_posts
+++ b/webapp/plugins/facebook/tests/testdata/133954286636768_posts
@@ -1,0 +1,44 @@
+{
+   "data": [
+      {
+         "id": "133954286636768_144568048938151",
+         "from": {
+            "name": "Facebook Hacker Cup",
+            "category": "Website",
+            "id": "133954286636768"
+         },
+         "message": "Round 2 is over and the final scoreboard will be up shortly.  It will take us a while to fully verify the scores so they may shuffle a little in the next couple days, but you will be able to see the as-graded score for all competitors.",
+         "link": "http://www.facebook.com/hackercup/scoreboard.php/?round=178767375498716",
+         "name": "http://www.facebook.com/hackercup/scoreboard.php/?round=178767375498716",
+         "caption": "www.facebook.com",
+         "icon": "http://b.static.ak.fbcdn.net/rsrc.php/yD/r/aS8ecmYRys0.gif",
+         "type": "link",
+         "created_time": "2011-02-06T00:05:19+0000",
+         "updated_time": "2011-02-06T00:05:19+0000",
+         "likes": {
+            "data": [
+               {
+                  "name": "York Mw",
+                  "id": "100000234593146"
+               },
+               {
+                  "name": "Sabbar Khatib",
+                  "id": "100001478065484"
+               },
+               {
+                  "name": "Shih-Chiang Lin",
+                  "id": "792519448"
+               },
+               {
+                  "name": "David Sanchez Jimenez",
+                  "id": "100000103487278"
+               }
+            ],
+            "count": 97
+         },
+         "comments": {
+            "count": 73
+         }
+      }
+   ]
+}

--- a/webapp/plugins/facebook/tests/testdata/144568048938151_comments-limit=25-offset=25
+++ b/webapp/plugins/facebook/tests/testdata/144568048938151_comments-limit=25-offset=25
@@ -1,0 +1,243 @@
+{
+   "data": [
+      {
+         "id": "144568048938151_1230967",
+         "from": {
+            "name": "Govind Chandrasekhar",
+            "id": "508111053"
+         },
+         "message": "T-shits for those who submitted wrong answers? That's unfair to those who had the foresight to know that their answers were buggy, and hence didn't bother with submission.",
+         "created_time": "2011-02-06T00:37:22+0000",
+         "likes": 7
+      },
+      {
+         "id": "144568048938151_1230990",
+         "from": {
+            "name": "Mark Zammata",
+            "id": "733775875"
+         },
+         "message": "Cmd -> color a -> h4cker",
+         "created_time": "2011-02-06T00:44:39+0000",
+         "likes": 2
+      },
+      {
+         "id": "144568048938151_1230996",
+         "from": {
+            "name": "David Berthelot",
+            "id": "100000859513781"
+         },
+         "message": "lol a T-shirt for a wrong answer :) I love the sense of humor that some people have here. So you could just upload a bunch of random numbers and printf(\"Hello mum\");. Hehehe",
+         "created_time": "2011-02-06T00:45:49+0000",
+         "likes": 5
+      },
+      {
+         "id": "144568048938151_1231021",
+         "from": {
+            "name": "Mark Karpel\u00e8s",
+            "id": "532974378"
+         },
+         "message": "shouldn't have done that half alsleep, missed the 6 minutes limit ~",
+         "created_time": "2011-02-06T00:52:00+0000"
+      },
+      {
+         "id": "144568048938151_1231024",
+         "from": {
+            "name": "Hongliang Liu",
+            "id": "682021444"
+         },
+         "message": "FB financial department is happy to save 150$ T-shirts.",
+         "created_time": "2011-02-06T00:52:05+0000",
+         "likes": 4
+      },
+      {
+         "id": "144568048938151_1231071",
+         "from": {
+            "name": "Martin Cifko \u0160tef\u010dek",
+            "id": "791864198"
+         },
+         "message": "just give 2 t-shirt to the first 150 people ;-) and no, i'm not one of them",
+         "created_time": "2011-02-06T01:00:26+0000",
+         "likes": 4
+      },
+      {
+         "id": "144568048938151_1231075",
+         "from": {
+            "name": "Wayne Colvin",
+            "id": "503383185"
+         },
+         "message": "\u0040Steve : Downloading the file always started the timer whether your browser showed it right or not. Those people (including me) knew full well that they were forfeiting a question they couldn't answer if they downloaded the input. :/",
+         "created_time": "2011-02-06T01:01:01+0000"
+      },
+      {
+         "id": "144568048938151_1231089",
+         "from": {
+            "name": "Jon Adams",
+            "id": "1374900264"
+         },
+         "message": "there should totally be a pity round for the remaining 150 t-shirts",
+         "created_time": "2011-02-06T01:03:20+0000",
+         "likes": 3
+      },
+      {
+         "id": "144568048938151_1231104",
+         "from": {
+            "name": "Pradeep Chelani",
+            "id": "1393001281"
+         },
+         "message": "some people used sine cosine function and some people use left right bit operators to solve first problem...never thought it was so diff to solve large numbers...still unable to understand their logic...can someone explain me",
+         "created_time": "2011-02-06T01:06:38+0000",
+         "likes": 1
+      },
+      {
+         "id": "144568048938151_1231110",
+         "from": {
+            "name": "Martin Cifko \u0160tef\u010dek",
+            "id": "791864198"
+         },
+         "message": "I don't really get the solution for problem 1, i downloaded a few source codes\nI have the same algorithm, but it's still not fast enough on my computer ;-))",
+         "created_time": "2011-02-06T01:07:37+0000"
+      },
+      {
+         "id": "144568048938151_1231136",
+         "from": {
+            "name": "Pradeep Chelani",
+            "id": "1393001281"
+         },
+         "message": "\u0040Martin...same here..some people O(N*M) solution was accepted while mine O(P*P) is not even working on my machine",
+         "created_time": "2011-02-06T01:10:31+0000"
+      },
+      {
+         "id": "144568048938151_1231139",
+         "from": {
+            "name": "Martin Cifko \u0160tef\u010dek",
+            "id": "791864198"
+         },
+         "message": "i got O(P*L) :-))",
+         "created_time": "2011-02-06T01:11:14+0000"
+      },
+      {
+         "id": "144568048938151_1231192",
+         "from": {
+            "name": "Pradeep Chelani",
+            "id": "1393001281"
+         },
+         "message": "i dont think their is much diff in O(P*L) and O(P*P)",
+         "created_time": "2011-02-06T01:16:16+0000"
+      },
+      {
+         "id": "144568048938151_1231243",
+         "from": {
+            "name": "Martin Cifko \u0160tef\u010dek",
+            "id": "791864198"
+         },
+         "message": "\u0040pradeep just a little, but in O(P*L) u dont have to check if (i*j\u003cl), because it's always true... anyway that doesn't help...",
+         "created_time": "2011-02-06T01:23:32+0000",
+         "likes": 1
+      },
+      {
+         "id": "144568048938151_1231296",
+         "from": {
+            "name": "Wonjohn-Wonjun Choi",
+            "id": "100000150076278"
+         },
+         "message": "OMGOMGOMOGMOGMOGMG Can we have another subround please? I completely forgot about this T_T",
+         "created_time": "2011-02-06T01:30:12+0000"
+      },
+      {
+         "id": "144568048938151_1231312",
+         "from": {
+            "name": "Abhiraj Pande",
+            "id": "100000492868617"
+         },
+         "message": "Studious student's output and solution was wrong.",
+         "created_time": "2011-02-06T01:32:33+0000"
+      },
+      {
+         "id": "144568048938151_1231369",
+         "from": {
+            "name": "Pradeep Chelani",
+            "id": "1393001281"
+         },
+         "message": "\u0040abhiraj which output is wrong?",
+         "created_time": "2011-02-06T01:40:56+0000"
+      },
+      {
+         "id": "144568048938151_1231454",
+         "from": {
+            "name": "Abhiraj Pande",
+            "id": "100000492868617"
+         },
+         "message": "\u0040pradeep: they have given that c is a character from substring but they are considering it a or b.",
+         "created_time": "2011-02-06T01:53:02+0000"
+      },
+      {
+         "id": "144568048938151_1231734",
+         "from": {
+            "name": "Pradeep Chelani",
+            "id": "1393001281"
+         },
+         "message": "it means c is any character in substring not 'c' as character",
+         "created_time": "2011-02-06T02:29:01+0000",
+         "likes": 1
+      },
+      {
+         "id": "144568048938151_1231795",
+         "from": {
+            "name": "Noor Ali",
+            "id": "1424405954"
+         },
+         "message": "Hmmm...sorry I don't participate about this competition. Caused I very busy yesterday. When I can paticipate round again?",
+         "created_time": "2011-02-06T02:35:22+0000"
+      },
+      {
+         "id": "144568048938151_1231822",
+         "from": {
+            "name": "Luca Ambrosi",
+            "id": "510426156"
+         },
+         "message": "can anyone write here the problem statements pls?",
+         "created_time": "2011-02-06T02:39:10+0000"
+      },
+      {
+         "id": "144568048938151_1231841",
+         "from": {
+            "name": "Sam Rose",
+            "id": "544780370"
+         },
+         "message": "Maaaaaan they were some difficult problems. Major kudos to anyone that managed to get any of them. I racked my brains on the Bonus Assignment one for 2 and a half hours and got no where even close to the answer ^_^\n\nI'm gonna side with the \"Give everyone from round 2 t-shirts\" party :p",
+         "created_time": "2011-02-06T02:41:57+0000",
+         "likes": 2
+      },
+      {
+         "id": "144568048938151_1232077",
+         "from": {
+            "name": "Erik Ramsgaard Wognsen",
+            "id": "738668796"
+         },
+         "message": "Maybe they don't print the t-shirts until they know the sizes of the lucky people, so I don't think any will go to waste either way ^^",
+         "created_time": "2011-02-06T03:30:46+0000"
+      },
+      {
+         "id": "144568048938151_1232078",
+         "from": {
+            "name": "Anshul Goyal",
+            "id": "1406403734"
+         },
+         "message": "I can't say about T-shirts ..\nBut problems were damn good although I wasn't able to solve any one of them correctly.",
+         "created_time": "2011-02-06T03:30:54+0000"
+      },
+      {
+         "id": "144568048938151_1232411",
+         "from": {
+            "name": "Rafael Telles Muller",
+            "id": "536776067"
+         },
+         "message": "I guess Facebook will have to keep 150 shirts..LMAO. This first Hacker cup was a complete failure.",
+         "created_time": "2011-02-06T04:17:38+0000"
+      }
+   ],
+   "paging": {
+      "next": "https://graph.facebook.com/144568048938151/comments?limit=25&offset=50",
+      "previous": "https://graph.facebook.com/144568048938151/comments?limit=25&offset=0"
+   }
+}

--- a/webapp/plugins/facebook/tests/testdata/144568048938151_comments-limit=25-offset=50
+++ b/webapp/plugins/facebook/tests/testdata/144568048938151_comments-limit=25-offset=50
@@ -1,0 +1,198 @@
+{
+   "data": [
+      {
+         "id": "144568048938151_1232411",
+         "from": {
+            "name": "Rafael Telles Muller",
+            "id": "536776067"
+         },
+         "message": "I guess Facebook will have to keep 150 shirts..LMAO. This first Hacker cup was a complete failure.",
+         "created_time": "2011-02-06T04:17:38+0000"
+      },
+      {
+         "id": "144568048938151_1232582",
+         "from": {
+            "name": "Akhil Kunnath",
+            "id": "800223221"
+         },
+         "message": "Can anybody pls share all the 3 qns here ?? I'm not able to see the problem statements............",
+         "created_time": "2011-02-06T04:47:37+0000"
+      },
+      {
+         "id": "144568048938151_1232840",
+         "from": {
+            "name": "Aditya Permana",
+            "id": "1302210867"
+         },
+         "message": "Little Scott recently learned how to perform arithmetic operations modulo some prime number P. As a training set he picked two sequences a of length N and b of length M, generated in the following way:\na1=A1\na2=A2\nai=(ai-2 * A3 + ai-1*A4 + A5) mod P, for i=3...N\nb1=B1\nb2=B2\nbj=(bj-2 * B3 + bj-1 * B4 + B5) mod P, for j=3...M\n\nNow he wants to find the number of pairs (i, j), where 1 \u2264 i \u2264 N and 1 \u2264 j \u2264 M, such that (ai * bj) mod P \u003c L, for given number L. He asked you to do the same to help him check his answers.\nInput\n\nThe first line of input file consists of a single number T, the number of test cases. Each test consists of three lines. The first line of a test case contains two integers: prime number P and positive integer L. The second line consists of six non-negative integers N, A1, A2, A3, A4, A5. Likewise, the third line contains six non-negative integers M, B1, B2, B3, B4, B5.\nOutput\n\nOutput T lines, with the answer to each test case on a single line.\nConstraints\n\nT = 20\n2 \u2264 P \u003c 250,000\nP is prime\n1 \u2264 L \u2264 P\n2 \u2264 N, M \u2264 10,000,000\n0 \u2264 A1, A2, A3, A4, A5, B1, B2, B3, B4, B5 \u003c P \n\nExample inputExample output\n\n5\n3 1\n4 0 2 2 2 2\n2 1 2 1 0 0\n3 1\n5 2 0 0 1 1\n5 1 1 2 0 0\n3 3\n5 0 0 1 2 2\n3 2 1 1 1 1\n5 1\n5 2 0 4 0 4\n3 2 1 2 4 4\n5 4\n2 2 1 3 1 4\n5 1 0 2 3 3\n\n6\n10\n15\n3\n9",
+         "created_time": "2011-02-06T05:53:29+0000"
+      },
+      {
+         "id": "144568048938151_1232842",
+         "from": {
+            "name": "Aditya Permana",
+            "id": "1302210867"
+         },
+         "message": "Studious Student II\n\nYou've decided to make up another string manipulation game instead of paying attention in class. Starting with a string composed entirely of 'a' and 'b' characters, you will iteratively apply the following operation:\n\nFor a string s of length len, choose indices i and j, where i \u003c j \u003c len. Choose a character c that occurs in the substring which begins at zero-based index i of string s and extends to the index j (inclusive). Replace all characters in s with zero-based index in [i, j] with a single instance of c to generate s'. Set s to be s'.\n\nAs an example of sequence of operations consider the string 'abba'. Some of the possible transformations are shown below. The substring being replaced is enclosed in square brackets.\n\n   1. [abb]a \u2192 [aa] \u2192 a\n   2. a[bba] \u2192 [aa] \u2192 a\n   3. ab[ba] \u2192 [abb] \u2192 a\n   4. a[bb]a \u2192 aba\n\nThe goal of your game is simple: calculate how many different sequences of operations you can perform. As this number can be very large, you decide to calculate it modulo 1,000,000,007. Two sequences of operations are considered different if they differ in length, or if they differ in at least one position. Note that the order of operations is a factor. The empty sequence of operations should be counted as well. Operations can be considered triples of (i, j, c) as described above, and these are the only values used when computing whether two operations are the same.\nInput\n\nThe first line of the input file contains a single number N, the number of test cases. Each test case is written on a separate line, and contains a string consisting of letters 'a' and 'b'.\nOutput\n\nOutput N lines, with the answer to each test case on a single line.\nConstraints\n\nN = 20\n1 \u2264 len \u2264 60\ns only contains the lowercase characters 'a' and 'b'.\n\nExample input\n\n5\nab\naba\naabb\nababa\nbbbbb\nExample output\n3\n13\n57\n642\n120",
+         "created_time": "2011-02-06T05:54:21+0000"
+      },
+      {
+         "id": "144568048938151_1232846",
+         "from": {
+            "name": "Aditya Permana",
+            "id": "1302210867"
+         },
+         "message": "Bonus Assignments\n\nYou are in charge of a group of N workers, and you want to pay a one-time bonus to each of them. The bonus for each worker is an integer number of dollars. According to state law the bonus of the worker who gets the least should be no less than A, but no more than B. To motivate your staff, the bonus of the worker who gets the most should be no less than C and no more than D.\n\nWorkers tend to spend their entire bonuses on HackerCola. Each of them buys bottles of HackerCola until he runs out of money, i.e., until amount of money left is less than the price of one bottle. Workers are very individualistic and each of them uses his own money only, so they never pool to buy HackerCola. Unfortunately you don't remember the price of one bottle of HackerCola, but you are pretty sure that it is an integer number of dollars greater than 1.\n\nSince you care about the working class you want to assign bonuses to workers in such a way that there would be at least one worker who would have some money left after buying as much HackerCola as possible regardless of the price of the bottle. Calculate the number of possible bonus assignments that fit this constraint. Two bonus assignments are different if at least one worker gets different bonus in each assignment. Since the answer can be large, calculate it modulo 1,000,000,007.\nInput\n\nThe first line of the input contains one integer T, the number of test cases. Each of the next T lines consists of 5 integers separated by spaces: N, A, B, C and D.\nOutput\n\nFor each of the test cases print a line containing number of possible bonus assignments modulo 1,000,000,007.\nConstraints\n\nT = 20\n1 \u2264 N \u2264 10^6\n1 \u2264 A \u2264 B \u2264 10^6\n1 \u2264 C \u2264 D \u2264 10^6\n\nExample input\n5\n2 1 2 4 5\n2 2 4 3 5\n1 5 10 5 10\n5 5 7 2 3\n5 2 7 5 12\nExample output\n6\n10\n0\n0\n149190",
+         "created_time": "2011-02-06T05:55:29+0000"
+      },
+      {
+         "id": "144568048938151_1232881",
+         "from": {
+            "name": "Abhiraj Pande",
+            "id": "100000492868617"
+         },
+         "message": "hey does anyone think studios student is wrong? I think its wrong. Its mentioned that c is a character from substring. Now consider the example of bbbbb. 'a' is not present in this string still 120 solution comes when we replace it with 'a' or 'b'",
+         "created_time": "2011-02-06T06:04:40+0000"
+      },
+      {
+         "id": "144568048938151_1232906",
+         "from": {
+            "name": "Vladimir Basunkov",
+            "id": "100002004060331"
+         },
+         "message": "WOW! Great solutions with FFT for first problem!Really cool=) I feel so stupid...=/",
+         "created_time": "2011-02-06T06:09:12+0000",
+         "likes": 1
+      },
+      {
+         "id": "144568048938151_1233264",
+         "from": {
+            "name": "Pradeep Balakrishna",
+            "id": "1081351919"
+         },
+         "message": "can anyone pls share the idea behind scott's new trick",
+         "created_time": "2011-02-06T07:58:13+0000"
+      },
+      {
+         "id": "144568048938151_1233290",
+         "from": {
+            "name": "Ananya Mallik",
+            "id": "1560315625"
+         },
+         "message": "O(M*N) passed xD",
+         "created_time": "2011-02-06T08:08:23+0000"
+      },
+      {
+         "id": "144568048938151_1234137",
+         "from": {
+            "name": "Parth Shah",
+            "id": "100001898527166"
+         },
+         "message": "d hell wid these solutions who bloody cares..........",
+         "created_time": "2011-02-06T11:57:22+0000"
+      },
+      {
+         "id": "144568048938151_1234324",
+         "from": {
+            "name": "Robert Burke",
+            "id": "23917679"
+         },
+         "message": "\u0040Abhiraj: For input 'bbbbb'...\nThere is 1 sequence in which you do nothing.\nThere is 1 sequence in which your first move is [bbbbb].\nThere are 4 sequences in which your first move is [bbbb]b or b[bbbb].\nThere are 18 sequences in which your first move is [bbb]bb, b[bbb]b, or bb[bbb].\nThere are 96 sequences in which your first move is [bb]bbb, b[bb]bb, bb[bb]b, or bbb[bb]\n1+1+4+18+96 = 120",
+         "created_time": "2011-02-06T12:39:03+0000",
+         "likes": 1
+      },
+      {
+         "id": "144568048938151_1234441",
+         "from": {
+            "name": "Adam Folwarczny",
+            "id": "1273118667"
+         },
+         "message": "University of Warsaw ... Gz xd",
+         "created_time": "2011-02-06T13:09:37+0000"
+      },
+      {
+         "id": "144568048938151_1234621",
+         "from": {
+            "name": "Thomas Dybdahl Ahle",
+            "id": "755563278"
+         },
+         "message": "A few people passed with O(P*P) or O(P*L) by using massive parallelization. Kind of cheating perhaps, but then I suppose the problem authors wanted it to be solvable with slightly simpler algorithms than FFT, like Karatsuba.",
+         "created_time": "2011-02-06T13:57:18+0000"
+      },
+      {
+         "id": "144568048938151_1234649",
+         "from": {
+            "name": "Thomas Dybdahl Ahle",
+            "id": "755563278"
+         },
+         "message": "\u0040Robert Burke I wish they had put explanations under the examples.",
+         "created_time": "2011-02-06T14:03:55+0000"
+      },
+      {
+         "id": "144568048938151_1235860",
+         "from": {
+            "name": "Akhil Kunnath",
+            "id": "800223221"
+         },
+         "message": "thnx Aditya.. thnx very much..........",
+         "created_time": "2011-02-06T16:42:23+0000"
+      },
+      {
+         "id": "144568048938151_1237947",
+         "from": {
+            "name": "Jos\u00e9 Ram\u00f3n Garc\u00eda Alvarado",
+            "id": "654687405"
+         },
+         "message": "Looks like HE made it ...\nCan't wait to see Petr on action again!\nIs ACRush competing with a different name BTW?",
+         "created_time": "2011-02-06T21:31:32+0000"
+      },
+      {
+         "id": "144568048938151_1238690",
+         "from": {
+            "name": "Sreesasanka Gunturi",
+            "id": "1581787658"
+         },
+         "message": "Guys, Is it happening to me or everyone. I cant see the problem set. Just that I did not qualify for round 2 does not mean I can never the problems(but download solutions!!!) for this round. Plzz post the problems if possible thanks...",
+         "created_time": "2011-02-06T23:49:33+0000"
+      },
+      {
+         "id": "144568048938151_1238852",
+         "from": {
+            "name": "Dario Lepre Battistin",
+            "id": "1704653001"
+         },
+         "message": "Se solo qualcuno mi insegnasse quest'arte ci proverei anch'io.",
+         "created_time": "2011-02-07T00:14:19+0000"
+      },
+      {
+         "id": "144568048938151_1239654",
+         "from": {
+            "name": "Ananya Mallik",
+            "id": "1560315625"
+         },
+         "message": "yeah acrush is rank 8 i suppose .\nhttp://forums.topcoder.com/;jsessionid=A066C5A0E84294BEB6ADA6FEC3D836E9?module=Thread&threadID=695777&start=800&mc=830#1320829",
+         "created_time": "2011-02-07T02:16:57+0000"
+      },
+      {
+         "id": "144568048938151_1241789",
+         "from": {
+            "name": "Mehmet Ali Karata\u015f",
+            "id": "100001241452656"
+         },
+         "message": "hacked bay facebook xd !!! zaaaaaaaaaaaaa",
+         "created_time": "2011-02-07T10:39:20+0000"
+      },
+      {
+         "id": "144568048938151_1245190",
+         "from": {
+            "name": "Ankit Sablok",
+            "id": "1333740280"
+         },
+         "message": "who all r u giving t shirts",
+         "created_time": "2011-02-07T21:08:37+0000"
+      }
+   ],
+   "paging": {
+      "previous": "https://graph.facebook.com/144568048938151/comments?limit=25&offset=25"
+   }
+}


### PR DESCRIPTION
This was quite literally the most frustrating thing I've ever had to code. Debugging stuff in the crawler is devilishly difficult. I'd love to see a mechanism for isolating crawls so you don't have to run them all at the same time (unless that already exists, in which case I'm a bit of a moron :p)

Anyway! The Facebook Crawler was only collecting 25 replies for a post, now it (in theory and in practice) collects all replies. I made a few changes to the code and here's a few justifications:

class.FacebookCrawler.php line 288 - I changed this because the comment id is always the last ID and with some API calls there was no 2 index. It only went up to 1. This seemed like an apt fix.

The whole collapsed comment part of the parseStream() method in the class.FacebookCrawler.php has been put into a do-while loop that is dependent on there being a paging part of the JSON that's returned. This fixed the replies not being fetched.

Test data files:

133954286636768 - the Facebook Hacker Cup page id
144568048938151 - a post on the Facebook Hacker Cup page

Then there are 3 pages of comments for the 144568048938151 post. Now, the original _posts file says that the post has 73 replies but I counted it twice: there are 70. I have no idea why there is a discrepancy here. TrevorBramble suggested deleted posts in IRC but I've not been able to verify that.

And finally there's a unit test for this :) testPostReplyPaging in TestOfFacebookCrawler.php

I hope it all works and holds up under testing. It all came out clean on my end and all of my pages seem to have the right amount of posts now. Let me know what you think!
