### PR TITLE
Create log files that don't exist.  Don't error out.

### DIFF
--- a/tests/classes/class.ThinkUpBasicUnitTestCase.php
+++ b/tests/classes/class.ThinkUpBasicUnitTestCase.php
@@ -146,6 +146,11 @@ class ThinkUpBasicUnitTestCase extends UnitTestCase {
         }
     }
 
+    static private function isLogWritable($path) {
+        return (is_file($path) && is_writable($path)) ||
+          (is_dir(dirname($path)) && is_writable(dirname($path)));
+    }
+
     /**
      * Preemptively halt test run if testing environment requirement isn't met.
      * Prevents unnecessary/inexplicable failures and data loss.
@@ -167,20 +172,20 @@ class ThinkUpBasicUnitTestCase extends UnitTestCase {
         if ($THINKUP_CFG['log_location'] === false) {
             $message = "In order to test your ThinkUp installation, \$THINKUP_CFG['log_location'] must be set to a ".
             "writable file.";
-        } else if (!is_writable($THINKUP_CFG['log_location'])) {
+        } else if (!self::isLogWritable($THINKUP_CFG['log_location'])) {
             $message = "In order to test your ThinkUp installation with your current settings, ".
             $THINKUP_CFG['log_location']. " must be a writable file.";
-        } else if (filesize($THINKUP_CFG['log_location']) > 10485760) {
+        } else if (file_exists($THINKUP_CFG['log_location']) && filesize($THINKUP_CFG['log_location']) > 10485760) {
             $message = "Your crawler log file is so large it may cause a PHP Fatal error due to memory usage. ".
             "Please make ". $THINKUP_CFG['log_location']. " less than 10MB in size and try again.";
         }
         if ( !isset($THINKUP_CFG['stream_log_location']) || $THINKUP_CFG['stream_log_location'] === false) {
             $message = "In order to test your ThinkUp installation, \$THINKUP_CFG['stream_log_location'] must be set ".
             "to a writable file.";
-        } else if (!is_writable($THINKUP_CFG['stream_log_location'])) {
+        } else if (!self::isLogWritable($THINKUP_CFG['stream_log_location'])) {
             $message = "In order to test your ThinkUp installation with your current settings, ".
             $THINKUP_CFG['stream_log_location']. " must be a writable file.";
-        } else if (filesize($THINKUP_CFG['stream_log_location']) > 10485760) {
+        } else if (file_exists($THINKUP_CFG['stream_log_location']) && filesize($THINKUP_CFG['stream_log_location']) > 10485760) {
             $message = "Your stream log file is so large it may cause a PHP Fatal error due to memory usage. ".
             "Please make ". $THINKUP_CFG['stream_log_location']. " less than 10MB in size and try again.";
         }

--- a/webapp/_lib/model/class.Logger.php
+++ b/webapp/_lib/model/class.Logger.php
@@ -310,7 +310,7 @@ class Logger {
             $type = 'w';
         }
         $filehandle = null;
-        if (is_writable($filename)) {
+        if (is_writable($filename) || is_writable(dirname($filename))) {
             $filehandle = fopen($filename, $type);// or die("can't open file $filename");
         } else {
             error_log("Unable to write log file: " . $filename);


### PR DESCRIPTION
If a log file doesn't exist, but its parent directory is writable, don't error out.
