### PR TITLE
Slick Grid search updates

### DIFF
--- a/tests/TestOfGridController.php
+++ b/tests/TestOfGridController.php
@@ -39,6 +39,11 @@ class TestOfGridController extends ThinkUpUnitTestCase {
         $webapp->registerPlugin('twitter', 'TwitterPlugin');
     }
 
+    public function tearDown() {
+        parent::tearDown();
+        GridController::$MAX_ROWS = 5000;
+    }
+
     public function testConstructor() {
         $controller = new GridController(true);
         $this->assertTrue(isset($controller));
@@ -113,6 +118,45 @@ class TestOfGridController extends ThinkUpUnitTestCase {
         $this->assertEqual(count($ob->posts), 3);
     }
 
+    public function testOwnerWithAccessTweetsAllMaxLimit() {
+        $builders = $this->buildData();
+        GridController::$MAX_ROWS = 1;
+        $this->simulateLogin('me@example.com');
+        $_GET['u'] = 'someuser1';
+        $_GET['n'] = 'twitter';
+        $_GET['d'] = 'tweets-all';
+        $controller = new GridController(true);
+        $this->assertTrue(isset($controller));
+        ob_start();
+        $controller->control();
+        $results = ob_get_contents();
+        ob_end_clean();
+        $json = substr($results, 29, strrpos($results, ';') - 30);
+        $ob = json_decode( $json );
+        $this->assertEqual($ob->status, 'success');
+        $this->assertEqual(count($ob->posts), 2);
+    }
+
+    public function testOwnerWithAccessTweetsAllMaxNoLimit() {
+        $builders = $this->buildData();
+        GridController::$MAX_ROWS = 0;
+        $this->simulateLogin('me@example.com');
+        $_GET['u'] = 'someuser1';
+        $_GET['n'] = 'twitter';
+        $_GET['d'] = 'tweets-all';
+        $_GET['nolimit'] = '1';
+        $controller = new GridController(true);
+        $this->assertTrue(isset($controller));
+        ob_start();
+        $controller->control();
+        $results = ob_get_contents();
+        ob_end_clean();
+        $json = substr($results, 29, strrpos($results, ';') - 30);
+        $ob = json_decode( $json );
+        $this->assertEqual($ob->status, 'success');
+        $this->assertEqual(count($ob->posts), 3);
+    }
+    
     public function testReplyToSearch() {
         $builders = $this->buildData();
         $this->simulateLogin('me@example.com');

--- a/tests/TestOfPostMySQLDAO.php
+++ b/tests/TestOfPostMySQLDAO.php
@@ -719,6 +719,20 @@ class TestOfPostMySQLDAO extends ThinkUpUnitTestCase {
     }
 
     /**
+     * Test setting count to 0 to set no post row return limit
+     */
+    public function testGetAllPostIteratorsNoLimit() {
+        $dao = new PostMySQLDAO();
+        $posts_it = $dao->getAllPostsIterator(18, 'twitter', 0);
+        $cnt = 0;
+        $this->assertIsA($posts_it,'PostIterator');
+        foreach($posts_it as $key => $value) {
+            $cnt++;
+        }
+        $this->assertEqual($cnt, 41);
+    }
+
+    /**
      * Test getPost on a post that exists
      */
     public function testGetPostExists() {

--- a/webapp/_lib/controller/class.GridController.php
+++ b/webapp/_lib/controller/class.GridController.php
@@ -34,7 +34,8 @@ class GridController extends ThinkUpAuthController {
     /**
      * const max rows for grid
      */
-    const MAX_ROWS = 5000;
+    public static $MAX_ROWS = 5000;
+
     /**
      * number of days to look back for retweeted posts
      */
@@ -97,17 +98,20 @@ class GridController extends ThinkUpAuthController {
                         $post_dao = DAOFactory::getDAO('PostDAO');
                         $posts_it = $post_dao->getRepliesToPostIterator($_GET['t'], $_GET['n']);
                     } else {
+                        if(isset($_GET['nolimit']) && $_GET['nolimit'] == 'true') {
+                            self::$MAX_ROWS = 0;
+                        }
                         $webapp = Webapp::getInstance();
                         $webapp->setActivePlugin($instance->network);
                         $tab = $webapp->getDashboardMenuItem($_GET['d'], $instance);
                         $posts_it = $tab->datasets[0]->retrieveIterator();
                     }
-                    echo '{"status":"success","posts": [' . "\n";
+                    echo '{"status":"success","limit":' . self::$MAX_ROWS . ',"posts": [' . "\n";
                     $cnt = 0;
                     // lets make sure we have a post iterator, and not just a list of posts
                     if( get_class($posts_it) != 'PostIterator' ) {
                         throw Exception("Grid Search should use a PostIterator to conserve memory");
-                    } 
+                    }
                     foreach($posts_it as $key => $value) {
                         $cnt++;
                         $data = array('id' => $cnt, 'text' => $value->post_text,
@@ -127,5 +131,13 @@ class GridController extends ThinkUpAuthController {
         } else {
             echo '{"status":"failed","message":"Missing Parameters"}';
         }
+    }
+
+    /**
+     * return max rows
+     * @return int $MAX_ROWS
+     */
+    public static function getMaxRows() {
+        return self::$MAX_ROWS;
     }
 }

--- a/webapp/_lib/controller/class.PostController.php
+++ b/webapp/_lib/controller/class.PostController.php
@@ -53,6 +53,9 @@ class PostController extends ThinkUpController {
                     $config = Config::getInstance();
                     $this->addToView('disable_embed_code', ($config->getValue('is_embed_disabled') ||
                     $post->is_protected ));
+                    if(isset($_GET['search'])) {
+                        $this->addToView('search_on', true);
+                    }
                     if ( !$post->is_protected || $this->isLoggedIn()) {
                         $plugin_option_dao = DAOFactory::GetDAO('PluginOptionDAO');
                         $options = $plugin_option_dao->getOptionsHash('geoencoder', true);

--- a/webapp/_lib/model/class.PostMySQLDAO.php
+++ b/webapp/_lib/model/class.PostMySQLDAO.php
@@ -739,13 +739,15 @@ class PostMySQLDAO extends PDODAO implements PostDAO  {
             $q .= 'AND p.is_protected = 0 ';
         }
         $q .= "ORDER BY $order_by $direction ";
-        $q .= "LIMIT :start_on_record, :limit";
         $vars = array(
             ':author_id'=>$author_id,
             ':network'=>$network,
-            ':limit'=>(int)$count,
-            ':start_on_record'=>(int)$start_on_record
         );
+        if(isset($count) && $count > 0) {
+            $q .= "LIMIT :start_on_record, :limit";
+            $vars[':limit'] = (int)$count;
+            $vars[':start_on_record'] = (int)$start_on_record;
+        }
 
         if ($this->profiler_enabled) Profiler::setDAOMethod(__METHOD__);
         $ps = $this->execute($q, $vars);

--- a/webapp/_lib/view/_grid.search.tpl
+++ b/webapp/_lib/view/_grid.search.tpl
@@ -1,10 +1,11 @@
 <div id="grid_search_template">
-<div id="grid_overlay_div" class="grid_overlay_div{if $version2}2{/if}">
+<div id="grid_overlay_div" class="grid_overlay_div2">
 <script type="text/javascript">
-    GRID_TYPE={if $version2}2{else}1{/if};
+    GRID_TYPE=2;
 </script>
-<iframe class="grid_iframe{if $version2}2{/if}" id="grid_iframe" src="{$site_root_path}assets/img/ui-bg_glass_65_ffffff_1x400.png" 
+<iframe class="grid_iframe2" id="grid_iframe" src="{$site_root_path}assets/img/ui-bg_glass_65_ffffff_1x400.png" 
 frameborder="0" scrolling="no"></iframe>
-<div id="close_grid_search_div"><a href="#" id="close_grid_search" onclick="return false;"><img src="{$site_root_path}assets/img/close-icon.gif" /></a></div>
+<div id="close_grid_search_div"><a href="#" 
+id="close_grid_search" onclick="return false;"><img src="{$site_root_path}assets/img/close-icon.gif" /></a></div>
 </div>
 </div>

--- a/webapp/_lib/view/_post.word-frequency.tpl
+++ b/webapp/_lib/view/_post.word-frequency.tpl
@@ -9,7 +9,8 @@
 </div>
 
 <div id="word-frequency-posts-div">
-    <div align="right"<a href="#" onclick="return false;" id="word-frequency-close"><img src="{$site_root_path}assets/img/close-icon.gif" width="27" height="26" /></a></div>
+    <div align="right"><a href="#" onclick="return false;" id="word-frequency-close">
+    <img src="{$site_root_path}assets/img/close-icon.gif" width="27" height="26" /></a></div>
     <div id="word-frequency-posts">
     </div>
 </div>

--- a/webapp/_lib/view/dashboard.tpl
+++ b/webapp/_lib/view/dashboard.tpl
@@ -63,7 +63,7 @@
 
             {if $data_template}
               {include file=$data_template}
-              <div class="float-l">
+              <div class="float-l" id="older-posts-div">
                 {if $next_page}
                   <a href="{$site_root_path}index.php?{if $smarty.get.v}v={$smarty.get.v}&{/if}{if $smarty.get.u}u={$smarty.get.u}&{/if}{if $smarty.get.n}n={$smarty.get.n}&{/if}page={$next_page}" id="next_page">&#60; Older Posts</a>
                 {/if}

--- a/webapp/_lib/view/post.index.tpl
+++ b/webapp/_lib/view/post.index.tpl
@@ -15,13 +15,24 @@
           
           <li>
           Replies
+          <form id="grid_search_form" action="{$site_root_path}post">
+          <input type="hidden" name="t" value="{$post->post_id}" />
+          <input type="hidden" name="n" value="{$post->network}" />
           <ul class="side-subnav">
-          <li{if $smarty.get.v eq ''} class="currentview"{/if}><a href="index.php?t={$post->post_id}&n={$post->network}">Post Replies&nbsp;&nbsp;&nbsp;</a></li>
+          <li{if $smarty.get.v eq ''} class="currentview"{/if}>
+          <a href="index.php?t={$post->post_id}&n={$post->network}">Post Replies&nbsp;&nbsp;&nbsp;</a>
+          </li>
           {if $logged_in_user && $post->reply_count_cache && $post->reply_count_cache > 1}
-            <li id="grid_search_icon"><a href="#" class="grid_search" title="Search" onclick="return false;"><span>Search & Filter Replies</span></a></li>
+            <li><input type="text" name="search" id="grid_search_sidebar_input" value="" style="margin-top: 3px;"/></li>
+            <li id="grid_search_input">
+                <a href="#" class="grid_search" 
+                onclick="$('#grid_search_form').submit(); return false;" title="Search">
+                <span>Search & Filter Replies</span></a></li>
           {/if}
           <li><a href="{$site_root_path}post/export.php?u={$post->author_username}&n={$post->network}&post_id={$post->post_id}&type=replies">Export Replies (CSV)</a></li>
-          </ul></li>
+          </ul>
+          </form>
+          </li>
         {/if}
         
         {if $sidebar_menu}
@@ -179,7 +190,7 @@
                 {if $replies && $logged_in_user}
                     {include file="_grid.search.tpl" version2=true}
                 {/if}
-                <div id="post-replies-div"><br>
+                <div id="post-replies-div"{if $search_on} style="display: none;"{/if}><br />
                   <div id="post_replies clearfix">
                   {foreach from=$replies key=tid item=t name=foo}
                     {include file="_post.clean.tpl" t=$t sort='no' scrub_reply_username=true reply_count=$post->reply_count_cache}
@@ -188,6 +199,7 @@
                   </div>
                 </div>
                 <script src="{$site_root_path}assets/js/extlib/Snowball.stemmer.min.js" type="text/javascript"></script>
+                {if $search_on}<script type="text/javascript">grid_search_on = true</script>{/if}
                 <script src="{$site_root_path}assets/js/word_frequency.js" type="text/javascript"></script>
                 {if !$logged_in_user && $private_reply_count > 0}
                   <span style="font-size:12px">Not showing {$private_reply_count} private repl{if $private_reply_count == 1}y{else}ies{/if}.</span>

--- a/webapp/assets/css/style.css
+++ b/webapp/assets/css/style.css
@@ -210,15 +210,15 @@ text-align: center;
 #sidemenu {display : none;}
 
 /* slick grid style */
-.grid_iframe {width: 920px; height: 660px; display: none; border: solid black 0px;}
+.grid_iframe {width: 705px; height: 660px; display: none; border: solid black 0px;}
 .grid_iframe2 {width: 705px; height: 660px; display: none; border: solid black 0px;}
 #close_grid_search_div {text-align: right; margin-right: 10px;}
 .grid_overlay_div { 
-    width: 920px; height: 700px; border: solid black 2px; display: none; top: 30px; left: 50%;
+    width: 720px; height: 700px; border: solid black 0px; display: none; top: 30px; left: 50%;
     z-index: 100; margin-left: -536px; position: absolute; background-color: #fff;
 }
 .grid_overlay_div2 { 
-    width: 720px; height: 700px; border: solid gray 1px;  display: none; top: 150px; left: 50%; background-color: #fff;
+    width: 720px; height: 700px; border: solid gray 0px;  display: none; top: 150px; left: 50%; background-color: #fff;
 }
 /* body overlay div (backround grayout for slick grid search unit */
 #screen {position: absolute; left: 0; top: 0; background: #000; z-index: 99; color: red; display: none;}

--- a/webapp/assets/html/grid.html
+++ b/webapp/assets/html/grid.html
@@ -29,14 +29,24 @@ $(document).keyup(function(e) {
 <form onsubmit="return false;"  id="grid_search_form">
 <p style="padding-left: 20px">
 <label style="font-size: 20px;">Search:&nbsp;</label><input type=text id="grid_search_input" style="width:100px;">
-<input type="submit" value="search">
-<input type="button" value="export" id="grid_export">
-&nbsp; <span style="font-size: 20px;"><b><span id="grid_search_count" style="font-size: 20px;">0</span></b> results</span>
+<input type="submit" value="search" />
+<input type="button" value="export" id="grid_export" />
+&nbsp; <span style="font-size: 20px;">
+<b><span id="grid_search_count" style="font-size: 20px;">0</span></b> results</span>
 &nbsp; &nbsp; <span style="font-size: 10px;"><em>hint: esc key closes search</em></span>
+
+<span id="overlimit" style="display: none;"> 
+  <br /><br />
+  <span style="padding: 5px 5px 5px 5px; background-color: #FFFFAA">
+    <b>NOTE: Search limited to <span id="max_rows"></span> for performance. 
+    <a href="#" onclick="parent.tu_grid_search.load_iframe(true); return false;">show all?</a></b>
+  </span>
+</span>
+
 </p>
 </form>
-<img src="../img/loading.gif" id="grid_search_spinner" style="margin: 250px 0px 0px 430px;">
-<div id="myGrid" style="width:860px;height:600px; display: none; margin: 20px 0px 0px 20px;"></div>
+<img src="../img/loading.gif" id="grid_search_spinner" style="margin: 250px 0px 0px 310px;">
+<div id="myGrid" style="width:650px;height:600px; display: none; margin: 20px 0px 0px 20px;"></div>
 <script type="text/javascript">
     tu_grid_search.get_data();
 </script>

--- a/webapp/assets/js/word_frequency.js
+++ b/webapp/assets/js/word_frequency.js
@@ -142,6 +142,9 @@ var TUWordFrequency = function() {
 
         // show frequency div
         $('#word-frequency-div').show();
+        if(typeof(grid_search_on) != 'undefined' && grid_search_on == true) {
+            $('#word-frequency-div').hide();
+        }
 
         //pull in and clean post texts...
         var posts = $('.reply_text');
@@ -155,7 +158,7 @@ var TUWordFrequency = function() {
 
         // sort by count
         this.sorted_words = this.sort_words();
-
+        
         // show top 20 words sorted by frequency
         for(i = 0; i < this.sorted_words.length; i++) {
             if(i >= 20 ) {

--- a/webapp/plugins/facebook/model/class.FacebookPlugin.php
+++ b/webapp/plugins/facebook/model/class.FacebookPlugin.php
@@ -121,7 +121,7 @@ class FacebookPlugin implements CrawlerPlugin, DashboardPlugin {
         $alltab = new MenuItem("All", 'All status updates', $fb_data_tpl, 'Posts');
         $alltabds = new Dataset("all_facebook_posts", 'PostDAO', "getAllPosts",
         array($instance->network_user_id, $instance->network, 15, "#page_number#"),
-        'getAllPostsIterator', array($instance->network_user_id, $instance->network, GridController::MAX_ROWS), false );
+        'getAllPostsIterator', array($instance->network_user_id, $instance->network, GridController::getMaxRows()), false );
         $alltabds->addHelp('userguide/listings/facebook/dashboard_all_facebook_posts');
         $alltab->addDataset($alltabds);
         $menus["all_facebook_posts"] = $alltab;

--- a/webapp/plugins/twitter/model/class.TwitterPlugin.php
+++ b/webapp/plugins/twitter/model/class.TwitterPlugin.php
@@ -146,12 +146,11 @@ class TwitterPlugin implements CrawlerPlugin, DashboardPlugin, PostDetailPlugin 
     public function getDashboardMenuItems($instance) {
         $twitter_data_tpl = Utils::getPluginViewDirectory('twitter').'twitter.inline.view.tpl';
         $menus = array();
-
         //All tab
         $all_mi = new MenuItem("All Tweets", "All tweets", $twitter_data_tpl, "Tweets");
         $all_mi_ds = new Dataset("all_tweets", 'PostDAO', "getAllPosts", array($instance->network_user_id,
         'twitter', 15, "#page_number#"), 'getAllPostsIterator', array($instance->network_user_id, 'twitter', 
-        GridController::MAX_ROWS) );
+        GridController::getMaxRows()) );
         $all_mi_ds->addHelp('userguide/listings/twitter/dashboard_tweets-all');
         $all_mi->addDataset($all_mi_ds);
         $menus['tweets-all'] = $all_mi;
@@ -185,7 +184,7 @@ class TwitterPlugin implements CrawlerPlugin, DashboardPlugin, PostDetailPlugin 
             //All Mentions
             $amtab = new MenuItem("All Mentions", "Any post that mentions you", $twitter_data_tpl, 'Replies');
             $amtabds1 = new Dataset("all_tweets", 'PostDAO', "getAllPosts", array($instance->network_user_id,
-           'twitter', 15), "getAllMentionsIterator", array($instance->network_username, GridController::MAX_ROWS, 
+           'twitter', 15), "getAllMentionsIterator", array($instance->network_username, GridController::getMaxRows(), 
            'twitter'));
             $amtabds2 = new Dataset("all_mentions", 'PostDAO', "getAllMentions",
             array($instance->network_username, 15, $instance->network, '#page_number#'));
@@ -315,7 +314,7 @@ class TwitterPlugin implements CrawlerPlugin, DashboardPlugin, PostDetailPlugin 
         $fvalltab = new MenuItem("All", "All favorites", $twitter_data_tpl, 'Favorites');
         $fvalltabds = new Dataset("all_tweets", 'FavoritePostDAO', "getAllFavoritePosts",
         array($instance->network_user_id, 'twitter', 20, "#page_number#"), 'getAllFavoritePostsIterator',
-        array($instance->network_user_id, 'twitter', GridController::MAX_ROWS) );
+        array($instance->network_user_id, 'twitter', GridController::getMaxRows()) );
         $fvalltabds->addHelp('userguide/listings/twitter/dashboard_ftweets-all');
         $fvalltab->addDataset($fvalltabds);
         $menus["ftweets-all"] = $fvalltab;

--- a/webapp/plugins/twitter/view/twitter.inline.view.tpl
+++ b/webapp/plugins/twitter/view/twitter.inline.view.tpl
@@ -26,16 +26,25 @@
     </p>
   </div>
 {/if}
+{if $is_searchable}
+    {include file="_grid.search.tpl"}
+    <script type="text/javascript" src="{$site_root_path}assets/js/grid_search.js"></script>
+{/if}
+
 {if $all_tweets and ($display eq 'tweets-all' or $display eq 'tweets-questions')}
+<div id="all-posts-div">
   {foreach from=$all_tweets key=tid item=t name=foo}
     {include file="_post.tpl" t=$t}
   {/foreach}
+</div>
 {/if}
 
 {if $all_tweets and $display eq 'ftweets-all'}
+<div id="all-posts-div">
   {foreach from=$all_tweets key=tid item=t name=foo}
     {include file="_post.tpl" t=$t}
   {/foreach}
+</div>
 {/if}
 
 {if $most_replied_to_tweets}
@@ -76,9 +85,11 @@
 {/if} 
 
 {if $all_mentions}
+<div id="all-posts-div">
   {foreach from=$all_mentions key=tid item=t name=foo}
     {include file="_post.otherorphan.tpl" t=$t}
   {/foreach}
+</div>
 {/if}
 
 {if $all_replies}
@@ -157,9 +168,5 @@ or ($display eq 'followers-former' and not $people) or ($display eq 'followers-e
   {/literal}
 </script>
 
-{if $is_searchable}
-    {include file="_grid.search.tpl"}
-    <script type="text/javascript" src="{$site_root_path}assets/js/grid_search.js"></script>
-    
-{/if}
+
 


### PR DESCRIPTION
Updates and test fix...
- Add notice if search limit of 5000 is reached
- Add ability to override search limit
- Load all-tweets search grid inline on page
- Post replies Slickgrid search should work from any post view
- Add sidebar search input box
- Disable grid column re-ordering, causes grid to clear
- Hide word frequency when loading search view from url
- Updated faceboook plugin
- Hide posts on All Mentions and Favorites -> All when loading search
- Hide paging ("Older Posts") when loading search
  
  Closes #814 #714 #709
