### PR TITLE
Issue #456: Fixed inactive owner login error message.

### DIFF
--- a/webapp/_lib/controller/class.PasswordResetController.php
+++ b/webapp/_lib/controller/class.PasswordResetController.php
@@ -58,6 +58,7 @@ class PasswordResetController extends ThinkUpController {
                 } else {
                     $owner_dao->activateOwner($user->email);
                     $owner_dao->clearAccountStatus($user->email);
+                    $owner_dao->resetFailedLogins($user->email);
                     $login_controller->addSuccessMessage('You have changed your password.');
                 }
                 return $login_controller->go();


### PR DESCRIPTION
This fixes the behavior of "inactive account" and "bad password" failed login attempts.
## Inactive Account Login
### Previous Behavior

Login attempt of an inactive (new) owner would display the message, `Inactive account. . Reset your password.` (where the `Reset your password` text links to the password reset page).
### New Behavior

Login attempt of an inactive (new) owner now displays the message, `Inactive account. You must activate your account.` (where the `You must activate your account` text links to the _Activate Your Account_ section of the ThinkUp Step-by-Step Installation Guide doc page).
## Too Many Bad Password Login Attempts
### Previous Behavior

On the 1st through 9th login attempt with a bad password the message, `Incorrect password` is displayed. On the 10th bad password login attempt the user account is deactivated and the message `Incorrect password` is displayed.

On the 11th and subsequent login attempts the message, `Inactive account. Account deactivated due to too many failed logins. Reset your password.`

The account remains deactivated until the password reset process is completed; however, even after the reset is completed the failed login count was never being reset, which was a bug.
### New Behavior

On the 1st through 9th login attempt with a bad password the message, `Incorrect password` is displayed. On the 10th bad password login attempt the user account is deactivated and the following message is displayed, `Inactive account. Account deactivated due to too many failed logins. Reset your password.` (where the `Reset your password` text links to the password reset page).

The account remains deactivated until the password reset process is completed. The password reset process now zeros out the owner's failed login attempts as well as reactivating the user. 
