### PR TITLE
do not require table prefixes in migration sql scripts to have leading whitespace

### DIFF
--- a/webapp/_lib/controller/class.UpgradeController.php
+++ b/webapp/_lib/controller/class.UpgradeController.php
@@ -260,8 +260,7 @@ class UpgradeController extends ThinkUpAuthController {
                         // check for modified prefix
                         $table_prefix = $config->getValue('table_prefix');
                         if($table_prefix != 'tu_') {
-                            $migration_string = preg_replace("/\s`tu_/", " `$table_prefix", $migration_string);
-                            $migration_string = preg_replace("/\stu_/", " $table_prefix", $migration_string);
+                            $migration_string = preg_replace("/\btu_/", " $table_prefix", $migration_string);
                         }
                         $migration = array("version" =>  $migration_version, 'sql'  => $migration_string);
                         array_push($migrations, $migration);


### PR DESCRIPTION
This patch allows the UPDATE in 2011-04-25_v0.11.sql.migration to succeed when the table prefix is not tu_.  Alternatively, you need to add whitespace before tu_users.network.
