### PR TITLE
RT count display (issue #667)

### DIFF
--- a/webapp/_lib/model/class.Post.php
+++ b/webapp/_lib/model/class.Post.php
@@ -28,6 +28,13 @@
  * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
  */
 class Post {
+    
+    /**
+     * @const int
+     * twitter currently maxes out on returning a RT count at 100.
+     */
+    const TWITTER_RT_THRESHOLD = 100;
+    
     /**
      *
      * @var int
@@ -174,6 +181,11 @@ class Post {
      * @var int, non-persistent, used for UI
      */
     var $all_retweets;
+    
+    /**
+     * @var int, non-persistent, used for UI, indicates whether twitter rt count threshold was reached.
+     */
+    var $rt_threshold;
 
     /**
      * Constructor
@@ -218,6 +230,15 @@ class Post {
         }
         // non-persistent, sum of two persistent values, used for UI information display
         $this->all_retweets = $val['old_retweet_count_cache'] + $val['retweet_count_cache'];
+        if ($val['retweet_count_cache'] >= self::TWITTER_RT_THRESHOLD) {
+            // if the new RT count, obtained from twitter, has maxed out, set a non-persistent flag field 
+            // to indicate this. The templates will make use of this info to add a '+' after the sum if the 
+            // flag is set.
+            $this->rt_threshold = 1;
+        }
+        else {
+            $this->rt_threshold = 0;
+        }
     }
 
     /**

--- a/webapp/_lib/model/class.PostMySQLDAO.php
+++ b/webapp/_lib/model/class.PostMySQLDAO.php
@@ -485,6 +485,15 @@ class PostMySQLDAO extends PDODAO implements PostDAO  {
             $retweeted_post_data = $vals['retweeted_post']['content'];
             // $this->logger->logInfo("this is a retweet- first processing original " .
             // $retweeted_post_data['post_id'] . ".", __METHOD__.','.__LINE__);
+            // it turns out that for a native retweet, Twitter may not reliably update the count stored in the 
+            // original-- there may be a lag.  So, if there is a first retweet, the original post still
+            // may show 0 rts. This is less common w/ the REST API than the streaming API, but does not hurt to
+            // address it anyway. So, if we know there was a retweet, but the rt count is showing 0, set it to 1.
+            // We know it is at least 1.
+            if (isset($retweeted_post_data['retweet_count_cache']) &&
+                    ($retweeted_post_data['retweet_count_cache'] == 0 )) {
+                $retweeted_post_data['retweet_count_cache'] = 1;
+            }
             // if so, process the original post first.
             $this->addPostAndEntities($retweeted_post_data, null);
         }

--- a/webapp/_lib/view/_post.lite.tpl
+++ b/webapp/_lib/view/_post.lite.tpl
@@ -53,7 +53,7 @@
     <div class="grid_2 center">
     {if $t->network eq 'twitter'}
       {if $t->all_retweets > 0}
-        <span class="reply-count"><a href="{$site_root_path}post/?t={$t->post_id}&n={$t->network}&v=fwds">{$t->all_retweets}<!-- retweet{if $t->retweet_count_cache eq 1}{else}s{/if}--></a></span>
+        <span class="reply-count"><a href="{$site_root_path}post/?t={$t->post_id}&n={$t->network}&v=fwds">{$t->all_retweets|number_format}{if $t->rt_threshold}+{/if}<!-- retweet{if $t->retweet_count_cache eq 1}{else}s{/if}--></a></span>
       {else}
         &#160;
       {/if}

--- a/webapp/_lib/view/_post.tpl
+++ b/webapp/_lib/view/_post.tpl
@@ -81,7 +81,7 @@
     <div class="grid_2 center">
     {if $t->network eq 'twitter'}
       {if $t->all_retweets > 0}
-        <span class="reply-count"><a href="{$site_root_path}post/?t={$t->post_id}&n={$t->network}&v=fwds">{$t->all_retweets}<!-- retweet{if $t->retweet_count_cache eq 1}{else}s{/if}--></a></span>
+        <span class="reply-count"><a href="{$site_root_path}post/?t={$t->post_id}&n={$t->network}&v=fwds">{$t->all_retweets|number_format}{if $t->rt_threshold}+{/if}<!-- retweet{if $t->retweet_count_cache eq 1}{else}s{/if}--></a></span>
       {else}
         &#160;
       {/if}

--- a/webapp/plugins/twitter/view/twitter.post.retweets.tpl
+++ b/webapp/plugins/twitter/view/twitter.post.retweets.tpl
@@ -50,7 +50,7 @@
               <div class="grid_5 center big-number omega">
                 <div class="bl">
                   <div class="key-stat">
-                      <h1>{$post->all_retweets|number_format}</h1>
+                      <h1>{$post->all_retweets|number_format}{if $post->rt_threshold}+{/if}</h1>
                       <h3>fwd{if $post->all_retweets > 1}s{/if} to {$reach|number_format}</h3>
                     {/if}
                   </div>


### PR DESCRIPTION
This addresses issue #667, that Anil posted earlier yesterday. (see that issue for my comments on what causes the behavior and what the rationale was for building things that way).

What this fix does is append a '+' to the display of the number of RTs, if the 'new' RT count (obtained from twitter) has maxed out at twitter's current reporting threshold of 100 RTs.  That indicates to the user that the displayed value (a sum of the old and new RT counts) has maxed out and that the actual number may be higher than shown.
[This is only an issue wrt the number displayed – all the actual RTs are in the database and will be fetched and listed as appropriate].

Longer term,  we should take advantage of the fact that we do have all the RTs stored, to be more accurate in our reporting than Twitter. However, this is a small change that will be simple to fold into this upcoming release or the next, so I think it makes sense to make the mod for now so that the UI is not misleading.

[Let's keep the issue open and return to it].

In case you'd looked at my (now retracted) pull req from yesterday, I'd originally done this by appending a '+' to the RT total if the 'new' component of the sum was maxed at the total.  However, some templates expect that RT value to be a number (and render it in number format), so this was not the right approach.

So what I have done instead is add a new non-persistent flag to the post object.  If it is set, this indicates that the 'new' RT threshold has been reached.
The Post model contains the logic wrt what the threshold value is (>=100), and the view templates have the logic wrt how to display that information (appending a  '+' to the number).

While I was at it, I noticed that in some templates the RT sum was rendered as a number, but in others it was not.  It seemed like it ought to be treated consistently as a number everywhere, so I made that change as well. Let me know if that change does not make sense.
