### PR TITLE
Fix a random PHP notice in the WordPress plugin, to keep the error log quiet

### DIFF
--- a/extras/wordpress/thinkup/classes/ThinkUpAdminPages.class.php
+++ b/extras/wordpress/thinkup/classes/ThinkUpAdminPages.class.php
@@ -58,7 +58,8 @@ class ThinkUpAdminPages {
         echo '<br /><br />';
 
         // decide which page to load based on a 'step' GET variable
-        switch ($_GET['step']) {
+        $step = isset( $_GET['step'] ) ? $_GET['step'] : '';
+        switch ($step) {
             case 'help':
                 ThinkUpAdminPages::help();
                 break;


### PR DESCRIPTION
Fix a random PHP notice in the WordPress plugin, to keep the error log quiet. As all good developer do, I develop with PHP notices turned on. Quieting notices helps legitimate mistakes to stand out more prominently.
