### PR TITLE
Addresses issues #864, #865, and #863.

### DIFF
--- a/webapp/_lib/model/class.MentionMySQLDAO.php
+++ b/webapp/_lib/model/class.MentionMySQLDAO.php
@@ -89,7 +89,9 @@ class MentionMySQLDAO extends PDODAO implements MentionDAO {
         $ps  = $this->execute($q, $vars);
         $res = $this->getUpdateCount($ps);
         if (!$res) {
-            throw new Exception("Error: Could not update mentions_posts.");
+            $this->logger->logDebug("Could not update mentions_posts with $post_id, $mention_id", 
+            __METHOD__.','. __LINE__);
+            // throw new Exception("Error: Could not update mentions_posts.");
         }
     }
 

--- a/webapp/_lib/view/_link.tpl
+++ b/webapp/_lib/view/_link.tpl
@@ -15,7 +15,9 @@
   </div>
   <div class="grid_14">
     {if $l->is_image}
+     {if $l->expanded_url}
       <a href="{$l->url}"><div class="pic"><img src="{$l->expanded_url}" /></div></a>
+     {/if}
     {else}
       {if $l->expanded_url}
       <small>

--- a/webapp/_lib/view/_post.clean.tpl
+++ b/webapp/_lib/view/_post.clean.tpl
@@ -35,7 +35,9 @@
     </div>
     <div class="grid_12 omega">
       {if $t->link->is_image}
-        <div class="pic"><a href="{$t->link->url}"><img src="{$t->link->expanded_url}" /></a></div>
+        {if $t->link->expanded_url}
+         <div class="pic"><a href="{$t->link->url}"><img src="{$t->link->expanded_url}" /></a></div>
+        {/if}
       {/if}
       <div class="post">
         {if $t->post_text}

--- a/webapp/_lib/view/_post.lite.tpl
+++ b/webapp/_lib/view/_post.lite.tpl
@@ -16,7 +16,9 @@
   <div class="individual-tweet post clearfix{if $t->is_protected} private{/if}">
     <div class="grid_14">
       {if $t->link->is_image}
-        <div class="pic"><a href="{$t->link->url}"><img src="{$t->link->expanded_url}" /></a></div>
+        {if $t->link->expanded_url}
+          <div class="pic"><a href="{$t->link->url}"><img src="{$t->link->expanded_url}" /></a></div>
+        {/if}
       {/if}
       
       <div class="post">

--- a/webapp/_lib/view/_post.otherorphan.tpl
+++ b/webapp/_lib/view/_post.otherorphan.tpl
@@ -18,7 +18,9 @@
   </div>
   <div class="grid_12 omega">
       {if $t->link->is_image}
-        <div class="pic"><a href="{$t->link->url}"><img src="{$t->link->expanded_url}" alt=""></a></div>
+        {if $t->link->expanded_url}
+         <div class="pic"><a href="{$t->link->url}"><img src="{$t->link->expanded_url}" /></a></div>
+        {/if}
       {/if}
       
       <div class="post">

--- a/webapp/_lib/view/_post.tpl
+++ b/webapp/_lib/view/_post.tpl
@@ -37,7 +37,9 @@
         </div>
     <div class="grid_9">
       {if $t->link->is_image}
-        <div class="pic"><a href="{$t->link->url}"><img src="{$t->link->expanded_url}" /></a></div>
+        {if $t->link->expanded_url}
+         <div class="pic"><a href="{$t->link->url}"><img src="{$t->link->expanded_url}" /></a></div>
+        {/if}
       {/if}
       <div class="post">
         {if $t->post_text}
@@ -65,12 +67,6 @@
       {/if}
         {if $t->favd_count}
           <small>&nbsp;<a href="{$site_root_path}post/?t={$t->post_id}&n={$t->network}&v=favs">Fav'd: {$t->favd_count}</a></small>
-        {/if}
-        {if $t->link->expanded_url and !$t->link->is_image and ($t->link->expanded_url != $t->link->url)}
-          <br>
-          <small>
-            <a href="{$t->link->expanded_url}" title="{$t->link->expanded_url}">{$t->link->expanded_url}</a>
-          </small>
         {/if}
 
       <span class="small gray">


### PR DESCRIPTION
In templates, check whether expanded_url is set before trying to display it as image src.
Remove extra display of expanded link in _post.tpl.
Don't throw exception on multiple inserts of same record into mentions_posts.
