### PR TITLE
Minor Facebook Documentation Fix

### DIFF
--- a/docs/source/userguide/listings/facebook/dashboard_all_facebook_posts.rst
+++ b/docs/source/userguide/listings/facebook/dashboard_all_facebook_posts.rst
@@ -1,5 +1,0 @@
-All
-===
-
-All the status updates for the Facebook user or page instance which ThinkUp has captured, displayed in 
-reverse-chronological order.

--- a/docs/source/userguide/listings/facebook/dashboard_facebook_posts.rst
+++ b/docs/source/userguide/listings/facebook/dashboard_facebook_posts.rst
@@ -1,0 +1,18 @@
+Posts
+=====
+
+All
+---
+
+All the status updates for the Facebook user or page instance which ThinkUp has captured, displayed in
+reverse-chronological order.
+
+Most Replied-To
+---------------
+
+All the status updates for this Facebook user or page instance with replies, ordered by most-replied to first.
+
+Questions
+---------
+
+The Facebook user or page status updates which are an inquiry (ie, contain a question mark).

--- a/docs/source/userguide/listings/facebook/dashboard_listings.rst
+++ b/docs/source/userguide/listings/facebook/dashboard_listings.rst
@@ -3,12 +3,7 @@ Facebook
 
 ThinkUp offers several listings for a registered Facebook user profile or page data.
 
-Posts
------
-
 .. toctree::
    :maxdepth: 1
 
-   dashboard_all_facebook_posts.rst
-   dashboard_mostreplies.rst
-   dashboard_questions.rst
+   dashboard_facebook_posts.rst

--- a/docs/source/userguide/listings/facebook/dashboard_mostreplies.rst
+++ b/docs/source/userguide/listings/facebook/dashboard_mostreplies.rst
@@ -1,4 +1,0 @@
-Most Replied-To
-===============
-
-All the status updates for this Facebook user or page instance with replies, ordered by most-replied to first.

--- a/docs/source/userguide/listings/facebook/dashboard_questions.rst
+++ b/docs/source/userguide/listings/facebook/dashboard_questions.rst
@@ -1,4 +1,0 @@
-Questions
-=========
-
-The Facebook user or page status updates which are an inquiry (ie, contain a question mark).


### PR DESCRIPTION
Instead of having a file for each one sentence definition about Facebook posts, I thought it would be better to combine them onto a single page and file. It makes it easier to browse through them all at once, instead of having to click each individual link.

The Twitter data listing also has the same one sentence per page formatting, so if you approve of this, that would be the next thing to change.
