### PR TITLE
adds 'home timeline' support and view

### DIFF
--- a/tests/TestOfPostMySQLDAO.php
+++ b/tests/TestOfPostMySQLDAO.php
@@ -180,6 +180,19 @@ class TestOfPostMySQLDAO extends ThinkUpUnitTestCase {
             }
             $counter++;
         }
+        
+        // Add some protected posts
+        $counter = 0;
+        while ($counter < 5) {
+            $post_id = $counter + 20000;
+            $pseudo_minute = str_pad(($counter), 2, "0", STR_PAD_LEFT);
+            $builders[] = FixtureBuilder::build('posts', array('post_id'=>$post_id, 'author_user_id'=>123456,
+            'author_username'=>'user_123456', 'author_fullname'=>'User 123456', 'is_geo_encoded'=>0,
+            'old_retweet_count_cache' => 0, 'in_rt_of_user_id' => null, 'is_protected'=>1,
+            'post_text'=>'This is link post '.$counter, 'source'=>'web', 'pub_date'=>'2006-03-01 00:'.
+            $pseudo_minute.':00', 'reply_count_cache'=>0, 'retweet_count_cache'=>0, 'network'=>'twitter'));
+            $counter++;
+        }
 
         //Add replies to specific post
         $builders[] = FixtureBuilder::build('posts', array('post_id'=>131, 'author_user_id'=>20,
@@ -200,7 +213,7 @@ class TestOfPostMySQLDAO extends ThinkUpUnitTestCase {
         'author_username'=>'linkbaiter', 'author_fullname'=>'Link Baiter', 'network'=>'twitter', 
         'post_text'=>'@shutterbug This is a link post reply http://example.com/', 'source'=>'web', 
         'pub_date'=>'2006-03-01 00:00:00', 'reply_count_cache'=>0, 'retweet_count_cache'=>0, 
-        'old_retweet_count_cache' => 0, 'in_rt_of_user_id' => null,
+        'old_retweet_count_cache' => 0, 'in_rt_of_user_id' => null, 'is_protected'=>0,
         'in_reply_to_post_id'=>41, 'location'=>'Mumbai, Maharashtra, India', 'reply_retweet_distance'=>1500, 
         'is_geo_encoded'=>1));
 
@@ -214,14 +227,14 @@ class TestOfPostMySQLDAO extends ThinkUpUnitTestCase {
         'author_username'=>'quoter', 'author_fullname'=>'Quoter of Quotables', 'network'=>'twitter', 
         'post_text'=>'Be liberal in what you accept and conservative in what you send', 'source'=>'web', 
         'pub_date'=>'2006-03-01 00:00:00', 'reply_count_cache'=>0, 'retweet_count_cache'=>0,
-        'old_retweet_count_cache' => 0, 'in_rt_of_user_id' => null,
+        'old_retweet_count_cache' => 0, 'in_rt_of_user_id' => null, 'is_protected'=>0,
         'location'=>'New Delhi, Delhi, India', 'geo'=>'28.635308,77.22496', 'is_geo_encoded'=>1));
         //retweet 1
         $builders[] = FixtureBuilder::build('posts', array('post_id'=>135, 'author_user_id'=>20,
         'author_username'=>'user1', 'author_fullname'=>'User 1', 'network'=>'twitter', 
         'post_text'=>'RT @quoter Be liberal in what you accept and conservative in what you send', 'source'=>'web', 
         'pub_date'=>'2006-03-01 00:00:00', 'reply_count_cache'=>0, 'retweet_count_cache'=>0, 
-        'old_retweet_count_cache' => 0, 'in_rt_of_user_id' => null,
+        'old_retweet_count_cache' => 0, 'in_rt_of_user_id' => null, 'is_protected'=>0,
         'in_retweet_of_post_id'=>134, 'location'=>'Chennai, Tamil Nadu, India', 'geo'=>'13.060416,80.249634', 
         'reply_retweet_distance'=>2000, 'is_geo_encoded'=>1, 'in_reply_to_post_id'=>null));
         //retweet 2
@@ -229,7 +242,7 @@ class TestOfPostMySQLDAO extends ThinkUpUnitTestCase {
         'author_username'=>'user2', 'author_fullname'=>'User 2', 'network'=>'twitter', 
         'post_text'=>'RT @quoter Be liberal in what you accept and conservative in what you send', 
         'source'=>'web', 'pub_date'=>'2006-03-01 00:00:00', 'reply_count_cache'=>0, 'retweet_count_cache'=>0, 
-        'old_retweet_count_cache' => 0, 'in_rt_of_user_id' => null,
+        'old_retweet_count_cache' => 0, 'in_rt_of_user_id' => null, 'is_protected'=>0,
         'in_retweet_of_post_id'=>134, 'location'=>'Dwarka, New Delhi, Delhi, India', 'geo'=>'28.635308,77.22496', 
         'reply_retweet_distance'=>'0', 'is_geo_encoded'=>1));
         //retweet 3
@@ -237,7 +250,7 @@ class TestOfPostMySQLDAO extends ThinkUpUnitTestCase {
         'author_username'=>'linkbaiter', 'author_fullname'=>'Link Baiter', 'network'=>'twitter', 
         'post_text'=>'RT @quoter Be liberal in what you accept and conservative in what you send', 
         'source'=>'web', 'pub_date'=>'2006-03-01 00:00:00', 'reply_count_cache'=>0, 'retweet_count_cache'=>0, 
-        'old_retweet_count_cache' => 0, 'in_rt_of_user_id' => null,
+        'old_retweet_count_cache' => 0, 'in_rt_of_user_id' => null, 'is_protected'=>0,
         'in_retweet_of_post_id'=>134, 'location'=>'Mumbai, Maharashtra, India', 'geo'=>'19.017656,72.856178', 
         'reply_retweet_distance'=>1500, 'is_geo_encoded'=>1));
 
@@ -274,14 +287,14 @@ class TestOfPostMySQLDAO extends ThinkUpUnitTestCase {
         'author_username'=>'user3', 'author_fullname'=>'User 3', 'network'=>'twitter', 
         'post_text'=>'@user4 I\'m replying to another post not in the TT db', 'source'=>'web', 
         'pub_date'=>'2006-03-01 00:00:00', 'reply_count_cache'=>0, 'retweet_count_cache'=>0, 
-        'old_retweet_count_cache' => 0, 'in_rt_of_user_id' => null,
+        'old_retweet_count_cache' => 0, 'in_rt_of_user_id' => null, 'is_protected'=>0,
         'in_reply_to_user_id'=>20, 'in_reply_to_post_id'=>251));
 
         //Add post by instance not on public timeline
         $builders[] = FixtureBuilder::build('posts', array('post_id'=>143, 'author_user_id'=>24,
         'author_username'=>'notonpublictimeline', 'author_fullname'=>'Not on public timeline', 
         'network'=>'twitter', 'post_text'=>'This post should not be on the public timeline', 
-        'old_retweet_count_cache' => 0, 'in_rt_of_user_id' => null,
+        'old_retweet_count_cache' => 0, 'in_rt_of_user_id' => null, 'is_protected'=>0,
         'source'=>'web', 'pub_date'=>'2006-03-01 00:00:00'));
 
         //Add replies to specific post
@@ -1900,7 +1913,7 @@ class TestOfPostMySQLDAO extends ThinkUpUnitTestCase {
     public function testGetPoststoGeoencode() {
         $dao = new PostMySQLDAO();
         $posts = $dao->getPoststoGeoencode();
-        $this->assertEqual(count($posts), 136);
+        $this->assertEqual(count($posts), 141);
         $this->assertIsA($posts, "array");
     }
 
@@ -2179,6 +2192,37 @@ class TestOfPostMySQLDAO extends ThinkUpUnitTestCase {
         $this->assertEqual($mention['user_name'], 'RSAMatthew');
         $this->assertEqual($mention['count_cache'], 1);
         $this->assertEqual($mp[0]['author_user_id'], 140955302);
+    }
+    
+    /**
+     * test of getPostsByFriends method
+     */
+    public function testGetPostsByFriends() {
+        $builders = array();
+        $builders[] = FixtureBuilder::build('follows', array('user_id'=>13, 'follower_id'=>18));
+        $builders[] = FixtureBuilder::build('follows', array('user_id'=>19, 'follower_id'=>18));
+        $dao = new PostMySQLDAO();
+        $res = $dao->getPostsByFriends(18, 'twitter', 10);
+        $this->assertEqual(count($res), 10);
+        $this->assertEqual($res[0]->author_user_id,13);
+        $this->assertEqual($res[1]->author_user_id,19);
+    }
+    
+    /**
+     * test of getPostsByFriends method. Checking that protected posts aren't included when the
+     * 'public' flag is set.
+     */
+    public function testGetPostsByFriends2() {
+        $builders = array();
+        $builders[] = FixtureBuilder::build('follows', array('user_id'=>13, 'follower_id'=>18));
+        $builders[] = FixtureBuilder::build('follows', array('user_id'=>123456, 'follower_id'=>18));
+        $dao = new PostMySQLDAO();
+        $res = $dao->getPostsByFriends(18, 'twitter', 5, 1, false); // not public
+        $this->assertEqual(count($res), 5);
+        $this->assertEqual($res[0]->author_user_id, 123456);
+        $res = $dao->getPostsByFriends(18, 'twitter', 5, 1, true); // public
+        $this->assertEqual(count($res), 5);
+        $this->assertEqual($res[0]->author_user_id,13);
     }
 
     /**

--- a/tests/TestOfWebapp.php
+++ b/tests/TestOfWebapp.php
@@ -83,7 +83,7 @@ class TestOfWebapp extends ThinkUpUnitTestCase {
 
         $menus_array = $webapp->getDashboardMenu($instance);
         $this->assertIsA($menus_array, 'Array');
-        $this->assertEqual(sizeof($menus_array), 18);
+        $this->assertEqual(sizeof($menus_array), 19);
         $this->assertIsA($menus_array['tweets-all'], 'MenuItem');
     }
 

--- a/webapp/_lib/model/class.Config.php
+++ b/webapp/_lib/model/class.Config.php
@@ -147,6 +147,9 @@ class Config {
     public function getGMTOffset($time = 0) {
         $time = $time ? $time : 'now';
         $tz = ($this->getValue('timezone')==null)?date('e'):$this->getValue('timezone');
+        // this may be currently required for some setups to avoid fatal php timezone complaints when
+        // exec'ing off the streaming child processes.
+        // date_default_timezone_set($tz);
         return timezone_offset_get( new DateTimeZone($tz), new DateTime($time) ) / 3600;
     }
 }

--- a/webapp/_lib/model/class.PostMySQLDAO.php
+++ b/webapp/_lib/model/class.PostMySQLDAO.php
@@ -744,6 +744,59 @@ class PostMySQLDAO extends PDODAO implements PostDAO  {
         return $this->getAllPostsByUserID($author_id, $network, $count, $order_by, $direction, $include_replies, 1,
         $iterator = true, $is_public);
     }
+    
+    /**
+     * Iterator wrapper for getPostsByFriends
+     */
+    public function getPostsByFriendsIterator($user_id, $network, $count, $is_public=false) {
+        return $this->getPostsByFriends($user_id, $network, $count, 1, $is_public, true);
+    }
+
+    /**
+     * get the posts from the friends of the given user_id;
+     * that is, their 'timeline' data
+     */
+    public function getPostsByFriends($user_id, $network, $count = 15, $page = 1, $is_public = false, 
+        $iterator = false) {
+
+        $start_on_record = ($page - 1) * $count;
+        if ($is_public) {
+            $protected = 'AND p.is_protected = 0 ';
+        } else {
+            $protected = '';
+        }
+
+        $q  = "SELECT p.*, l.id, l.url, l.expanded_url, l.title, l.clicks, l.is_image, " . 
+        "pub_date + interval #gmt_offset# hour AS adj_pub_date ";
+        $q .= "FROM #prefix#posts AS p ";
+        $q .= "LEFT JOIN #prefix#links AS l ";
+        $q .= "ON p.post_id = l.post_id AND p.network = l.network ";
+        $q .= "WHERE p.network = :network ";
+        $q .= $protected;
+        $q .= " AND p.author_user_id IN ( ";
+        $q .= "   SELECT user_id FROM #prefix#follows AS f ";
+        $q .= "   WHERE f.follower_id=:user_id AND f.active=1 AND f.network=:network ";
+        $q .= ")";
+        $q .= "ORDER BY p.post_id DESC ";
+        $q .= "LIMIT :start_on_record, :limit";
+        $vars = array(
+            ':user_id'=>$user_id,
+            ':network'=>$network,
+            ':limit'=>$count,
+            ':start_on_record'=>(int)$start_on_record
+        );
+        if ($this->profiler_enabled) Profiler::setDAOMethod(__METHOD__);
+        $ps = $this->execute($q, $vars);
+        if ($iterator) {
+            return (new PostIterator($ps));
+        }
+        $all_rows = $this->getDataRowsAsArrays($ps);
+        $posts = array();
+        foreach ($all_rows as $row) {
+            $posts[] = $this->setPostWithLink($row);
+        }
+        return $posts;
+    }
 
     public function getAllQuestionPosts($author_id, $network, $count, $page=1, $order_by = 'pub_date',
     $direction = 'DESC', $is_public = false) {

--- a/webapp/_lib/model/interface.PostDAO.php
+++ b/webapp/_lib/model/interface.PostDAO.php
@@ -208,6 +208,31 @@ interface PostDAO {
      */
     public function getAllPosts($author_id, $network, $count, $page=1, $include_replies=true,
     $order_by = 'pub_date', $direction = 'DESC', $is_public = false);
+    
+    /**
+     * get the posts from the friends of the given user_id; 
+     * that is, their 'timeline' data.
+     * @param int $user_id
+     * @param str  $network
+     * @param int $count
+     * @param int $page
+     * @param bool $is_public
+     * @param bool $iterator
+     * @return array Posts or PostsIterator
+     */
+    public function getPostsByFriends($user_id, $network, $count = 15, $page = 1, $is_public = false, 
+    $iterator = false);
+    
+    /**
+     * Iterator wrapper for getPostsByFriends
+     * @param int $user_id
+     * @param str  $network
+     * @param int $count
+     * @param bool $is_public
+     * @return PostsIterator
+     */
+    public function getPostsByFriendsIterator($user_id, $network, $count, $is_public=false);
+
 
     /**
      * Get all posts by an author given an author ID that contain a question mark

--- a/webapp/plugins/twitter/model/class.TwitterPlugin.php
+++ b/webapp/plugins/twitter/model/class.TwitterPlugin.php
@@ -255,6 +255,14 @@ class TwitterPlugin implements CrawlerPlugin, DashboardPlugin, PostDetailPlugin 
         $poptabds->addHelp('userguide/listings/twitter/dashboard_followers-mostfollowed');
         $poptab->addDataset($poptabds);
         $menus["friends-mostfollowed"] = $poptab;
+        
+        // 'home timeline'
+        $tltab = new MenuItem("Timeline", "Your Home Timeline", $twitter_data_tpl);
+        $tltab2 = new Dataset("home_timeline", 'PostDAO', "getPostsByFriends",
+        array($instance->network_user_id, $instance->network, 20, '#page_number#', !Session::isLoggedIn()),
+        'getPostsByFriendsIterator', array($instance->network_user_id, 'twitter', GridController::getMaxRows()));
+        $tltab->addDataset($tltab2);
+        $menus["home-timeline"] = $tltab;
 
         //Follower count history
         $follower_history_tpl = Utils::getPluginViewDirectory('twitter').'twitter.followercount.tpl';

--- a/webapp/plugins/twitter/tests/TestOfTwitterPlugin.php
+++ b/webapp/plugins/twitter/tests/TestOfTwitterPlugin.php
@@ -62,7 +62,7 @@ class TestOfTwitterPlugin extends ThinkUpUnitTestCase {
 
         $menus = $this->webapp->getDashboardMenu($instance);
 
-        $this->assertEqual(sizeof($menus), 18, "Test number of Twitter Dashboard menu items");
+        $this->assertEqual(sizeof($menus), 19, "Test number of Twitter Dashboard menu items");
         $first_post_menuitem = $menus["tweets-all"];
         $this->assertEqual($first_post_menuitem->name, "All Tweets", "Test name of first post menu item");
         $this->assertEqual($first_post_menuitem->description, "All tweets", "Test description of first post menu item");
@@ -74,12 +74,17 @@ class TestOfTwitterPlugin extends ThinkUpUnitTestCase {
         $this->assertEqual($first_post_menuitem_dataset->dao_method_name, "getAllPosts",
         "Test first post menu item's first dataset fetching method");
 
-        // check favorites menu, which just has one item currently
+        // favorites menu
         $favs_menu = $menus["ftweets-all"];
         $this->assertEqual(sizeof($favs_menu), 1);
         $favs_menuitem_datasets = $favs_menu->getDatasets();
         $favs_menuitem_dataset = $favs_menuitem_datasets[0];
         $this->assertEqual($favs_menuitem_dataset->name, "all_tweets");
+        
+        $links_menuitem = $menus["favd-all"];
+        $links_menuitem_datasets = $links_menuitem->getDatasets();
+        $links_menuitem_dataset = $links_menuitem_datasets[0];
+        $this->assertEqual($links_menuitem_dataset->name, "all_favd");
 
         // check links menu
         $links_menu = $menus["links-friends"];
@@ -96,6 +101,11 @@ class TestOfTwitterPlugin extends ThinkUpUnitTestCase {
         $links_menuitem_datasets = $links_menuitem->getDatasets();
         $links_menuitem_dataset = $links_menuitem_datasets[0];
         $this->assertEqual($links_menuitem_dataset->name, "links");
+        
+        $links_menuitem = $menus["home-timeline"];
+        $links_menuitem_datasets = $links_menuitem->getDatasets();
+        $links_menuitem_dataset = $links_menuitem_datasets[0];
+        $this->assertEqual($links_menuitem_dataset->name, "home_timeline");
 
         //Test post page menu items
         $post = new Post(array('id'=>1, 'author_user_id'=>10, 'author_username'=>'no one', 'author_fullname'=>"No One",

--- a/webapp/plugins/twitter/view/twitter.inline.view.tpl
+++ b/webapp/plugins/twitter/view/twitter.inline.view.tpl
@@ -73,6 +73,7 @@
 
 {if ($display eq 'mentions-all' and not $all_mentions) or 
     ($display eq 'mentions-allreplies' and not $all_replies) or
+    ($display eq 'home-timeline' and not $home_timeline) or
     ($display eq 'mentions-orphan' and not $orphan_replies)}
   <div class="ui-state-highlight ui-corner-all" style="margin: 20px 0px; padding: .5em 0.7em;"> 
     <p>
@@ -93,6 +94,14 @@
 <div id="all-posts-div">
   {foreach from=$all_mentions key=tid item=t name=foo}
     {include file="_post.otherorphan.tpl" t=$t}
+  {/foreach}
+</div>
+{/if}
+
+{if $home_timeline}
+<div id="all-posts-div">
+  {foreach from=$home_timeline key=tid item=t name=foo}
+    {include file="_post.tpl" t=$t}
   {/foreach}
 </div>
 {/if}

--- a/webapp/plugins/twitterrealtime/model/class.ConsumerStreamProcess.php
+++ b/webapp/plugins/twitterrealtime/model/class.ConsumerStreamProcess.php
@@ -71,7 +71,7 @@ class ConsumerStreamProcess {
             $this->json_parser->parseJSON($status);
             $logger->logDebug("retrieved item is: [" . $status . "]", __METHOD__.','.__LINE__);
         } else {
-            $logger->logDebug(" -ran out of list items -- sleeping " . $this->STIME, __METHOD__.','.__LINE__);
+            // $logger->logDebug(" -ran out of list items -- sleeping " . $this->STIME, __METHOD__.','.__LINE__);
             sleep($this->STIME);
         }
     }

--- a/webapp/plugins/twitterrealtime/streaming/stream2.php
+++ b/webapp/plugins/twitterrealtime/streaming/stream2.php
@@ -29,6 +29,7 @@ require_once 'init.php';
 require_once THINKUP_WEBAPP_PATH.'plugins/twitterrealtime/model/class.StreamCollect2.php';
 require_once THINKUP_WEBAPP_PATH.'plugins/twitterrealtime/model/class.ConsumerUserStream.php';
 require_once THINKUP_WEBAPP_PATH.'plugins/twitterrealtime/model/class.StreamMessageQueueMySQL.php';
+require_once THINKUP_WEBAPP_PATH.'plugins/twitterrealtime/model/class.StreamMessageQueueRedis.php';
 
 
 $stream_coll = new StreamCollect2($argc, $argv);


### PR DESCRIPTION
This adds a 'home timeline' view to the UI, showing the most recent collected posts from those people the owner follows.  Am open to changes in what it's labelled and where it lives in the left navbar.

Support for the slickgrid search is included.  However, the default filter for the grid search (in `grid_search.js`), which searches only on the 'text' field, is not quite what we want for this view. It would be much more useful to filter at least on author_username as well as text. But, we don't want to search on the author field for e.g. the 'all tweets' search (since there, the author is just always the owner). I think what we might want to do is create a hidden field when building the page, that the js can use to define the filter used. I'll leave that for a later modification.

I included a few minor streaming plugin tweaks: commented out that noisy log stmt, added a necessary (at least for me) REQUIRE stmt in `stream2.php`.
I also included (commented-out) the timezone function call in class.Config.php that I require to get things to work. Don't feel like you need to pull this in; however it's convenient for me to have it in there so that I don't have to keep looking it up, and might be that someone else has the same issue. [You are probably right that longer-term we should fix @ controller level].
