### PR TITLE
fix for favorites search bug - issue #703

### DIFF
--- a/webapp/_lib/model/class.FavoritePostMySQLDAO.php
+++ b/webapp/_lib/model/class.FavoritePostMySQLDAO.php
@@ -189,6 +189,6 @@ class FavoritePostMySQLDAO extends PostMySQLDAO implements FavoritePostDAO  {
     }
     public function getAllFavoritePostsIterator($user_id, $network, $count) {
         return $this->getAllFavoritePostsByUserID($user_id, $network, $count, "pub_date",
-        "DESC", null, $iterator = true);
+        "DESC", null, $page = 1, $iterator = true);
     }
 }


### PR DESCRIPTION
This fixes an issue with favorites search (the symptom - the search overlay would come up, but not be populated). The issue was related to a missing pagination argument in an iterator method.

As noted in #703, let's keep the issue itself open and I will add a test for this, hopefully by next weekend.  

Since the fix is very simple I wanted to go ahead w/ it now.
