### PR TITLE
Issue #905: Fixed padding on status/alert messages in dashboard view.

### DIFF
--- a/webapp/_lib/view/dashboard.tpl
+++ b/webapp/_lib/view/dashboard.tpl
@@ -38,14 +38,14 @@
     </div>
 
     <div class="thinkup-canvas round-all grid_20 alpha omega prepend_20 append_20" style="min-height:340px">
-      <div class="prefix_1">
+      <div class="prefix_1 suffix_1">
 
         {include file="_usermessage.tpl"}
 
         {if $instance}
             <!--begin public user dashboard-->
             {if $user_details}
-            <div class="suffix_1 grid_18 alpha omega">
+            <div class="grid_18 alpha omega">
               <div class="clearfix dashboard-header round-all">
                 <div class="grid_2 alpha">
                   <div class="avatar-container">


### PR DESCRIPTION
After familiarizing myself with 960.gs, I determined the simplest change was to move the `suffix_1` class up to the parent div which gives the parent a 40px right-padding to go along with the 40px left-padding it had via the `prefix_1` class.

A very small change, but it does fix the issue!
