### PR TITLE
Issue #105: _fixed_ missing facebook status updates by checking for exist

### DIFF
--- a/webapp/plugins/facebook/model/class.FacebookCrawler.php
+++ b/webapp/plugins/facebook/model/class.FacebookCrawler.php
@@ -244,6 +244,12 @@ class FacebookCrawler {
             "pub_date"=>$p->created_time, 
             "in_reply_to_user_id"=>'', "in_reply_to_post_id"=>'', "source"=>'', 'network'=>$network,
             'is_protected'=>$is_protected);
+
+            //sometimes the Facebook object doesn't contain a message field. If blank, try "name"
+            if ($ttp["post_text"] == '') {
+                $ttp["post_text"] = isset($p->name)?$p->name:'';
+            }
+
             array_push($thinkup_posts, $ttp);
             if ( isset($p->comments)) {
                 $comments_captured = 0;


### PR DESCRIPTION
Issue #105: _fixed_ missing facebook status updates by checking for existence of _message_ in the facebook object, then uses _name_ if message is blank

Hi, Gina and Mark:

I was having problem similar to item #105, where some of my links and photos were not showing up in the stream. Turns out that they were in the stream, and WERE being added to the database. However, the facebook post object did not contain a "message" field, so no data was being entered into the database. My "fix" was to check the "message" field and, if it was blank, use the data in the "name" field instead. 

Just to be clear, it doesn't find "missing" links, photos and videos, but it fills in the data in "post_text" so that the "missing" posts reappear. I hope that makes sense :)

Mark
