### PR TITLE
RT count display - issue #667

### DIFF
--- a/webapp/_lib/model/class.Post.php
+++ b/webapp/_lib/model/class.Post.php
@@ -28,6 +28,13 @@
  * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
  */
 class Post {
+    
+    /**
+     * @const int
+     * twitter currently maxes out on returning a RT count at 100.
+     */
+    const TWITTER_RT_THRESHOLD = 100;
+    
     /**
      *
      * @var int
@@ -217,7 +224,14 @@ class Post {
             $this->favorited = $val["favorited"];
         }
         // non-persistent, sum of two persistent values, used for UI information display
-        $this->all_retweets = $val['old_retweet_count_cache'] + $val['retweet_count_cache'];
+        // add a '+' if the count from twitter has maxed out, to indicate as much.
+        $rt_sum = $val['old_retweet_count_cache'] + $val['retweet_count_cache'];
+        if ($val['retweet_count_cache'] >= self::TWITTER_RT_THRESHOLD) {
+            $this->all_retweets = $rt_sum . "+";
+        }
+        else {
+            $this->all_retweets = $rt_sum;
+        }
     }
 
     /**


### PR DESCRIPTION
This addresses issue #667, that Anil posted earlier today.
What it does is add a '+' to the button that shows the number of RTs, if the 'new' RT count (obtained from twitter) has maxed out at twitter's current reporting threshold of 100 RTs. 
[This is only an issue wrt the number displayed on the buttons – all the RTs are in the database and will be fetched as appropriate].

This should not be the final fix, as we might as well take advantage of the fact that we do have all the RTs stored, to be more accurate in our reporting than Twitter.  However, it's a small change that will be simple to fold into this upcoming release or the next, so I think it makes sense to make the mod for now.

We should leave the issue open, though.  There are a few different ways we could address it fully, so we can have a longer discussion later when there is more time.
