### PR TITLE
A script to ensure all public methods in a class are documented in there 

### DIFF
--- a/docs/source/contribute/developers/writecode/styleguide/php.rst
+++ b/docs/source/contribute/developers/writecode/styleguide/php.rst
@@ -69,3 +69,16 @@ Drupal conventions to take notice of
 Some of these are inherited from PEAR:
 
 * When constructing multi line IFs, the boolean operator should be at the beginning of the line, not the end.
+
+Method and parameter names in interfaces
+----------------------------------------
+
+Methods and there parameters in interfaces must have exactly the same name as in there implementing classes.
+Whitespace must also be the same in both the class and interface.
+
+The interfaceCheck script located at extras/scripts/interfaceCheck will automatically check you have followed this rule.
+
+You can run it from the terminal by typing ./extras/scripts/interfaceCheck from ThinkUp's root directory
+
+It will print any errors to the terminal, no output means everythings fine.
+

--- a/extras/scripts/interfaceCheck
+++ b/extras/scripts/interfaceCheck
@@ -1,0 +1,148 @@
+#!/bin/bash
+ 
+# Navigate to the model directory
+cd `dirname $0`/../../webapp/_lib/model
+
+# Get a list of all the files which are interfaces 
+ls | grep 'interface.' >ListOfInterfaces.txt
+
+# Find out how many interfaces we have (We need to pipe the output of WC to awk as it prints the name of the file also) 
+length=$(wc -l ListOfInterfaces.txt | awk '{print $1}')
+
+# Variable to keep track of how far through the list of interfaces we are
+loop_count=1
+
+# Go through each interface in the list
+while [ $loop_count -le $length ]
+do
+
+# Get the interface to check
+interface_to_check=$(head -1 ListOfInterfaces.txt)
+
+# Open the interface file and get a list of all the methods
+cat $interface_to_check | grep 'public function' > WorkingInterface.txt
+
+# Now open the corresponding class
+
+# Determine if its a plugin or DAO
+echo $interface_to_check | grep -q 'DAO.php'
+
+# If its a DAO ($? returns the value of the last command)
+if [ $? = "0" ]; then
+	class_to_check=$interface_to_check
+	# Remove interface. from the front, and add class.
+	class_to_check=${class_to_check/'interface.'/'class.'}
+	# Remove DAO.php from the end, and add MySQLDAO.php
+	class_to_check=${class_to_check/'DAO'/'MySQLDAO'}
+	
+	# Check there is a class implementing the interface in this directory (currently this script doesn't support implementing classes outside of this directory)
+	# Redirecting the error output stops error messages about missing files being printed to the terminal
+	ls $class_to_check > /dev/null 2>&1
+	
+	# If an implementing class isn't present in this directory
+	if [ $? != "0" ]; then
+		# We skip this interface
+		# Increment the counter
+		loop_count=`expr $loop_count + 1`
+		# Remove this interface from the list
+		sed -i -e "1d" ListOfInterfaces.txt
+		# Delete our working file as it wont be empty
+		rm WorkingInterface.txt
+		continue
+	fi
+	
+	# If an implementing class is present in this directory
+	# Get all the methods from the implementing class
+	cat $class_to_check | grep 'public function' > WorkingClass.txt
+
+# If its a plugin	
+else
+	class_to_check=$interface_to_check
+	#Remove interface. from the front and add class.
+	class_to_check=${class_to_check/'interface.'/'class.'}
+	#Remove Plugin from the end
+	class_to_check=${class_to_check/'Plugin'/}
+	
+	# Redirecting the error output stops error messages about missing files being printed to the terminal
+	ls $class_to_check > /dev/null 2>&1
+	
+	# If an implementing class isn't present in this directory
+	if [ $? != "0" ]; then
+		# We skip this interface
+		# Increment the counter
+		loop_count=`expr $loop_count + 1`
+		# Remove this interface from the list
+		sed -i -e "1d" ListOfInterfaces.txt
+		# Delete our working file as it wont be empty
+		rm WorkingInterface.txt
+		continue
+	fi
+	
+	# If an implementing class is present in this directory
+	# Get all the methods from the implementing class
+	cat $class_to_check | grep 'public function' > WorkingClass.txt
+fi
+
+# Now we have all the methods we need to check every public method in the class is in the interface
+# If a method isn't in the interface print out an error message
+
+#Get the number of lines in the class We need to pipe the output of WC to awk as it prints the name of the file also) 
+class_length=$(wc -l WorkingClass.txt | awk '{print $1}')
+
+# Variable to keep track of how far through the class we are
+counter=0
+
+#For each method in the class
+while [ $class_length -ne $counter ]
+do
+	# Get the first method we want to look for
+	method_to_check=$(head -1 WorkingClass.txt)
+	# Stip the { from the end (interfaces dont have the { so our search for it will fail if we dont remove it)
+	method_to_check=${method_to_check/'{'/''}
+	# Remove leading whitespace characters (otherwise grep will try to match the whitespace which wont be present in the interface)
+	method_to_check="${method_to_check#"${method_to_check%%[![:space:]]*}"}"   
+	# Remove trailing whitespace characters (otherwise grep will try to match the whitespace which wont be present in the interface)
+	method_to_check="${method_to_check%"${method_to_check##*[![:space:]]}"}"   
+
+	# Methods which are excluded from being checked
+	echo $method_to_check | grep -q -E '(__construct)|(registerCrawlerPlugin)|(registerStreamerPlugin)'
+	 
+	# If the method is one of the exclusions
+	if [ $? = "0" ]; then
+		# Increment the counter 
+		counter=`expr $counter + 1`
+		continue 
+	fi
+	
+	# Search for the method in the interface
+	grep -q "$method_to_check" WorkingInterface.txt
+	
+	# If it is in the interface
+	if [ $? = "0" ]; then
+		# Remove the top line of working class
+		sed -i -e "1d" WorkingClass.txt
+
+	# If it isn't in the interface
+	else
+		# Print an error message
+		echo $method_to_check ' is present in ' $class_to_check ' but not present or spelt differently in ' $interface_to_check
+		# Remove the top line of the working class
+		sed -i -e "1d" WorkingClass.txt
+	fi
+
+	# Increment the counter 
+	counter=`expr $counter + 1`
+done
+
+# Now were dont checking that class and interface pair we need to move onto the next one
+# Increment the loop_count
+loop_count=`expr $loop_count + 1`
+# Remove the interface we just checked from the list of interfaces
+sed -i -e "1d" ListOfInterfaces.txt
+
+done
+
+# Clean up
+rm WorkingClass.txt
+rm ListOfInterfaces.txt
+rm WorkingInterface.txt

--- a/webapp/_lib/model/class.InviteMySQLDAO.php
+++ b/webapp/_lib/model/class.InviteMySQLDAO.php
@@ -62,7 +62,7 @@ class InviteMySQLDAO extends PDODAO implements InviteDAO {
         return $this->getDataIsReturned($ps);
     }
 
-    public function isInviteValid( $invite_code) {
+    public function isInviteValid($invite_code) {
         if ($this->doesInviteExist($invite_code)) {
             $q = " SELECT created_time FROM #prefix#invites WHERE invite_code=:invite_code";
             $vars = array(

--- a/webapp/_lib/model/interface.FavoritePostDAO.php
+++ b/webapp/_lib/model/interface.FavoritePostDAO.php
@@ -48,7 +48,7 @@ interface FavoritePostDAO extends PostDAO {
      * @param str $network
      * @return int
      */
-    public function unFavorite($tid, $uid, $network="twitter");
+    public function unFavorite($tid, $uid, $network = 'twitter');
     /**
      * Wrapper function for getAllFavoritePostsByUserID. Supports pagination.
      * @param int $owner_id
@@ -84,7 +84,7 @@ interface FavoritePostDAO extends PostDAO {
      * @param int $count
      * @return PostIterator
      */
-    public function getAllFavoritePostsByUsernameIterator($username, $network, $count=0);
+    public function getAllFavoritePostsByUsernameIterator($username, $network, $count = 0);
     /**
      * Iterator wrapper for getAllFavoritePostsByUserID
      * @param int $user_id

--- a/webapp/_lib/model/interface.FollowDAO.php
+++ b/webapp/_lib/model/interface.FollowDAO.php
@@ -236,9 +236,9 @@ interface FollowDAO {
 
     /**
      * Gets the friends that do not follow you back.
-     * @param int $uid
+     * @param int $user_id
      * @param str $network
      * @return array - numbered keys, with arrays - named keys
      */
-    public function getFriendsNotFollowingBack($uid, $network);
+    public function getFriendsNotFollowingBack($user_id, $network);
 }

--- a/webapp/_lib/model/interface.FollowerCountDAO.php
+++ b/webapp/_lib/model/interface.FollowerCountDAO.php
@@ -43,9 +43,9 @@ interface FollowerCountDAO  {
      * Get follower count history for a user
      * @param int $network_user_id
      * @param str $network
-     * @param str $group_by 'DAY', 'WEEK', 'MONTH'
+     * @param str $units 'DAY', 'WEEK', 'MONTH'
      * @param int $limit Defaults to 10
      * @return array $history, $percentages
      */
-    public function getHistory($network_user_id, $network, $group_by, $limit=10);
+    public function getHistory($network_user_id, $network, $units, $limit=10);
 }

--- a/webapp/_lib/model/interface.HashtagDAO.php
+++ b/webapp/_lib/model/interface.HashtagDAO.php
@@ -51,15 +51,15 @@ interface HashtagDAO {
     public function getHashtagInfoForTag($hashtag, $network = 'twitter');
     /**
      * Get the hashtag(s) which appear in a given post.
-     * @param int $post_id
+     * @param int $pid
      * @param str $network
      * @return array hashtag_posts table array
      */
-    public function getHashtagsForPost($post_id, $network = 'twitter');
+    public function getHashtagsForPost($pid, $network = 'twitter');
     /**
      * Get an array of post IDs where a hashtag appears by hashtag ID.
-     * @param int $hashtag_id Hashtag ID
+     * @param int $hid Hashtag ID
      * @return array hashtag_posts table array
      */
-    public function getHashtagsForPostHID($hashtag_id);
+    public function getHashtagsForPostHID($hid);
 }

--- a/webapp/_lib/model/interface.InstallerDAO.php
+++ b/webapp/_lib/model/interface.InstallerDAO.php
@@ -88,9 +88,9 @@ interface InstallerDAO {
     /**
      * Run a sql migration command
      *
-     * @param str $sql SQL command to execute
+     * @param str $insql SQL command to execute
      */
-    public function runMigrationSQL($sql);
+    public function runMigrationSQL($insql);
 
     /**
      * Diff the current database table structure with desired table structure.
@@ -101,7 +101,7 @@ interface InstallerDAO {
      * @param array $existing_tables
      * @return array Array of 'queries', and 'for_update', what SQL will update the current structure to desired state
      */
-    public function diffDataStructure($queries = '', $tables = array());
+    public function diffDataStructure($desired_structure_sql_string = '', $existing_tables = array());
 
     /**
      * Temporary method to determine if database is 64-bit post ID ready

--- a/webapp/_lib/model/interface.InstanceDAO.php
+++ b/webapp/_lib/model/interface.InstanceDAO.php
@@ -41,7 +41,7 @@ interface InstanceDAO {
      * @param str $network name of network to limit to
      * @return array with Instance
      */
-    public function getAllActiveInstancesStalestFirstByNetwork( $network = "twitter" );
+    public function getAllActiveInstancesStalestFirstByNetwork($network = "twitter");
 
     /**
      * Get all active instances, by last run oldest first
@@ -195,7 +195,7 @@ interface InstanceDAO {
      * @param int $viewer_id
      * @param str $network Defaults to 'facebook'
      */
-    public function getByUserAndViewerId($network_user_id, $viewer_id, $network = "facebook");
+    public function getByUserAndViewerId($network_user_id, $viewer_id, $network = 'facebook');
 
     /**
      * Get instance by viewer ID on a network
@@ -203,7 +203,7 @@ interface InstanceDAO {
      * @param str $network
      * @return Instance
      */
-    public function getByViewerId($viewer_id, $network = "facebook");
+    public function getByViewerId($viewer_id, $network = 'facebook');
 
     /**
      * Get the number of hours since the freshest instance was updated
@@ -214,8 +214,8 @@ interface InstanceDAO {
     /**
      * Update network username
      * @param int instance ID
-     * @param str new username
+     * @param str new network_username
      * @return int Count of updated instances
      */
-    public function updateUsername($id, $username);
+    public function updateUsername($id, $network_username);
 }

--- a/webapp/_lib/model/interface.LinkDAO.php
+++ b/webapp/_lib/model/interface.LinkDAO.php
@@ -100,7 +100,7 @@ interface LinkDAO {
      * @param str $url
      * @return array with numbered keys, with strings
      */
-    public function getLinksToExpandByURL($prefix);
+    public function getLinksToExpandByURL($url);
     /**
      * Gets a link with a given ID
      * @param int $id

--- a/webapp/_lib/model/interface.MutexDAO.php
+++ b/webapp/_lib/model/interface.MutexDAO.php
@@ -34,7 +34,7 @@ interface MutexDAO {
      * @param string $name
      * @return boolean True if the mutex was obtained, false if another thread was already holding this mutex.
      */
-    public function getMutex($name);
+    public function getMutex($name, $timeout=1);
 
     /**
      * Release a named mutex.

--- a/webapp/_lib/model/interface.OptionDAO.php
+++ b/webapp/_lib/model/interface.OptionDAO.php
@@ -113,4 +113,34 @@ interface OptionDAO {
      * @return bool Whether or not an options table exists
      */
     public function isOptionsTable();
+    
+    /**
+     * Does ? (Updates a option, maybe)
+     * @param $namespace
+     * @param $name
+     * @param $value 
+     * @return int Update Count
+     */
+    public function updateOptionByName($namespace, $name, $value);
+    
+    /**
+     * Gets option data from session using namespace as a key
+     * @param $namespace
+     * @retrun $array Hash of option data
+     */
+    public function getSessionData($namespace);
+    
+    /**
+     * Sets option data in the session using namespace as a key
+     * @param $namespace
+     * @param array Hash of option data
+     * @retun $array Hash of option data
+     */
+    public function setSessionData($namespace, $data);
+    
+    /**
+     * Clears session data by namespace
+     * @param $namespace
+     */
+    public function clearSessionData($namespace);
 }

--- a/webapp/_lib/model/interface.OwnerDAO.php
+++ b/webapp/_lib/model/interface.OwnerDAO.php
@@ -79,19 +79,19 @@ interface OwnerDAO {
     /**
      * Set hashed, owner password in the data store.
      * @param str $email
-     * @param str $password
+     * @param str $pwd
      * @return int Affected rows
      */
-    public function updatePassword($email, $password);
+    public function updatePassword($email, $pwd);
 
     /**
      * Insert owner
      * @param str $email
-     * @param str $password
+     * @param str $pass
      * @param str $full_name
      * @return mixed Activation code int if successful, false if not
      */
-    public function create($email, $password, $full_name);
+    public function create($email, $pass, $full_name);
 
     /**
      * Update last_login field for given owner
@@ -126,11 +126,11 @@ interface OwnerDAO {
      * Insert an activated admin owner
      *
      * @param str $email
-     * @param str $password
+     * @param str $pass
      * @param str $full_name
      * @return mixed Activation code int if successful, false if not
      */
-    public function createAdmin($email, $password, $full_name);
+    public function createAdmin($email, $pass, $full_name);
 
     /**
      * Promote an owner to admin status.
@@ -187,10 +187,10 @@ interface OwnerDAO {
     /**
      * Generates and sets a new API key.
      *
-     * @param str $owner_id
+     * @param str $id
      * @return str A new API Key
      */
-    public function resetAPIKey($owner_id);
+    public function resetAPIKey($id);
 
     /**
      * Checks if the email/password credentials are authorized.

--- a/webapp/_lib/model/interface.PluginDAO.php
+++ b/webapp/_lib/model/interface.PluginDAO.php
@@ -36,7 +36,7 @@ interface PluginDAO {
      * @param bool Only get active plugins
      * @return array A list of Plugin objects
      */
-    public function getAllPlugins($isactive = false);
+    public function getAllPlugins($is_active = false);
 
     /**
      * Get all active plugins
@@ -86,7 +86,7 @@ interface PluginDAO {
      * @param bool Active flag, 1 if activating, 0 if deactivating
      * @return int number of updated rows
      */
-    public function setActive($plugin_id, $is_active);
+    public function setActive($id, $active);
 
     /**
      * Detect what plugins exist in the filesystem; parse their header comments for plugin metadata

--- a/webapp/_lib/model/interface.PluginOptionDAO.php
+++ b/webapp/_lib/model/interface.PluginOptionDAO.php
@@ -61,7 +61,7 @@ interface PluginOptionDAO {
      * @param int A plugin option id
      * @return bool If successful or not
      */
-    public function deleteOption($option_id);
+    public function deleteOption($id);
 
     /**
      * Get a hash of Option objects keyed on option name

--- a/webapp/_lib/model/interface.PostDAO.php
+++ b/webapp/_lib/model/interface.PostDAO.php
@@ -35,7 +35,7 @@ interface PostDAO {
      * @param str $network
      * @return Post Post with optional link member object set, null if post doesn't exist
      */
-    public function getPost($post_id, $network);
+    public function getPost($post_id, $network, $is_public = false);
 
     /**
      * Get replies to a post
@@ -80,7 +80,7 @@ interface PostDAO {
      * start at 1, not 0.
      * @return array Retweets of post with optional link object set
      */
-    public function getRetweetsOfPost($post_id, $network = 'twitter', $order_by = 'default', $unit = 'km',
+    public function getRetweetsOfPost($post_id, $network='twitter', $order_by = 'default', $unit = 'km',
     $is_public = false, $count = null, $page = 1);
 
     /**
@@ -93,7 +93,7 @@ interface PostDAO {
      * @param bool $include_original_post Whether or not to include the post you're querying. Defaults to true.
      * @return array Array of replies, retweets, and original post
      */
-    public function getRelatedPostsArray($post_id, $network = 'twitter', $is_public = false, $count = 350, $page =1,
+    public function getRelatedPostsArray($post_id, $network='twitter', $is_public = false, $count = 350, $page = 1,
     $geo_encoded_only = true, $include_original_post = true);
 
     /**
@@ -106,7 +106,7 @@ interface PostDAO {
      * @param bool $include_original_post Whether or not to include the post you're querying. Defaults to true.
      * @return array Array of post objects
      */
-    public function getRelatedPosts($post_id, $network = 'twitter', $is_public = false, $count = 350, $page = 1,
+    public function getRelatedPosts($post_id, $network='twitter', $is_public = false, $count = 350, $page = 1,
     $geo_encoded_only = true, $include_original_post = true);
 
     /**
@@ -127,7 +127,7 @@ interface PostDAO {
      * @param str $network Defaults to 'twitter'
      * @return array Back and forth posts
      */
-    public function getExchangesBetweenUsers($author_id, $other_user_id, $network = 'twitter');
+    public function getExchangesBetweenUsers($author_id, $other_user_id, $network='twitter');
 
     /**
      * Check to see if Post is in database
@@ -295,7 +295,7 @@ interface PostDAO {
      * @param str $network
      * @return Iterator PostIterator by author (no link set)
      */
-    public function getAllPostsByUsernameIterator($username, $network);
+    public function getAllPostsByUsernameIterator($username, $network, $count = 0);
 
     /**
      * Get count of posts by author username
@@ -392,7 +392,7 @@ interface PostDAO {
      * @param str $network Default 'twitter'
      * @return array Post objects with author set
      */
-    public function getOrphanReplies($username, $count, $network = 'twitter', $page = 1);
+    public function getOrphanReplies($username, $count, $network = "twitter", $page = 1); 
 
     /**
      * Get stray replied-to posts--posts that are listed in the in_repy_to_post_id field, but aren't in the posts table
@@ -410,7 +410,7 @@ interface PostDAO {
      * @return array $row['id'],$row['location'],$row['geo'],$row['post']
      * @return array $row['in_reply_to_post_id'],$row['in_retweet_of_post_id']
      */
-    public function getPostsToGeoencode($limit = 500);
+    public function getPostsToGeoencode($limit = 5000);
 
     /**
      * Set geo-location data for post
@@ -422,7 +422,7 @@ interface PostDAO {
      * @param int $distance
      * @return bool True if geo-location data for post added successfully
      */
-    public function setGeoencodedPost($post_id, $is_geo_encoded = 0, $location = NULL, $geodata = NULL, $distance = 0);
+    public function setGeoencodedPost($post_id, $is_geo_encoded = 0, $location = null, $geodata = null, $distance = 0);
 
     /**
      * Get specified number of most-replied-to posts by a username on a network
@@ -464,4 +464,11 @@ interface PostDAO {
      * @return int Count of posts updated
      */
     public function updateAuthorUsername($author_user_id, $network, $author_username);
+    
+    /**
+     * Sanitizes an order_by argument to avoid SQL injection and ensure that the table you're ordering by is valid.
+     * @param string $order_by Column to order on.
+     * @return string Sanitized column name. If the column was invalid, "pub_date" is returned.
+     */
+    public function sanitizeOrderBy($order_by);
 }

--- a/webapp/_lib/model/interface.PostErrorDAO.php
+++ b/webapp/_lib/model/interface.PostErrorDAO.php
@@ -40,7 +40,7 @@ interface PostErrorDAO {
      * @param int $post_id ID of the post that got the error
      * @param int $error_code The HTTP error code (such as 404 not found or 403 not authorized)
      * @param string $error_text Description of the error
-     * @param int $issued_to ID of the authorized user who got the error.
+     * @param int $issued_to_user_id ID of the authorized user who got the error.
      */
-    public function insertError($post_id, $network, $error_code, $error_text, $issued_to);
+    public function insertError($post_id, $network, $error_code, $error_text, $issued_to_user_id);
 }


### PR DESCRIPTION
Hi,

I have created a script that compares the public methods in a class in the webapp/_lib/model to there interface to ensure that the developer has remembered to document the methods in the interface.

I have also edited some methods in the interfaces to ensure that they are identical to there implementing class, as we discussed on the mailing list.

I have also added some methods which were missing from some of the interfaces.

Finally I have edited the code style guide to add a rule saying that methods and parameters in the interfaces must match the ones in the implementing class, as we discussed in the mailing list. And added a few lines about how to use the script.

The script has 1 main limitation, which is that it only compares classes and interfaces in the model directory. This means that currently it excludes the following interfaces from the check:

interface.ThinkUpPlugin.php
interface.DashboardPlugin.php
interface.PostDetailPlugin.php

This is due to me not wanting to have to traverse every directory looking for implementing classes.

Thanks

Aaron
