### PR TITLE
Issue #564: New release notifications

### DIFF
--- a/tests/TestOfUtils.php
+++ b/tests/TestOfUtils.php
@@ -165,4 +165,36 @@ class TestOfUtils extends ThinkUpBasicUnitTestCase {
         $converted = Utils::convertNumericStrings($test_str);
         $this->assertEqual($converted, $number);
     }
+
+    public function testNewVersionAvailable() {
+        $config = Config::getInstance();
+
+        $config->setValue('THINKUP_VERSION', '0.9');
+        $version_test_result = Utils::checkForNewVersion('0.10');
+        $this->assertTrue($version_test_result);
+
+        $config->setValue('THINKUP_VERSION', '1.12.657');
+        $version_test_result = Utils::checkForNewVersion('0.9');
+        $this->assertFalse($version_test_result);
+
+        $config->setValue('THINKUP_VERSION', '0.9a');
+        $version_test_result = Utils::checkForNewVersion('0.9b');
+        $this->assertTrue($version_test_result);
+
+        $config->setValue('THINKUP_VERSION', '0.9');
+        $version_test_result = Utils::checkForNewVersion('1.0');
+        $this->assertTrue($version_test_result);
+         
+        $config->setValue('THINKUP_VERSION', '0.9r56');
+        $version_test_result =  Utils::checkForNewVersion('0.9r57');
+        $this->assertTrue($version_test_result);
+
+        // what happens if version.txt is missing or unreachable
+        $not_found_test = Utils::getURLContents('http://thinkupapp.com/this/path/will/defiantly/404/index.php');
+        $this->assertPattern('/404 Not Found/', $not_found_test);
+
+        $config->setValue('THINKUP_VERSION', '0.9');
+        $version_test_result = Utils::checkForNewVersion($not_found_test);
+        $this->assertFalse($version_test_result);
+    }
 }

--- a/webapp/_lib/controller/class.ThinkUpController.php
+++ b/webapp/_lib/controller/class.ThinkUpController.php
@@ -96,6 +96,7 @@ abstract class ThinkUpController {
             }
             if ($this->isAdmin()) {
                 $this->addToView('user_is_admin', true);
+                $this->addToView('new_version_available', Utils::checkForNewVersion());
             }
             $THINKUP_VERSION = $config->getValue('THINKUP_VERSION');
             $this->addToView('thinkup_version', $THINKUP_VERSION);

--- a/webapp/_lib/model/class.Utils.php
+++ b/webapp/_lib/model/class.Utils.php
@@ -144,6 +144,25 @@ class Utils {
     }
 
     /**
+     * Compare installed version against latest stable release
+     * @param str $latest_version Set for testing purposes only. 
+     * @return mixed Version number when new version available, False if installed version is latest
+     */
+    public static function checkForNewVersion($latest_version = null) {
+        $config = Config::getInstance();
+        $THINKUP_VERSION = $config->getValue("THINKUP_VERSION");
+        if (is_null($latest_version)) {
+            $latest_version = Utils::getURLContents("http://thinkupapp.com/version.txt");
+        }
+        if (version_compare($THINKUP_VERSION, $latest_version, "<") == false) {
+            return false;
+        }
+        else {
+            return $latest_version;
+        }
+    }
+
+    /**
      * Get plugins that exist in the ThinkUp plugins directory
      * @param str $dir
      * @return array Plugins

--- a/webapp/_lib/view/_statusbar.tpl
+++ b/webapp/_lib/view/_statusbar.tpl
@@ -73,7 +73,9 @@
   <div class="status-bar-right text-right">
     <ul> 
       {if $logged_in_user}
-        <li>Logged in as: {$logged_in_user} | <a href="{$site_root_path}account/?m=manage">Settings</a> | <a href="{$site_root_path}session/logout.php">Log Out</a></li>
+        <li>Logged in as: {$logged_in_user} | {if $user_is_admin && $new_version_available} 
+        <a href="https://github.com/ginatrapani/ThinkUp/downloads">Version {$new_version_available} Available</a> | {/if}
+        <a href="{$site_root_path}account/?m=manage">Settings</a> | <a href="{$site_root_path}session/logout.php">Log Out</a></li>
       {else}
       
         <li><a href="http://thinkupapp.com/">Get ThinkUp</a> | <a href="{$site_root_path}session/login.php">Log In</a></li>


### PR DESCRIPTION
Added a function checkForNewVersion in model/classUtils.php that takes the current installed version, the latest stable release (as found in http://thinkupapp.com/version.txt), and compares them. If there is a newer release available, we return the new version number, and if not we return false.

In view/_statusbar.tpl, added bits to display new version if the logged in user is an administrator and a new version is available.

Added $new_version_available to ThinkUpController

Added tests to tests/TestOfUtils.php to test various potential version naming situations, as well as confirm that we would not display the notification if the version.txt file is missing or unreachable.

An example of the result can be seen here: http://jclnk.net/tuvernotif
