### PR TITLE
use the instagram API for instagr.am links now instead of screen-scraping. Issues #846 and #632.

### DIFF
--- a/webapp/plugins/expandurls/tests/TestOfExpandURLsPlugin.php
+++ b/webapp/plugins/expandurls/tests/TestOfExpandURLsPlugin.php
@@ -322,9 +322,9 @@ class TestOfExpandURLsPlugin extends ThinkUpUnitTestCase {
         $this->assertEqual($link->error, '');
 
         $link = $link_dao->getLinkById(42);
-        $this->assertEqual($link->expanded_url, '');
+        $this->assertEqual($link->expanded_url, 'http://instagr.am/41/media/');
 
         $link = $link_dao->getLinkById(41);
-        $this->assertEqual($link->expanded_url, '');
+        $this->assertEqual($link->expanded_url, 'http://instagr.am/40/media/');
     }
 }

--- a/webapp/plugins/twitter/model/class.URLProcessor.php
+++ b/webapp/plugins/twitter/model/class.URLProcessor.php
@@ -58,6 +58,16 @@ class URLProcessor {
             } elseif (substr($u, 0, strlen('http://flic.kr/')) == 'http://flic.kr/') {
                 $is_image = 1;
             } elseif (substr($u, 0, strlen('http://instagr.am/')) == 'http://instagr.am/') {
+                // see: http://instagr.am/developer/embedding/ for reference
+                // the following does a redirect to the actual jpg
+                // make a check for an end slash in the url -- if it is there (likely) then adding a second
+                // slash prior to the 'media' string will break the expanded url
+                if ($u[strlen($u)-1] == '/') {
+                    $eurl = $u . 'media/';
+                } else {
+                    $eurl = $u . '/media/';
+                }
+                $logger->logDebug("expanded instagram URL to: " . $eurl, __METHOD__.','.__LINE__);
                 $is_image = 1;
             }
             if ($link_dao->insert($u, $eurl, $title, $tweet['post_id'], 'twitter', $is_image)) {

--- a/webapp/plugins/twitter/tests/TestOfURLProcessor.php
+++ b/webapp/plugins/twitter/tests/TestOfURLProcessor.php
@@ -112,9 +112,37 @@ class TestOfURLProcessor extends ThinkUpUnitTestCase {
         $this->assertEqual($result->post_id, 103);
         $this->assertEqual($result->network, 'twitter');
         $this->assertTrue($result->is_image);
+        
+        // instagr.am
+        // check first with ending slash in URL (which the URLs 'should' include)
+        $tweet["post_id"] = 104;
+        $tweet['post_text'] = "This is an instagram post http:/instagr.am/blah/ Yay!";
+        URLProcessor::processTweetURLs($this->logger, $tweet);
+        $link_dao = new LinkMySQLDAO();
+        $result = $link_dao->getLinkByUrl('http://instagr.am/blah/');
+        $this->assertIsA($result, "Link");
+        $this->assertEqual($result->url, 'http://instagr.am/blah/');
+        $this->assertEqual($result->expanded_url, 'http://instagr.am/blah/media/');
+        $this->assertEqual($result->title, '');
+        $this->assertEqual($result->post_id, 104);
+        $this->assertEqual($result->network, 'twitter');
+        $this->assertTrue($result->is_image);
+
+        // check w/out ending slash also just in case
+        $tweet["post_id"] = 105;
+        $tweet['post_text'] = "This is an instagram post http:/instagr.am/blah Yay!";
+        URLProcessor::processTweetURLs($this->logger, $tweet);
+        $result = $link_dao->getLinkByUrl('http://instagr.am/blah');
+        $this->assertIsA($result, "Link");
+        $this->assertEqual($result->url, 'http://instagr.am/blah');
+        $this->assertEqual($result->expanded_url, 'http://instagr.am/blah/media/');
+        $this->assertEqual($result->title, '');
+        $this->assertEqual($result->post_id, 105);
+        $this->assertEqual($result->network, 'twitter');
+        $this->assertTrue($result->is_image);
 
         //Flic.kr
-        $tweet["post_id"] = 104;
+        $tweet["post_id"] = 106;
         $tweet['post_text'] = "This is a Flickr post http://flic.kr/blah Yay!";
         URLProcessor::processTweetURLs($this->logger, $tweet);
 
@@ -124,7 +152,7 @@ class TestOfURLProcessor extends ThinkUpUnitTestCase {
         $this->assertEqual($result->url, 'http://flic.kr/blah');
         $this->assertEqual($result->expanded_url, '');
         $this->assertEqual($result->title, '');
-        $this->assertEqual($result->post_id, 104);
+        $this->assertEqual($result->post_id, 106);
         $this->assertEqual($result->network, 'twitter');
         $this->assertTrue($result->is_image);
     }


### PR DESCRIPTION
We can now just append a string to the original instagram link to get the image link-- or more accurately, a link that redirects to the jpg.  So, we can go back to doing the instagram derivation on the fly. 'expandInstagramImageURLs' in ExpandURLsPlugin is only needed to process any older links already in the database.

[I'm still having issues with my testing environment, but I checked this change against the relevant test suites and all should be okay.  Obviously let me know if anything fails.]
