### PR TITLE
Partial fix for #556

### DIFF
--- a/webapp/_lib/view/_email.forgotpassword.tpl
+++ b/webapp/_lib/view/_email.forgotpassword.tpl
@@ -1,7 +1,7 @@
 Hi there!
 
 Looks like you forgot your {$apptitle} password. Go to this URL to reset it:
-http://{$server}{$site_root_path}{$recovery_url}
+http{if $smarty.server.HTTPS}s{/if}://{$server}{$site_root_path}{$recovery_url}
 
 Or, if you remembered it, you can log in here and disregard this email:
-http://{$server}{$site_root_path}session/login.php
+http{if $smarty.server.HTTPS}s{/if}://{$server}{$site_root_path}session/login.php

--- a/webapp/_lib/view/_email.registration.tpl
+++ b/webapp/_lib/view/_email.registration.tpl
@@ -1,5 +1,5 @@
 Click on the link below to activate your new {$app_title} account:
 
-http://{$server}{$site_root_path|escape:'urlpathinfo'}session/activate.php?usr={$email}&code={$activ_code}
+http{if $smarty.server.HTTPS}s{/if}://{$server}{$site_root_path|escape:'urlpathinfo'}session/activate.php?usr={$email}&code={$activ_code}
 
 Thanks for registering!

--- a/webapp/_lib/view/_email.upgradetoken.tpl
+++ b/webapp/_lib/view/_email.upgradetoken.tpl
@@ -1,6 +1,6 @@
 Looks like you're upgrading your ThinkUp installation. Great! To complete the process, click on this link to apply new database updates:
 
-http://{$server}{$site_root_path}install/upgrade.php?upgrade_token={$token} 
+http{if $smarty.server.HTTPS}s{/if}://{$server}{$site_root_path}install/upgrade.php?upgrade_token={$token} 
 
 If you have trouble, get in touch with the ThinkUp community on the mailing list:
 

--- a/webapp/plugins/embedthread/view/embedthread.inline.view.tpl
+++ b/webapp/plugins/embedthread/view/embedthread.inline.view.tpl
@@ -4,7 +4,7 @@
 <p>Copy and paste this JavaScript into your web page to embed this ThinkUp thread on it.</p>
 
 <textarea rows="5" cols="100">
-&lt;script src="http://{$smarty.server.SERVER_NAME}{$site_root_path}plugins/embedthread/v1/thinkup_embed.php?p={$smarty.get.t}&n={$smarty.get.n|urlencode}">&lt;/script>
+&lt;script src="http{if $smarty.server.HTTPS}s{/if}://{$smarty.server.SERVER_NAME}{$site_root_path}plugins/embedthread/v1/thinkup_embed.php?p={$smarty.get.t}&n={$smarty.get.n|urlencode}">&lt;/script>
 </textarea>
 
 <h2>Preview Your Thread</h2>
@@ -12,6 +12,6 @@
 <p>Your embedded thread will look like this:</p><br /><br />
 
 
-<script src="http://{$smarty.server.SERVER_NAME}{$site_root_path}plugins/embedthread/v1/thinkup_embed.php?p={$smarty.get.t}&n={$smarty.get.n|urlencode}"></script>
+<script src="http{if $smarty.server.HTTPS}s{/if}://{$smarty.server.SERVER_NAME}{$site_root_path}plugins/embedthread/v1/thinkup_embed.php?p={$smarty.get.t}&n={$smarty.get.n|urlencode}"></script>
 
 <br/><br /><br />

--- a/webapp/plugins/embedthread/view/v1.embed.tpl
+++ b/webapp/plugins/embedthread/view/v1.embed.tpl
@@ -1,5 +1,5 @@
 ThinkUp{$post_id} = new function() {literal} {
-  var BASE_URL = {/literal}'http://{$smarty.server.SERVER_NAME}{$site_root_path}plugins/embedthread/';{literal}
+  var BASE_URL = {/literal}'http{if $smarty.server.HTTPS}s{/if}://{$smarty.server.SERVER_NAME}{$site_root_path}plugins/embedthread/';{literal}
   var STYLESHEET = BASE_URL + "assets/css/thinkupembedthread.css"
   var CONTENT_URL = BASE_URL + 'v1/thread_js.php?p={/literal}{$post_id}&n={$network|urlencode}{literal}';
   var ROOT = 'my_xss_magic';

--- a/webapp/plugins/facebook/view/facebook.account.index.tpl
+++ b/webapp/plugins/facebook/view/facebook.account.index.tpl
@@ -106,7 +106,7 @@ addPage"  id="{$i->network_username}" value="add page" /></span>
 <h2 class="subhead">Configure the Facebook Plugin</h2>
 <ol style="margin-left:40px">
 <li><a href="http://developers.facebook.com/setup/">Create a ThinkUp Facebook application.</a></li>
-<li>Set the Web Site &gt; Site URL to <pre>http://{$smarty.server.SERVER_NAME}{if $smarty.server.SERVER_PORT != '80'}:{$smarty.server.SERVER_PORT}{/if}{$site_root_path}</pre></li>
+<li>Set the Web Site &gt; Site URL to <pre>http{if $smarty.server.HTTPS}s{/if}://{$smarty.server.SERVER_NAME}{if $smarty.server.SERVER_PORT != '80'}:{$smarty.server.SERVER_PORT}{/if}{$site_root_path}</pre></li>
 <li>Enter the Facebook-provided API Key, Application Secret and Application ID here.</li></ol>
 {/if}
 <p>


### PR DESCRIPTION
Smarty templates now display URLs with correct protocol. Partially fixes #556.

Haven't tested this (I know, bad); what's the protocol for testing Smarty templates? Is there a doc I should read?
