### PR TITLE
Fix UTF-8 Content-Type header

### DIFF
--- a/webapp/_lib/controller/class.ThinkUpController.php
+++ b/webapp/_lib/controller/class.ThinkUpController.php
@@ -287,7 +287,7 @@ abstract class ThinkUpController {
         $this->content_type = $content_type;
         // if is to suppress 'headers already sent' error while testing, etc.
         if( ! headers_sent() ) {
-            header('Content-Type: ' . $this->content_type, true);
+            header('Content-Type: ' . $this->content_type . '; charset=utf-8', true);
         }
     }
 


### PR DESCRIPTION
In server setups where UTF-8 is not specified as default Content-Type, we need to explicitly send the UTF-8 charset as part of the Content-Type header.

This fixes that. :)
