### PR TITLE
Add size attribute for plugin text fields

### DIFF
--- a/webapp/_lib/controller/class.PluginConfigurationController.php
+++ b/webapp/_lib/controller/class.PluginConfigurationController.php
@@ -258,6 +258,9 @@ abstract class PluginConfigurationController extends ThinkUpAuthController {
             if (isset($args['value'])) {
                 $element['value'] = $args['value'];
             }
+            if (isset($args['size'])) {
+                $element['size'] = $args['size'];
+            }
             if (isset($args['advanced'])) {
                 $element['advanced'] = true;
                 // advanced options should not be required

--- a/webapp/_lib/view/_plugin.options.tpl
+++ b/webapp/_lib/view/_plugin.options.tpl
@@ -97,11 +97,10 @@ function show_advanced() {
 {if $option_obj.advanced}class="advanced-option-input"{/if}>
 
     {if $option_obj.type eq 'text_element'}
-
         <input type="text" 
         value="{if isset($option_obj.value)}{$option_obj.value|filter_xss}{/if}"
-            name="plugin_options_{$option_obj.name}" id="plugin_options_{$option_obj.name}" 
-            {if ! $user_is_admin} disabled="true"{/if} />
+            name="plugin_options_{$option_obj.name}" id="plugin_options_{$option_obj.name}"
+            {if isset($option_obj.size)}size="{$option_obj.size}" {/if}{if ! $user_is_admin} disabled="true"{/if} />
     {/if}
     {if $option_obj.type eq 'radio_element'}
     

--- a/webapp/plugins/facebook/controller/class.FacebookPluginConfigurationController.php
+++ b/webapp/plugins/facebook/controller/class.FacebookPluginConfigurationController.php
@@ -53,21 +53,21 @@ class FacebookPluginConfigurationController extends PluginConfigurationControlle
 
         // Application ID text field
         $this->addPluginOption(self::FORM_TEXT_ELEMENT, array('name'=>'facebook_app_id',
-        'label'=>'Application ID')); // add element
+        'label'=>'Application ID', 'size' => 18)); // add element
         // set a special required message
         $this->addPluginOptionRequiredMessage('facebook_app_id',
         'The Facebook plugin requires a valid Application ID.');
 
         // API Key text field
         $this->addPluginOption(self::FORM_TEXT_ELEMENT, array('name'=>'facebook_api_key',
-        'label'=>'API Key')); // add element
+        'label'=>'API Key', 'size' => 18)); // add element
         // set a special required message
         $this->addPluginOptionRequiredMessage('facebook_api_key',
         'The Facebook plugin requires a valid API Key.');
 
         // Application Secret text field
         $this->addPluginOption(self::FORM_TEXT_ELEMENT, array('name'=>'facebook_api_secret',
-        'label'=>'Application Secret')); // add element
+        'label'=>'Application Secret', 'size' => 37)); // add element
         // set a special required message
         $this->addPluginOptionRequiredMessage('facebook_api_secret',
         'The Facebook plugin requires a valid Application Secret.');

--- a/webapp/plugins/geoencoder/controller/class.GeoEncoderPluginConfigurationController.php
+++ b/webapp/plugins/geoencoder/controller/class.GeoEncoderPluginConfigurationController.php
@@ -39,7 +39,7 @@ class GeoEncoderPluginConfigurationController extends PluginConfigurationControl
 
         /** set option fields **/
         // gmaps_api_key text field
-        $name_field = array('name' => 'gmaps_api_key', 'label' => 'Google Maps API Key');
+        $name_field = array('name' => 'gmaps_api_key', 'label' => 'Google Maps API Key', 'size' => 55);
         $this->addPluginOption(self::FORM_TEXT_ELEMENT, $name_field);
         $this->addPluginOptionRequiredMessage('gmaps_api_key',
             'Please enter your Google Maps API Key');

--- a/webapp/plugins/hellothinkup/controller/class.HelloThinkUpPluginConfigurationController.php
+++ b/webapp/plugins/hellothinkup/controller/class.HelloThinkUpPluginConfigurationController.php
@@ -39,7 +39,7 @@ class HelloThinkUpPluginConfigurationController extends PluginConfigurationContr
 
         /** set option fields **/
         // name text field
-        $name_field = array('name' => 'testname', 'label' => 'Your Name'); // set an element name and label
+        $name_field = array('name' => 'testname', 'label' => 'Your Name', 'size' => 40); // set an element name and label
         $name_field['default_value'] = 'ThinkUp User'; // set default value
         $this->addPluginOption(self::FORM_TEXT_ELEMENT, $name_field); // add element
         // set testname header

--- a/webapp/plugins/hellothinkup/tests/TestOfHelloThinkUpPluginConfigurationController.php
+++ b/webapp/plugins/hellothinkup/tests/TestOfHelloThinkUpPluginConfigurationController.php
@@ -78,6 +78,19 @@ class TestOfHelloThinkUpPluginConfigurationController extends ThinkUpUnitTestCas
 
     }
 
+    public function testTextInputSize() {
+        //not logged in, no owner set
+        $controller = new HelloThinkUpPluginConfigurationController(null, 'hellothinkup');
+        $builder = FixtureBuilder::build('owners', array('email' => 'me@example.com', 'user_activated' => 1) );
+
+        $this->simulateLogin('me@example.com');
+        $owner_dao = DAOFactory::getDAO('OwnerDAO');
+        $owner = $owner_dao->getByEmail(Session::getLoggedInUser());
+        $controller = new HelloThinkUpPluginConfigurationController($owner, 'hellothinkup');
+        $output = $controller->go();
+        $this->assertEqual($controller->option_elements['testname']['size'], 40);
+    }
+
     public function testOptionList2HashByOptionName() {
         $build_data = $this->buildController();
         $controller = $build_data[0];

--- a/webapp/plugins/twitter/controller/class.TwitterPluginConfigurationController.php
+++ b/webapp/plugins/twitter/controller/class.TwitterPluginConfigurationController.php
@@ -134,10 +134,10 @@ class TwitterPluginConfigurationController extends PluginConfigurationController
      * Set plugin option fields for admin/plugin form
      */
     private function addOptionForm() {
-        $oauth_consumer_key = array('name' => 'oauth_consumer_key', 'label' => 'Consumer key');
+        $oauth_consumer_key = array('name' => 'oauth_consumer_key', 'label' => 'Consumer key', 'size' => 27);
         $this->addPluginOption(self::FORM_TEXT_ELEMENT, $oauth_consumer_key);
 
-        $oauth_consumer_secret = array('name' => 'oauth_consumer_secret', 'label' => 'Consumer secret');
+        $oauth_consumer_secret = array('name' => 'oauth_consumer_secret', 'label' => 'Consumer secret', 'size' => 47);
         $this->addPluginOption(self::FORM_TEXT_ELEMENT, $oauth_consumer_secret);
         $archive_limit_label = 'Pagination Limit <span style="font-size: 10px;">' .
         '[<a href="http://dev.twitter.com/pages/every_developer" title="Twitter still maintains a database '.


### PR DESCRIPTION
- add size option to addPluginOption() for text elements
- update hello plugin text for new size elemt
- update twitter plugin controller to expand oauth_consumer_key and oauth_consumer_secret inputs
- update facebook plugin controller to resize Application ID, API Key and Application Secret inputs
- Note: we'll need update google+ client secret once we merge that code in
  Closes #986 #987
