### PR TITLE
Issue #644 - incorrect URL for twitter post in _link.tpl

### DIFF
--- a/webapp/_lib/view/_link.tpl
+++ b/webapp/_lib/view/_link.tpl
@@ -33,7 +33,7 @@
         [<a href="{$site_root_path}post/?t={$t->in_reply_to_post_id}&n={$t->network}">in reply to</a>]
       {/if}
       <div class="small gray">
-      <span class="metaroll"><a href="http://twitter.com/{$l->container_post->author_username}/post/{$l->container_post->post_id}">{$l->container_post->adj_pub_date|relative_datetime}</a>
+      <span class="metaroll"><a href="http://twitter.com/{$l->container_post->author_username}/status/{$l->container_post->post_id}">{$l->container_post->adj_pub_date|relative_datetime}</a>
        {$l->container_post->location}</span>&nbsp;</div>
   </div>
   </div>


### PR DESCRIPTION
In _link.tpl, the URL for a twitter post needs to use 'status' instead of 'post' (the latter gives an error).

This can be seen in, e.g., the 'links from people you follow' tab.

While I was at it, I changed the template to have the twitter.com links open in a new tab rather than the same window.  If this does not sound like a good idea, I'll back out of that change.
