### PR TITLE
Issue #459: Added error code explanations to Twitter crawler output.

### DIFF
--- a/webapp/plugins/twitter/tests/TestOfTwitterCrawler.php
+++ b/webapp/plugins/twitter/tests/TestOfTwitterCrawler.php
@@ -622,4 +622,17 @@ class TestOfTwitterCrawler extends ThinkUpUnitTestCase {
         $tc->cleanUpFollows();
         $this->assertFalse($follow_dao->followExists(930061, 36823, 'twitter', true), 'Follow marked inactive');
     }
+
+    public function testLoggingErrorOutput() {
+        self::setUpInstanceUserGinaTrapani();
+        foreach ($this->api->getTwitterErrorCodes() as $error_code => $explanation) {
+            $this->api->apiRequest($error_code, array(), true);
+        }
+
+        $logfile = file_get_contents(Config::getInstance()->getValue('log_location'));
+
+        foreach ($this->api->getTwitterErrorCodes() as $error_code => $explanation) {
+            $this->assertPattern("/{$explanation}/", $logfile);
+        }
+    }
 }

--- a/webapp/plugins/twitter/tests/classes/mock.TwitterOAuth.php
+++ b/webapp/plugins/twitter/tests/classes/mock.TwitterOAuth.php
@@ -56,7 +56,12 @@ class TwitterOAuth {
         //        echo "READING LOCAL DATA FILE: ".$FAUX_DATA_PATH.$url. '
         //        ';
         if (!file_exists($FAUX_DATA_PATH.$url)) {
-            $this->last_status_code = 404;
+            if (is_numeric($url) && strlen($url) == 3) {
+                // if the URL is a 3 character, numeric string, set the last error code to it. For testing errors.
+                $this->last_status_code = (int)$url;
+            } else {
+                $this->last_status_code = 404;
+            }
             return "";
         } else {
             return file_get_contents($FAUX_DATA_PATH.$url);


### PR DESCRIPTION
I added a new array inside CrawlerTwitterAPIAccessorOAth that contains the error codes and their explanations and I added tow new methods: one for translating the errors and one for retrieving them (currently only for testing purposes).

The error code translation is only done in one place but that's the only place it seems to need it... I tested a it in the human-friendly crawler output and it came up when it was needed. 

I wrote tests for it, too. I had to make a small hacky change to the mock TwitterOAuth class to simulate each of the errors consistently but it works and I don't think it will get in the way of anything.

Let me know what you think :)
