### PR TITLE
338 broken account activation link when space present rc2

### DIFF
--- a/tests/TestOfRegisterController.php
+++ b/tests/TestOfRegisterController.php
@@ -131,7 +131,7 @@ class TestOfRegisterController extends ThinkUpUnitTestCase {
         'option_value' => 'true');
         $bdata = FixtureBuilder::build('options', $bvalues);
 
-        $_SERVER['HTTP_HOST'] = "http://mytestthinkup/";
+        $_SERVER['HTTP_HOST'] = "mytestthinkup/";
         $_POST['Submit'] = 'Register';
         $_POST['full_name'] = "Angelina Jolie";
         $_POST['email'] = 'angie@example.com';
@@ -146,7 +146,30 @@ class TestOfRegisterController extends ThinkUpUnitTestCase {
         $this->assertEqual($v_mgr->getTemplateDataItem('successmsg'),
         'Success! Check your email for an activation link.');
     }
+
+    public function testSpaceInHostName() {
+        // make sure registration is on...
+        $bvalues = array('namespace' => OptionDAO::APP_OPTIONS, 'option_name' => 'is_registration_open',
+        'option_value' => 'true');
+        $bdata = FixtureBuilder::build('options', $bvalues);
+
+        $_SERVER['HTTP_HOST'] = "mytestthinkup/";
+        $_POST['Submit'] = 'Register';
+        $_POST['full_name'] = "Angelina Jolie";
+        $_POST['email'] = 'angie@example.com';
+        $_POST['user_code'] = '123456';
+        $_POST['pass1'] = 'mypass';
+        $_POST['pass2'] = 'mypass';
+        $controller = new RegisterController(true);
+        $controller->getViewManager()->assign('site_root_path', 'test url with spaces/');
+        $results = $controller->go();
+
+        $email = Mailer::getLastMail();
+        
+        $this->assertPattern('/test%20url%20with%20spaces/', $email, 'Spaces found in activation URL.');
+    }
 }
+
 
 /**
  * Mock Captcha for test use

--- a/tests/classes/class.ThinkUpUnitTestCase.php
+++ b/tests/classes/class.ThinkUpUnitTestCase.php
@@ -97,4 +97,8 @@ class Mailer {
         fclose($fp);
         return $message;
     }
+
+    public static function getLastMail() {
+        return file_get_contents(THINKUP_WEBAPP_PATH . '_lib/view/compiled_view' . ThinkUpUnitTestCase::TEST_EMAIL);
+    }
 }

--- a/webapp/_lib/controller/class.RegisterController.php
+++ b/webapp/_lib/controller/class.RegisterController.php
@@ -83,6 +83,8 @@ class RegisterController extends ThinkUpController {
                             } else {
                                 $es = new SmartyThinkUp();
                                 $es->caching=false;
+                                // this next line is purely for testing purposes (tests needs to set the site root path)
+                                $es->assign('site_root_path', $this->view_mgr->getTemplateDataItem('site_root_path'));
                                 $session = new Session();
                                 $activ_code = rand(1000, 9999);
                                 $cryptpass = $session->pwdcrypt($_POST['pass2']);

--- a/webapp/_lib/view/_email.registration.tpl
+++ b/webapp/_lib/view/_email.registration.tpl
@@ -1,5 +1,5 @@
 Click on the link below to activate your new {$app_title} account:
 
-http://{$server}{$site_root_path}session/activate.php?usr={$email}&code={$activ_code}
+http://{$server}{$site_root_path|escape:'url'}session/activate.php?usr={$email}&code={$activ_code}
 
 Thanks for registering!


### PR DESCRIPTION
Well, that test was a million times harder than I expected it to be :p I'm going to share my pain.

So I decided the best way to go about it would be to write a function in the mock Mailer class that fetches the last email "sent" (saved to file) and return it to check the contents and check for escaped spaces in the URL. The template variable I was looking to mess around with was "site_root_path". No problem, I'll fetch the view manager and change it.

No dice.

The RegisterController class for some reason unbeknown to me uses a separate view manager (line 84) to generate the email content thus making it impossible to change normally. After spending 2 hours going insane thinking that PHP just didn't like me, I realised this was the problem and fixed it. I now have less hair.

Anyhoo, this should be the test you are looking for :) Let me know what you think.
