### PR TITLE
Properly handle html entities in DB for post_text

### DIFF
--- a/tests/WebTestOfPostDetailPage.php
+++ b/tests/WebTestOfPostDetailPage.php
@@ -98,4 +98,17 @@ class WebTestOfPostDetailPage extends ThinkUpWebTestCase {
         $this->assertTitle("Post Details | ThinkUp");
         $this->assertText('This is post 10');
     }
+
+    public function testPostPageWithPostHTMLEntities() {
+        //enable GeoEncoder plugin
+        $builder = FixtureBuilder::build('plugins', array('name'=>'Geoencoder', 'folder_name'=>'geoencoder',
+        'is_active'=>1));
+        $config = Config::getInstance();
+        $db_prefix = $config->getValue('table_prefix');
+        $pdo = PostMysqlDAO::$PDO;
+        $pdo->query("update " . $db_prefix . "posts set post_text = concat(post_text, ' &lt; &gt; &amp; < > &')");
+        $this->get($this->url.'/post/index.php?t=10&n=twitter');
+        $this->assertPattern("/This is post 10 &#60; &#62; &#38; &#60; &#62; &#38;/"); // we are all filtered entities
+        $this->assertText('This is post 10 < > & < > &'); // we render properly
+    }
 }

--- a/webapp/_lib/view/_post.qa.tpl
+++ b/webapp/_lib/view/_post.qa.tpl
@@ -5,7 +5,6 @@
     <div class="grid_12">post</div>
   </div>
 {/if}
-
 <div class="individual-tweet post clearfix"{if $smarty.foreach.foo.index % 2 == 1} style="background-color:#EEE"{/if}>
     <div class="grid_2 alpha">
       <div class="avatar-container">
@@ -32,7 +31,7 @@
     <div class="grid_12 omega">
       <div class="post">
         {if $r.question}
-           {$r.question|regex_replace:"/^@[a-zA-Z0-9_]+/":""|link_usernames:$i->network_username:$r.network}
+           {$r.question|filter_xss|regex_replace:"/^@[a-zA-Z0-9_]+/":""|link_usernames:$i->network_username:$r.network}
         {else}
           <span class="no-post-text">No post text</span>
         {/if}
@@ -76,7 +75,7 @@
   <div class="grid_12 omega">
       <div class="post">
         {if $r.answer}
-          {$r.answer|regex_replace:"/^@[a-zA-Z0-9_]+/":""|link_usernames:$i->network_username:$r.network}
+          {$r.answer|filter_xss|regex_replace:"/^@[a-zA-Z0-9_]+/":""|link_usernames:$i->network_username:$r.network}
         {else}
           <span class="no-post-text">No post text</span>
         {/if}

--- a/webapp/_lib/view/plugins/modifier.filter_xss.php
+++ b/webapp/_lib/view/plugins/modifier.filter_xss.php
@@ -43,5 +43,6 @@
  * @return string
  */
 function smarty_modifier_filter_xss($text) {
+    $text = html_entity_decode($text); # because twitter sends html encoded chars that get stuck in the db
     return filter_var($text, FILTER_SANITIZE_SPECIAL_CHARS);
 }

--- a/webapp/plugins/twitter/tests/TestOfTwitterCrawler.php
+++ b/webapp/plugins/twitter/tests/TestOfTwitterCrawler.php
@@ -235,6 +235,22 @@ class TestOfTwitterCrawler extends ThinkUpUnitTestCase {
         $this->assertEqual($post->geo, "");
     }
 
+    public function testFetchInstanceUserTweetsEscapeHTML() {
+        self::setUpInstanceUserAnilDash();
+
+        $tc = new TwitterCrawler($this->instance, $this->api);
+        $tc->fetchInstanceUserInfo();
+        $tc->fetchInstanceUserTweets();
+
+        //Test post with location has location set
+        $pdao = DAOFactory::getDAO('PostDAO');
+        $this->assertTrue($pdao->isPostInDB(15660373190, 'twitter'));
+        $post = $pdao->getPost(15660373190, 'twitter');
+        $this->assertEqual($post->post_text, "@nicknotned NYC isn't a rival, it's just a better evolution of the " .
+        "concept of a locale where innovation happens. > & <");
+
+    }
+
     public function testFetchInstanceUserTweetsUsernameChange() {
         $post_builder = self::setUpInstanceUserAnilDashUsernameChange();
 

--- a/webapp/plugins/twitter/tests/testdata/statuses_user_timeline_anildash.xml-count=100-include_rts=true
+++ b/webapp/plugins/twitter/tests/testdata/statuses_user_timeline_anildash.xml-count=100-include_rts=true
@@ -338,7 +338,7 @@
 <status>
   <created_at>Mon Jun 07 22:28:58 +0000 2010</created_at>
   <id>15660373190</id>
-  <text>@nicknotned NYC isn't a rival, it's just a better evolution of the concept of a locale where innovation happens.</text>
+  <text>@nicknotned NYC isn't a rival, it's just a better evolution of the concept of a locale where innovation happens. &gt; &amp; &lt;</text>
   <source>&lt;a href="http://itunes.apple.com/app/twitter/id333903271?mt=8" rel="nofollow"&gt;Twitter for iPhone&lt;/a&gt;</source>
   <truncated>false</truncated>
   <in_reply_to_status_id>15659719593</in_reply_to_status_id>


### PR DESCRIPTION
- updated _post.qa.tpl to add xss filter
- added test to twitter crawler with html entities
- html_entity_decode before xss filter to make sure we don't double encode
- added testPostPageWithPostHTMLEntities() test to WebTestOfPostDetailPage
  Closes #904
