### PR TITLE
Fix Facebook library link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ except for the  external libraries listed below.
 
 ## EXTERNAL LIBRARIES
 
-- [Facebook Platform PHP5 client](http://wiki.developers.facebook.com/index.php/PHP) (Included) 
+- [Facebook Platform PHP5 SDK](https://github.com/facebook/php-sdk) (Included) 
 - [SimpleTest](http://www.simpletest.org/) (Included)
 - [Smarty](http://smarty.net) (Included)
 - [Twitter OAuth by Abraham Williams](http://github.com/abraham/twitteroauth) (Included)


### PR DESCRIPTION
The old developer wiki at Facebook seems to not exist anymore.

I changed the link to point to the GitHub project that I believe resembles the same library. I am not 100% sure, though, so please make sure that is true.
