### PR TITLE
Slick Grid search updates

### DIFF
--- a/tests/TestOfGridController.php
+++ b/tests/TestOfGridController.php
@@ -39,6 +39,11 @@ class TestOfGridController extends ThinkUpUnitTestCase {
         $webapp->registerPlugin('twitter', 'TwitterPlugin');
     }
 
+    public function tearDown() {
+        parent::tearDown();
+        GridController::$MAX_ROWS = 5000;
+    }
+
     public function testConstructor() {
         $controller = new GridController(true);
         $this->assertTrue(isset($controller));
@@ -113,6 +118,45 @@ class TestOfGridController extends ThinkUpUnitTestCase {
         $this->assertEqual(count($ob->posts), 3);
     }
 
+    public function testOwnerWithAccessTweetsAllMaxLimit() {
+        $builders = $this->buildData();
+        GridController::$MAX_ROWS = 1;
+        $this->simulateLogin('me@example.com');
+        $_GET['u'] = 'someuser1';
+        $_GET['n'] = 'twitter';
+        $_GET['d'] = 'tweets-all';
+        $controller = new GridController(true);
+        $this->assertTrue(isset($controller));
+        ob_start();
+        $controller->control();
+        $results = ob_get_contents();
+        ob_end_clean();
+        $json = substr($results, 29, strrpos($results, ';') - 30);
+        $ob = json_decode( $json );
+        $this->assertEqual($ob->status, 'success');
+        $this->assertEqual(count($ob->posts), 2);
+    }
+
+    public function testOwnerWithAccessTweetsAllMaxNoLimit() {
+        $builders = $this->buildData();
+        GridController::$MAX_ROWS = 1;
+        $this->simulateLogin('me@example.com');
+        $_GET['u'] = 'someuser1';
+        $_GET['n'] = 'twitter';
+        $_GET['d'] = 'tweets-all';
+        $_GET['nolimit'] = '1';
+        $controller = new GridController(true);
+        $this->assertTrue(isset($controller));
+        ob_start();
+        $controller->control();
+        $results = ob_get_contents();
+        ob_end_clean();
+        $json = substr($results, 29, strrpos($results, ';') - 30);
+        $ob = json_decode( $json );
+        $this->assertEqual($ob->status, 'success');
+        $this->assertEqual(count($ob->posts), 3);
+    }
+    
     public function testReplyToSearch() {
         $builders = $this->buildData();
         $this->simulateLogin('me@example.com');

--- a/tests/TestOfPostMySQLDAO.php
+++ b/tests/TestOfPostMySQLDAO.php
@@ -719,6 +719,20 @@ class TestOfPostMySQLDAO extends ThinkUpUnitTestCase {
     }
 
     /**
+     * Test setting count to 0 to set no post row return limit
+     */
+    public function testGetAllPostIteratorsNoLimit() {
+        $dao = new PostMySQLDAO();
+        $posts_it = $dao->getAllPostsIterator(18, 'twitter', 0);
+        $cnt = 0;
+        $this->assertIsA($posts_it,'PostIterator');
+        foreach($posts_it as $key => $value) {
+            $cnt++;
+        }
+        $this->assertEqual($cnt, 41);
+    }
+
+    /**
      * Test getPost on a post that exists
      */
     public function testGetPostExists() {

--- a/webapp/_lib/controller/class.GridController.php
+++ b/webapp/_lib/controller/class.GridController.php
@@ -34,7 +34,8 @@ class GridController extends ThinkUpAuthController {
     /**
      * const max rows for grid
      */
-    const MAX_ROWS = 5000;
+    public static $MAX_ROWS = 5000;
+
     /**
      * number of days to look back for retweeted posts
      */
@@ -97,17 +98,20 @@ class GridController extends ThinkUpAuthController {
                         $post_dao = DAOFactory::getDAO('PostDAO');
                         $posts_it = $post_dao->getRepliesToPostIterator($_GET['t'], $_GET['n']);
                     } else {
+                        if(isset($_GET['nolimit']) && $_GET['nolimit'] == 'true') {
+                            self::$MAX_ROWS = 0;
+                        }
                         $webapp = Webapp::getInstance();
                         $webapp->setActivePlugin($instance->network);
                         $tab = $webapp->getDashboardMenuItem($_GET['d'], $instance);
                         $posts_it = $tab->datasets[0]->retrieveIterator();
                     }
-                    echo '{"status":"success","posts": [' . "\n";
+                    echo '{"status":"success","limit":' . self::$MAX_ROWS . ',"posts": [' . "\n";
                     $cnt = 0;
                     // lets make sure we have a post iterator, and not just a list of posts
                     if( get_class($posts_it) != 'PostIterator' ) {
                         throw Exception("Grid Search should use a PostIterator to conserve memory");
-                    } 
+                    }
                     foreach($posts_it as $key => $value) {
                         $cnt++;
                         $data = array('id' => $cnt, 'text' => $value->post_text,
@@ -127,5 +131,13 @@ class GridController extends ThinkUpAuthController {
         } else {
             echo '{"status":"failed","message":"Missing Parameters"}';
         }
+    }
+
+    /**
+     * return max rows
+     * @return int $MAX_ROWS
+     */
+    public static function getMaxRows() {
+        return self::$MAX_ROWS;
     }
 }

--- a/webapp/_lib/controller/class.PostController.php
+++ b/webapp/_lib/controller/class.PostController.php
@@ -53,6 +53,9 @@ class PostController extends ThinkUpController {
                     $config = Config::getInstance();
                     $this->addToView('disable_embed_code', ($config->getValue('is_embed_disabled') ||
                     $post->is_protected ));
+                    if(isset($_GET['search'])) {
+                        $this->addToView('search_on', true);
+                    }
                     if ( !$post->is_protected || $this->isLoggedIn()) {
                         $plugin_option_dao = DAOFactory::GetDAO('PluginOptionDAO');
                         $options = $plugin_option_dao->getOptionsHash('geoencoder', true);

--- a/webapp/_lib/model/class.PostMySQLDAO.php
+++ b/webapp/_lib/model/class.PostMySQLDAO.php
@@ -739,13 +739,15 @@ class PostMySQLDAO extends PDODAO implements PostDAO  {
             $q .= 'AND p.is_protected = 0 ';
         }
         $q .= "ORDER BY $order_by $direction ";
-        $q .= "LIMIT :start_on_record, :limit";
         $vars = array(
             ':author_id'=>$author_id,
             ':network'=>$network,
-            ':limit'=>(int)$count,
-            ':start_on_record'=>(int)$start_on_record
         );
+        if(isset($count) && $count > 0) {
+            $q .= "LIMIT :start_on_record, :limit";
+            $vars[':limit'] = (int)$count;
+            $vars[':start_on_record'] = (int)$start_on_record;
+        }
 
         if ($this->profiler_enabled) Profiler::setDAOMethod(__METHOD__);
         $ps = $this->execute($q, $vars);

--- a/webapp/_lib/view/_grid.search.tpl
+++ b/webapp/_lib/view/_grid.search.tpl
@@ -1,10 +1,11 @@
 <div id="grid_search_template">
-<div id="grid_overlay_div" class="grid_overlay_div{if $version2}2{/if}">
+<div id="grid_overlay_div" class="grid_overlay_div2">
 <script type="text/javascript">
-    GRID_TYPE={if $version2}2{else}1{/if};
+    GRID_TYPE=2;
 </script>
-<iframe class="grid_iframe{if $version2}2{/if}" id="grid_iframe" src="{$site_root_path}assets/img/ui-bg_glass_65_ffffff_1x400.png" 
+<iframe class="grid_iframe2" id="grid_iframe" src="{$site_root_path}assets/img/ui-bg_glass_65_ffffff_1x400.png" 
 frameborder="0" scrolling="no"></iframe>
-<div id="close_grid_search_div"><a href="#" id="close_grid_search" onclick="return false;"><img src="{$site_root_path}assets/img/close-icon.gif" /></a></div>
+<div id="close_grid_search_div"><a href="#" 
+id="close_grid_search" onclick="return false;"><img src="{$site_root_path}assets/img/close-icon.gif" /></a></div>
 </div>
 </div>

--- a/webapp/_lib/view/_post.word-frequency.tpl
+++ b/webapp/_lib/view/_post.word-frequency.tpl
@@ -9,7 +9,8 @@
 </div>
 
 <div id="word-frequency-posts-div">
-    <div align="right"<a href="#" onclick="return false;" id="word-frequency-close"><img src="{$site_root_path}assets/img/close-icon.gif" width="27" height="26" /></a></div>
+    <div align="right"><a href="#" onclick="return false;" id="word-frequency-close">
+    <img src="{$site_root_path}assets/img/close-icon.gif" width="27" height="26" /></a></div>
     <div id="word-frequency-posts">
     </div>
 </div>

--- a/webapp/_lib/view/post.index.tpl
+++ b/webapp/_lib/view/post.index.tpl
@@ -15,13 +15,24 @@
           
           <li>
           Replies
+          <form id="grid_search_form" action="{$site_root_path}post">
+          <input type="hidden" name="t" value="{$post->post_id}" />
+          <input type="hidden" name="n" value="{$post->network}" />
           <ul class="side-subnav">
-          <li{if $smarty.get.v eq ''} class="currentview"{/if}><a href="index.php?t={$post->post_id}&n={$post->network}">Post Replies&nbsp;&nbsp;&nbsp;</a></li>
+          <li{if $smarty.get.v eq ''} class="currentview"{/if}>
+          <a href="index.php?t={$post->post_id}&n={$post->network}">Post Replies&nbsp;&nbsp;&nbsp;</a>
+          </li>
           {if $logged_in_user && $post->reply_count_cache && $post->reply_count_cache > 1}
-            <li id="grid_search_icon"><a href="#" class="grid_search" title="Search" onclick="return false;"><span>Search & Filter Replies</span></a></li>
+            <li><input type="text" name="search" id="grid_search_sidebar_input" value="" style="margin-top: 3px;"/></li>
+            <li id="grid_search_input">
+                <a href="#" class="grid_search" 
+                onclick="$('#grid_search_form').submit(); return false;" title="Search">
+                <span>Search & Filter Replies</span></a></li>
           {/if}
           <li><a href="{$site_root_path}post/export.php?u={$post->author_username}&n={$post->network}&post_id={$post->post_id}&type=replies">Export Replies (CSV)</a></li>
-          </ul></li>
+          </ul>
+          </form>
+          </li>
         {/if}
         
         {if $sidebar_menu}
@@ -179,7 +190,7 @@
                 {if $replies && $logged_in_user}
                     {include file="_grid.search.tpl" version2=true}
                 {/if}
-                <div id="post-replies-div"><br>
+                <div id="post-replies-div"{if $search_on} style="display: none;"{/if}><br />
                   <div id="post_replies clearfix">
                   {foreach from=$replies key=tid item=t name=foo}
                     {include file="_post.clean.tpl" t=$t sort='no' scrub_reply_username=true reply_count=$post->reply_count_cache}
@@ -188,6 +199,7 @@
                   </div>
                 </div>
                 <script src="{$site_root_path}assets/js/extlib/Snowball.stemmer.min.js" type="text/javascript"></script>
+                {if $search_on}<script type="text/javascript">grid_search_on = true</script>{/if}
                 <script src="{$site_root_path}assets/js/word_frequency.js" type="text/javascript"></script>
                 {if !$logged_in_user && $private_reply_count > 0}
                   <span style="font-size:12px">Not showing {$private_reply_count} private repl{if $private_reply_count == 1}y{else}ies{/if}.</span>

--- a/webapp/assets/css/style.css
+++ b/webapp/assets/css/style.css
@@ -210,15 +210,15 @@ text-align: center;
 #sidemenu {display : none;}
 
 /* slick grid style */
-.grid_iframe {width: 920px; height: 660px; display: none; border: solid black 0px;}
+.grid_iframe {width: 705px; height: 660px; display: none; border: solid black 0px;}
 .grid_iframe2 {width: 705px; height: 660px; display: none; border: solid black 0px;}
 #close_grid_search_div {text-align: right; margin-right: 10px;}
 .grid_overlay_div { 
-    width: 920px; height: 700px; border: solid black 2px; display: none; top: 30px; left: 50%;
+    width: 720px; height: 700px; border: solid black 0px; display: none; top: 30px; left: 50%;
     z-index: 100; margin-left: -536px; position: absolute; background-color: #fff;
 }
 .grid_overlay_div2 { 
-    width: 720px; height: 700px; border: solid gray 1px;  display: none; top: 150px; left: 50%; background-color: #fff;
+    width: 720px; height: 700px; border: solid gray 0px;  display: none; top: 150px; left: 50%; background-color: #fff;
 }
 /* body overlay div (backround grayout for slick grid search unit */
 #screen {position: absolute; left: 0; top: 0; background: #000; z-index: 99; color: red; display: none;}

--- a/webapp/assets/html/grid.html
+++ b/webapp/assets/html/grid.html
@@ -29,14 +29,24 @@ $(document).keyup(function(e) {
 <form onsubmit="return false;"  id="grid_search_form">
 <p style="padding-left: 20px">
 <label style="font-size: 20px;">Search:&nbsp;</label><input type=text id="grid_search_input" style="width:100px;">
-<input type="submit" value="search">
-<input type="button" value="export" id="grid_export">
-&nbsp; <span style="font-size: 20px;"><b><span id="grid_search_count" style="font-size: 20px;">0</span></b> results</span>
+<input type="submit" value="search" />
+<input type="button" value="export" id="grid_export" />
+&nbsp; <span style="font-size: 20px;">
+<b><span id="grid_search_count" style="font-size: 20px;">0</span></b> results</span>
 &nbsp; &nbsp; <span style="font-size: 10px;"><em>hint: esc key closes search</em></span>
+
+<span id="overlimit" style="display: none;"> 
+  <br /><br />
+  <span style="padding: 5px 5px 5px 5px; background-color: #FFFFAA">
+    <b>NOTE: Search limited to <span id="max_rows"></span> for performance. 
+    <a href="#" onclick="parent.tu_grid_search.load_iframe(true); return false;">show all?</a></b>
+  </span>
+</span>
+
 </p>
 </form>
-<img src="../img/loading.gif" id="grid_search_spinner" style="margin: 250px 0px 0px 430px;">
-<div id="myGrid" style="width:860px;height:600px; display: none; margin: 20px 0px 0px 20px;"></div>
+<img src="../img/loading.gif" id="grid_search_spinner" style="margin: 250px 0px 0px 310px;">
+<div id="myGrid" style="width:650px;height:600px; display: none; margin: 20px 0px 0px 20px;"></div>
 <script type="text/javascript">
     tu_grid_search.get_data();
 </script>

--- a/webapp/assets/js/grid_search.js
+++ b/webapp/assets/js/grid_search.js
@@ -33,8 +33,11 @@ var TUGridSearch = function() {
             $('#close_grid_search').click(function() {
                 tu_grid_search.close_iframe();
             });
+            if(document.location.search.match(/search=/)) {
+                tu_grid_search.load_iframe();
+            }
         });
-        // tu_grid_search.load_iframe();
+        //tu_grid_search.load_iframe();
     }
 
     /**
@@ -43,6 +46,13 @@ var TUGridSearch = function() {
 	 */
     this.populate_grid = function(obj) {
         if (tu_grid_search.DEBUG) { console.debug(obj.posts.length + ' posts'); }
+        if (tu_grid_search.DEBUG) { console.debug(obj.limit + ' limit'); }
+        if((obj.posts.length - obj.limit) == 1) {
+            $('#max_rows').html(obj.limit);
+            $('#overlimit').show();
+        } else {
+            $('#overlimit').hide();
+        }
         $('#grid_search_icon').show();
         $('#grid_search_spinner').hide();
 
@@ -87,7 +97,7 @@ var TUGridSearch = function() {
             id : "text",
             name : "Text",
             field : "text",
-            width : 615,
+            width : 550,
             formatter: function(row, cell, value, columnDef, dataContext) {
                 var url_match = /(https?:\/\/([-\w\.]+)+(:\d+)?(\/([\w/_\.]*(\?\S+)?)?)?)/g;
                 value = value.replace(url_match, '<a href="$1" target="_blank">$1</a> ');
@@ -95,13 +105,13 @@ var TUGridSearch = function() {
                 return value;
             }
         } ];
-        if( parent.GRID_TYPE == 2) {
-            columns[3].width = 455;
-        }
+        //if( parent.GRID_TYPE == 2) {
+        columns[3].width = 400;
+        //}
 
         var options = {
             enableCellNavigation : false,
-            enableColumnReorder : true
+            enableColumnReorder : false
         };
 
         this.dataView.beginUpdate();
@@ -140,6 +150,16 @@ var TUGridSearch = function() {
             $('#grid_search_form').show();
         });
 
+        //if search arg, filter...
+        if(match_array = document.location.search.match(/search=(.*?)&/)) {
+            search_query = decodeURIComponent(unescape(match_array[1])).replace(/\+/g, ' ');
+            if (tu_grid_search.DEBUG) { console.debug("search param defined: %s", search_query); }
+            $('#grid_search_input').val(search_query);
+            $('#grid_search_input').focus();
+            this.value = search_query;
+            tu_grid_search.searchString = this.value;
+            tu_grid_search.dataView.refresh();
+        }
     }
 
     /**
@@ -158,8 +178,8 @@ var TUGridSearch = function() {
     /**
 	 * 
 	 */
-    this.load_iframe = function() {
-
+    this.load_iframe = function(nolimit) {
+        nolimit = nolimit ? true : false;
         // close grid search with escape key
         $(document).keyup( this.keyup );
 
@@ -167,14 +187,15 @@ var TUGridSearch = function() {
         // close top 20 words if needed
         if(typeof(tu_word_freq) != 'undefined') { tu_word_freq.close(); };
         tu_grid_search.loading = true;
-        if(GRID_TYPE==1) {
+        if(window.GRID_TYPE && GRID_TYPE==1) {
             window.scroll(0,0);
             $('#screen').css({ opacity: 0.7, "width":$(document).width(),"height":$(document).height()});
         } else {
             $('#post-replies-div').hide();
+            $('#all-posts-div').hide();
             $('#word-frequency-div').hide();
         }
-        var fade = (GRID_TYPE==1) ? 500 : 1;
+        var fade = (typeof(GRID_TYPE) != 'undefined' && GRID_TYPE==1) ? 500 : 1;
         $('#screen').fadeIn(fade, function() {
             $('#grid_overlay_div').show();
             $('#grid_iframe').show();
@@ -186,9 +207,10 @@ var TUGridSearch = function() {
             }
             if(typeof(post_username) != 'undefined') { query_string+= '&u=' + escape(post_username); } 
             $('#grid_iframe').attr('src',
-                    path + 'assets/html/grid.html?' + query_string + '&cb=' + (new Date()).getTime());
+                    path + 'assets/html/grid.html?' + query_string + '&nolimit=' + nolimit
+                    + '&cb=' + (new Date()).getTime());
             if (tu_grid_search.DEBUG) {
-                console.debug("loading grid search iframe %s",  $('#grid_iframe').attr('src') );
+                console.debug("loading grid search iframes %s",  $('#grid_iframe').attr('src') );
             }
             tu_grid_search.loading = false;
         });
@@ -201,11 +223,12 @@ var TUGridSearch = function() {
         $('#grid_iframe').attr('src', path + '/assets/img/ui-bg_glass_65_ffffff_1x400.png');
         $('#grid_overlay_div').hide();
         $('#grid_iframe').hide();
-        if(GRID_TYPE==1) {
+        if(typeof(GRID_TYPE) != 'undefined' && GRID_TYPE == 1) {
             $('#screen').fadeOut(500);
         } else {
             $('#post-replies-div').show();
             $('#word-frequency-div').show();
+            $('#all-posts-div').show();
         }
         $(document).unbind('keyup', this.keyup);
     }

--- a/webapp/assets/js/word_frequency.js
+++ b/webapp/assets/js/word_frequency.js
@@ -142,6 +142,9 @@ var TUWordFrequency = function() {
 
         // show frequency div
         $('#word-frequency-div').show();
+        if(typeof(grid_search_on) != 'undefined' && grid_search_on == true) {
+            $('#word-frequency-div').hide();
+        }
 
         //pull in and clean post texts...
         var posts = $('.reply_text');
@@ -155,7 +158,7 @@ var TUWordFrequency = function() {
 
         // sort by count
         this.sorted_words = this.sort_words();
-
+        
         // show top 20 words sorted by frequency
         for(i = 0; i < this.sorted_words.length; i++) {
             if(i >= 20 ) {

--- a/webapp/plugins/twitter/model/class.TwitterPlugin.php
+++ b/webapp/plugins/twitter/model/class.TwitterPlugin.php
@@ -146,12 +146,11 @@ class TwitterPlugin implements CrawlerPlugin, DashboardPlugin, PostDetailPlugin 
     public function getDashboardMenuItems($instance) {
         $twitter_data_tpl = Utils::getPluginViewDirectory('twitter').'twitter.inline.view.tpl';
         $menus = array();
-
         //All tab
         $all_mi = new MenuItem("All Tweets", "All tweets", $twitter_data_tpl, "Tweets");
         $all_mi_ds = new Dataset("all_tweets", 'PostDAO', "getAllPosts", array($instance->network_user_id,
         'twitter', 15, "#page_number#"), 'getAllPostsIterator', array($instance->network_user_id, 'twitter', 
-        GridController::MAX_ROWS) );
+        GridController::getMaxRows()) );
         $all_mi_ds->addHelp('userguide/listings/twitter/dashboard_tweets-all');
         $all_mi->addDataset($all_mi_ds);
         $menus['tweets-all'] = $all_mi;
@@ -185,7 +184,7 @@ class TwitterPlugin implements CrawlerPlugin, DashboardPlugin, PostDetailPlugin 
             //All Mentions
             $amtab = new MenuItem("All Mentions", "Any post that mentions you", $twitter_data_tpl, 'Replies');
             $amtabds1 = new Dataset("all_tweets", 'PostDAO', "getAllPosts", array($instance->network_user_id,
-           'twitter', 15), "getAllMentionsIterator", array($instance->network_username, GridController::MAX_ROWS, 
+           'twitter', 15), "getAllMentionsIterator", array($instance->network_username, GridController::getMaxRows(), 
            'twitter'));
             $amtabds2 = new Dataset("all_mentions", 'PostDAO', "getAllMentions",
             array($instance->network_username, 15, $instance->network, '#page_number#'));
@@ -315,7 +314,7 @@ class TwitterPlugin implements CrawlerPlugin, DashboardPlugin, PostDetailPlugin 
         $fvalltab = new MenuItem("All", "All favorites", $twitter_data_tpl, 'Favorites');
         $fvalltabds = new Dataset("all_tweets", 'FavoritePostDAO', "getAllFavoritePosts",
         array($instance->network_user_id, 'twitter', 20, "#page_number#"), 'getAllFavoritePostsIterator',
-        array($instance->network_user_id, 'twitter', GridController::MAX_ROWS) );
+        array($instance->network_user_id, 'twitter', GridController::getMaxRows()) );
         $fvalltabds->addHelp('userguide/listings/twitter/dashboard_ftweets-all');
         $fvalltab->addDataset($fvalltabds);
         $menus["ftweets-all"] = $fvalltab;

--- a/webapp/plugins/twitter/view/twitter.inline.view.tpl
+++ b/webapp/plugins/twitter/view/twitter.inline.view.tpl
@@ -26,10 +26,18 @@
     </p>
   </div>
 {/if}
+
+{if $is_searchable}
+    {include file="_grid.search.tpl"}
+    <script type="text/javascript" src="{$site_root_path}assets/js/grid_search.js"></script>
+{/if}
+
 {if $all_tweets and ($display eq 'tweets-all' or $display eq 'tweets-questions')}
+<div id="all-posts-div">
   {foreach from=$all_tweets key=tid item=t name=foo}
     {include file="_post.tpl" t=$t}
   {/foreach}
+</div>
 {/if}
 
 {if $all_tweets and $display eq 'ftweets-all'}
@@ -157,9 +165,5 @@ or ($display eq 'followers-former' and not $people) or ($display eq 'followers-e
   {/literal}
 </script>
 
-{if $is_searchable}
-    {include file="_grid.search.tpl"}
-    <script type="text/javascript" src="{$site_root_path}assets/js/grid_search.js"></script>
-    
-{/if}
+
 


### PR DESCRIPTION
- Add notice if search limit of 5000 is reached
- Add ability to override search limit
- Load all-tweets search grid inline on page
- Post replies Slickgrid search should work from any post view
- Add sidebar search input box
- Disable grid column re-ordering, causes grid to clear
- Hide word frequency when loading search view from url
  
  Closes #814 #714 #709
