### PR TITLE
Use plain text for cli crawler errors

### DIFF
--- a/webapp/_lib/controller/class.CrawlerAuthController.php
+++ b/webapp/_lib/controller/class.CrawlerAuthController.php
@@ -57,6 +57,7 @@ class CrawlerAuthController extends ThinkUpController {
         $authorized = false;
 
         if (isset($this->argc) && $this->argc > 1) { // check for CLI credentials
+            $this->content_type = 'text/plain';
             $session = new Session();
             $username = $this->argv[1];
             if ($this->argc > 2) {


### PR DESCRIPTION
Set content_type to text/plain when the crawler is run from the command
line so the text template is used when an error occurs.
