### PR TITLE
587_jquery_stylesheet_order_rc

### DIFF
--- a/webapp/_lib/view/_header.tpl
+++ b/webapp/_lib/view/_header.tpl
@@ -7,10 +7,10 @@
   <link type="text/css" rel="stylesheet" href="{$site_root_path}assets/css/base.css">
   <link type="text/css" rel="stylesheet" href="{$site_root_path}assets/css/positioning.css">
   <link type="text/css" rel="stylesheet" href="{$site_root_path}assets/css/style.css">
-  <link type="text/css" rel="stylesheet" href="{$site_root_path}assets/css/jquery-ui-1.7.1.custom.css">
 
   <!-- jquery -->
   <link type="text/css" rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8/themes/base/jquery-ui.css">
+  <link type="text/css" rel="stylesheet" href="{$site_root_path}assets/css/jquery-ui-1.7.1.custom.css">
   <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4/jquery.min.js"></script>
   <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8/jquery-ui.min.js"></script>
   <script type="text/javascript">var site_root_path = '{$site_root_path}';</script>


### PR DESCRIPTION
I moved the jQuery UI stylesheet below the jQuery stylesheet in the <!-- jQuery -->. This should fix the weighting issue. Since _header.tpl was the only file that grep found this in, I'm hoping that I'm not breaking some coding convention that we use for header code.
