### PR TITLE
Avatar on user detail page links to twitter profile

### DIFF
--- a/webapp/_lib/view/user.index.tpl
+++ b/webapp/_lib/view/user.index.tpl
@@ -28,7 +28,7 @@
         <div class="clearfix">
           <div class="grid_2 alpha">
             <div class="avatar-container">
-              <img src="{$profile->avatar}" class="avatar2"/><img src="{$site_root_path}plugins/{$profile->network|get_plugin_path}/assets/img/favicon.ico" class="service-icon2"/>
+              <a href="http://twitter.com/{$profile->username}" title="{$profile->username}"><img src="{$profile->avatar}" class="avatar2"/><img src="{$site_root_path}plugins/{$profile->network|get_plugin_path}/assets/img/favicon.ico" class="service-icon2"/></a>
             </div>
           </div>
           <div class="grid_12">


### PR DESCRIPTION
I just wanted to use a few user detail pages that I opened to quickly check up on their current tweets and discovered, that the avatar image used on this page doesn't link to the relevant profile.
Now it should link to the profile.
Hope my first commit isn't a complete disaster ;)
