### PR TITLE
Replies template - extra </div> - issue #655

### DIFF
--- a/webapp/_lib/view/_post.other.tpl
+++ b/webapp/_lib/view/_post.other.tpl
@@ -64,7 +64,6 @@
         {/if}</span>&nbsp;
         </div>
       </div>
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This is the extra Replies page `</div>` fix  - issue #655.  A `</div>` is removed from _post.other.tpl, which fixes layout issues on the Replies page.  See the issue for the related list thread.

Drew (the original reporter of this issue) has not indicated that he's noticed anything in the UI that breaks by doing the removal, nor have I.  Also, fwiw, the tests all still pass with this change.  Soooo... it seems reasonable to make this fix.  
That said, it still seems weird to me that this issue suddenly popped up.  
