### PR TITLE
ExpandURLs: Log an error for bad URLs to avoid repeat attempts

### DIFF
--- a/webapp/plugins/expandurls/model/class.ExpandURLsPlugin.php
+++ b/webapp/plugins/expandurls/model/class.ExpandURLsPlugin.php
@@ -168,6 +168,7 @@ class ExpandURLsPlugin implements CrawlerPlugin {
             } else {
                 $total_errors = $total_errors + 1;
                 $logger->logError($l." is not a valid URL; skipping expansion", __METHOD__.','.__LINE__);
+                $link_dao->saveExpansionError($l, "Invalid URL");
             }
         }
         $logger->logUserSuccess($total_expanded." URLs successfully expanded (".$total_errors." errors).",


### PR DESCRIPTION
While looking into [#878](https://github.com/ginatrapani/ThinkUp/issues/878), I found that the ExpandURLs plugin will attempt to expand a bad URL every time it runs, because no error gets logged in the tu_links table. 

Recording the error via the existing mechanism stops the repeated attempts. @schellack will have to verify that this is the sole cause of the error he's seeing in #878.
