### PR TITLE
Only query for pwd_salt in getSaltByEmail

### DIFF
--- a/webapp/_lib/model/class.OwnerMySQLDAO.php
+++ b/webapp/_lib/model/class.OwnerMySQLDAO.php
@@ -337,7 +337,7 @@ SQL;
      * @return str Salt
      */
     private function getSaltByEmail($email){
-        $q = "SELECT * ";
+        $q = "SELECT pwd_salt ";
         $q .= "FROM #prefix#owners u ";
         $q .= "WHERE u.email = :email";
         $vars = array(':email'=>$email);


### PR DESCRIPTION
No other fields from the result set are used by the function.
