### PR TITLE
Fix working directory & table prefix assumptions in tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -19,7 +19,7 @@ password to access it. This database name should match the one you just set in `
 In order for the tests to pass, you must:
 
 * Have a `tests/config.tests.inc.php` file with the correct values set
-* Set the crawler log file in `webapp/config.inc.php` and make that file writable
+* Set the crawler and stream log files in `webapp/config.inc.php` and make those files writable
 * Set the test database name to an empty tests database which the tests will destroy each run in `webapp/config.inc.php`
 * Set the test database user to a user with all privileges in the test database and global CREATE, DROP, and FILE privs
 * Set caching to false in `webapp/config.inc.php`
@@ -28,7 +28,7 @@ In order for the tests to pass, you must:
 
 To run a particular test suite, like the UserDAO suite, in the ThinkUp source code root folder, use this command: 
 
-    $ php tests/TestOfUserDAO.php
+    $ php tests/TestOfUserMySQLDAO.php
 
 To run all the test suites, use:
 

--- a/tests/TestOfBackupController.php
+++ b/tests/TestOfBackupController.php
@@ -132,7 +132,7 @@ class TestOfBackupController extends ThinkUpUnitTestCase {
             $zip_files[$zfile['name']] = $zfile['name'];
         }
         //verify we have create table file
-        $this->assertTrue($zip_files["create_tables.sql"]);
+        $this->assertTrue(isset($zip_files["create_tables.sql"]));
         $za->close();
         $q = "show tables";
         $q2 = "show create table ";
@@ -141,7 +141,7 @@ class TestOfBackupController extends ThinkUpUnitTestCase {
         while($data = $stmt->fetch(PDO::FETCH_ASSOC)) {
             foreach($data as $key => $value) {
                 $zfile = '/' . $value .'.txt';
-                $this->assertTrue($zip_files[$zfile]);
+                $this->assertTrue(isset($zip_files[$zfile]));
             }
         }
     }

--- a/tests/TestOfDAOFactory.php
+++ b/tests/TestOfDAOFactory.php
@@ -51,6 +51,9 @@ class TestOfDAOFactory extends ThinkUpUnitTestCase {
             'test_id int(11),' .
             'unique key test_id_idx (test_id)' .
             ')';
+        if ($this->testdb_helper->prefix != 'tu_') {
+            $test_table_sql = str_replace('tu_', $this->testdb_helper->prefix, $test_table_sql);
+        }
         $this->testdb_helper->runSQL($test_table_sql);
 
         //some test data as well
@@ -187,7 +190,7 @@ class TestOfDAOFactory extends ThinkUpUnitTestCase {
     public function testGetOwnerDAONoConfigFile(){
         $this->removeConfigFile();
         Config::destroyInstance();
-        $cfg_values = array("table_prefix"=>"tu_", "db_host"=>"localhost");
+        $cfg_values = array("table_prefix"=>$this->testdb_helper->prefix, "db_host"=>"localhost");
         $config = Config::getInstance($cfg_values);
         $dao = DAOFactory::getDAO('OwnerDAO', $cfg_values);
         $this->assertTrue(isset($dao));
@@ -348,7 +351,7 @@ class TestOfDAOFactory extends ThinkUpUnitTestCase {
     public function testGetInstallerDAONoConfigFile(){
         $this->removeConfigFile();
         Config::destroyInstance();
-        $cfg_values = array("table_prefix"=>"tu_", "db_host"=>"localhost");
+        $cfg_values = array("table_prefix"=>$this->testdb_helper->prefix, "db_host"=>"localhost");
         $config = Config::getInstance($cfg_values);
         $dao = DAOFactory::getDAO('InstallerDAO', $cfg_values);
         $this->assertTrue(isset($dao));

--- a/tests/TestOfExportMySQLDAO.php
+++ b/tests/TestOfExportMySQLDAO.php
@@ -288,7 +288,9 @@ class TestOfExportMySQLDAO extends ThinkUpUnitTestCase {
     }
 
     public function testGetExportFields() {
-        $test_table_sql = 'CREATE TABLE tu_test_table(' .
+        $config = Config::getInstance();
+        $config_array = $config->getValuesArray();
+        $test_table_sql = 'CREATE TABLE ' . $config_array['table_prefix'] . 'test_table(' .
             'id int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,' . 
             'test_name varchar(20),' .
             'test_id int(11),' .

--- a/tests/TestOfExportServiceUserDataController.php
+++ b/tests/TestOfExportServiceUserDataController.php
@@ -141,13 +141,13 @@ class TestOfExportServiceUserDataController extends ThinkUpUnitTestCase {
         }
 
         //verify we have create table file
-        $this->assertTrue($zip_files["/README.txt"]);
-        $this->assertTrue($zip_files["/posts.tmp"]);
-        $this->assertTrue($zip_files["/links.tmp"]);
-        $this->assertTrue($zip_files["/users_from_posts.tmp"]);
-        $this->assertTrue($zip_files["/follows.tmp"]);
-        $this->assertTrue($zip_files["/encoded_locations.tmp"]);
-        $this->assertTrue($zip_files["/favorites.tmp"]);
+        $this->assertTrue(isset($zip_files["/README.txt"]));
+        $this->assertTrue(isset($zip_files["/posts.tmp"]));
+        $this->assertTrue(isset($zip_files["/links.tmp"]));
+        $this->assertTrue(isset($zip_files["/users_from_posts.tmp"]));
+        $this->assertTrue(isset($zip_files["/follows.tmp"]));
+        $this->assertTrue(isset($zip_files["/encoded_locations.tmp"]));
+        $this->assertTrue(isset($zip_files["/favorites.tmp"]));
         $za->close();
     }
 }

--- a/tests/TestOfInstaller.php
+++ b/tests/TestOfInstaller.php
@@ -45,7 +45,7 @@ class TestOfInstaller extends ThinkUpUnitTestCase {
             // Define base URL, the same as $THINKUP_CFG['site_root_path']
             $current_script_path = explode('/', $_SERVER['PHP_SELF']);
             array_pop($current_script_path);
-            if ( in_array($current_script_path[count($current_script_path)-1],
+            if (!empty($current_script_path) && in_array($current_script_path[count($current_script_path)-1],
             array('account', 'post', 'session', 'user', 'install')) ) {
                 array_pop($current_script_path);
             }

--- a/tests/TestOfInstallerMySQLDAO.php
+++ b/tests/TestOfInstallerMySQLDAO.php
@@ -134,6 +134,9 @@ class TestOfInstallerMySQLDAO extends ThinkUpUnitTestCase {
         // test on complete table set; this should return just the INSERT query into plugins table
         $config = Config::getInstance();
         $config_array = $config->getValuesArray();
+        if ($config_array['table_prefix'] != 'tu_') {
+            $install_queries = str_replace('tu_', $config_array['table_prefix'], $install_queries);
+        }
         $dao = new InstallerMySQLDAO($config_array);
         $output = $dao->diffDataStructure($install_queries, $dao->getTables());
 
@@ -179,13 +182,15 @@ class TestOfInstallerMySQLDAO extends ThinkUpUnitTestCase {
     public function testNeedsSnowflakeUpgrade() {
         $dao = new InstallerMySQLDAO();
         $this->assertFalse($dao->needsSnowflakeUpgrade());
-        $this->testdb_helper->runSQL('ALTER TABLE tu_posts CHANGE post_id post_id bigint(11) NOT NULL;');
+        $this->testdb_helper->runSQL('ALTER TABLE #prefix#posts CHANGE post_id post_id bigint(11) NOT NULL;');
         $this->assertTrue($dao->needsSnowflakeUpgrade());
     }
 
     public function testRunMigration() {
+        $config = Config::getInstance();
+        $config_array = $config->getValuesArray();
         $dao = new InstallerMySQLDAO();
-        $this->testdb_helper->runSQL('CREATE TABLE `tu_test2` (`value` int(11) NOT NULL)');
+        $this->testdb_helper->runSQL('CREATE TABLE `#prefix#test2` (`value` int(11) NOT NULL)');
 
         //errors
         try {
@@ -195,24 +200,24 @@ class TestOfInstallerMySQLDAO extends ThinkUpUnitTestCase {
             $this->assertTrue(true, 'should thow exception');
         }
         try {
-            $dao->runMigrationSQL('insert into tu_test2 (valuee) VALUES ("a")');
+            $dao->runMigrationSQL('insert into #prefix#test2 (valuee) VALUES ("a")');
             $this->fail('should throw exception');
         } catch (Exception $e) {
             $this->assertTrue(true, 'should thow exception');
         }
 
         // old migration
-        $dao->runMigrationSQL("insert into tu_test2 (value) VALUES (1)");
-        $stmt = InstallerMySQLDAO::$PDO->query("select * from tu_test2");
+        $dao->runMigrationSQL('insert into #prefix#test2 (value) VALUES (1)');
+        $stmt = InstallerMySQLDAO::$PDO->query('select * from ' . $config_array['table_prefix'] . 'test2');
         $data = $stmt->fetchAll();
         $this->assertEqual(1, $data[0]['value']);
 
         //old migration multiple queries
-        $dao->runMigrationSQL("delete from tu_test2;" .
-        "insert into tu_test2 (value) VALUES (2);" .
-        "insert into tu_test2 (value) VALUES (3)");
+        $dao->runMigrationSQL("delete from #prefix#test2;" .
+        "insert into #prefix#test2 (value) VALUES (2);" .
+        "insert into #prefix#test2 (value) VALUES (3)");
 
-        $stmt = InstallerMySQLDAO::$PDO->query("select * from tu_test2");
+        $stmt = InstallerMySQLDAO::$PDO->query('select * from ' . $config_array['table_prefix'] . 'test2');
         $data = $stmt->fetchAll();
         $this->assertEqual(2, $data[0]['value']);
         $this->assertEqual(3, $data[1]['value']);
@@ -220,56 +225,60 @@ class TestOfInstallerMySQLDAO extends ThinkUpUnitTestCase {
     }
 
     public function testRunNewMigrationNoTable() {
+        $config = Config::getInstance();
+        $config_array = $config->getValuesArray();
         $dao = new InstallerMySQLDAO();
-        $this->testdb_helper->runSQL('CREATE TABLE `tu_test2` (`value` int(11) NOT NULL)');
-        $this->testdb_helper->runSQL('DROP TABLE IF EXISTS tu_completed_migrations');
+        $this->testdb_helper->runSQL('CREATE TABLE `#prefix#test2` (`value` int(11) NOT NULL)');
+        $this->testdb_helper->runSQL('DROP TABLE IF EXISTS #prefix#completed_migrations');
 
-        $dao->runMigrationSQL("insert into tu_test2 (value) VALUES (2);", true, $filename = 'a_file');
+        $dao->runMigrationSQL("insert into #prefix#test2 (value) VALUES (2);", true, $filename = 'a_file');
 
         // tu_completed_migrations table should now exists
-        $stmt = InstallerMySQLDAO::$PDO->query("SHOW TABLES LIKE 'tu_completed_migrations'");
+        $stmt = InstallerMySQLDAO::$PDO->query("SHOW TABLES LIKE '" . $config_array['table_prefix'] . "completed_migrations'");
         $data = $stmt->fetchAll();
         $this->assertEqual(1, count($data));
-        $this->assertEqual($data[0][0], "tu_completed_migrations");
+        $this->assertEqual($data[0][0], $config_array['table_prefix'] . "completed_migrations");
 
         // migration should have run
-        $stmt = InstallerMySQLDAO::$PDO->query("select * from tu_test2");
+        $stmt = InstallerMySQLDAO::$PDO->query("select * from " . $config_array['table_prefix'] . "test2");
         $data = $stmt->fetchAll();
         $this->assertEqual(2, $data[0]['value']);
 
         // tu_completed_migrations table should contan a record for our latest migration
-        $stmt = InstallerMySQLDAO::$PDO->query("select * from tu_completed_migrations");
+        $stmt = InstallerMySQLDAO::$PDO->query("select * from " . $config_array['table_prefix'] . "completed_migrations");
         $data = $stmt->fetchAll();
         $this->assertEqual($data[0]['migration'], 'a_file-0');
 
     }
 
     public function testRunNewMigrationsTwice() {
+        $config = Config::getInstance();
+        $config_array = $config->getValuesArray();
         $dao = new InstallerMySQLDAO();
-        $this->testdb_helper->runSQL('CREATE TABLE `tu_test2` (`value` int(11) NOT NULL)');
-        $this->testdb_helper->runSQL('DROP TABLE IF EXISTS tu_completed_migrations');
+        $this->testdb_helper->runSQL('CREATE TABLE `#prefix#test2` (`value` int(11) NOT NULL)');
+        $this->testdb_helper->runSQL('DROP TABLE IF EXISTS #prefix#completed_migrations');
 
-        $dao->runMigrationSQL("insert into tu_test2 (value) VALUES (2);", true, $filename = 'a_file');
+        $dao->runMigrationSQL("insert into #prefix#test2 (value) VALUES (2);", true, $filename = 'a_file');
 
         // first migration should have run
-        $stmt = InstallerMySQLDAO::$PDO->query("select * from tu_test2");
+        $stmt = InstallerMySQLDAO::$PDO->query("select * from " . $config_array['table_prefix'] . "test2");
         $data = $stmt->fetchAll();
         $this->assertEqual(count($data), 1);
         $this->assertEqual(2, $data[0]['value']);
 
         // tu_completed_migrations table should contain a record for our latest migration
-        $stmt = InstallerMySQLDAO::$PDO->query("select * from tu_completed_migrations");
+        $stmt = InstallerMySQLDAO::$PDO->query("select * from " . $config_array['table_prefix'] . "completed_migrations");
         $data = $stmt->fetchAll();
         $this->assertEqual(count($data), 1);
         $this->assertEqual($data[0]['migration'], 'a_file-0');
 
-        $dao->runMigrationSQL("insert into tu_test2 (value) VALUES (2);" .
-        "insert into tu_test2 (value) VALUES (3);" .
-        "insert into tu_test2 (value) VALUES (4);", 
+        $dao->runMigrationSQL("insert into #prefix#test2 (value) VALUES (2);" .
+        "insert into #prefix#test2 (value) VALUES (3);" .
+        "insert into #prefix#test2 (value) VALUES (4);",
         true, $filename = 'a_file');
 
         // migration should have run
-        $stmt = InstallerMySQLDAO::$PDO->query("select * from tu_test2");
+        $stmt = InstallerMySQLDAO::$PDO->query("select * from " . $config_array['table_prefix'] . "test2");
         $data = $stmt->fetchAll();
         $this->assertEqual(count($data), 3);
         $this->assertEqual(2, $data[0]['value']);
@@ -277,7 +286,7 @@ class TestOfInstallerMySQLDAO extends ThinkUpUnitTestCase {
         $this->assertEqual(4, $data[2]['value']);
 
         // tu_completed_migrations table should contain a record for our latest migration
-        $stmt = InstallerMySQLDAO::$PDO->query("select * from tu_completed_migrations");
+        $stmt = InstallerMySQLDAO::$PDO->query("select * from " . $config_array['table_prefix'] . "completed_migrations");
         $data = $stmt->fetchAll();
         $this->assertEqual(count($data), 3);
         $this->assertEqual($data[0]['migration'], 'a_file-0');
@@ -286,19 +295,21 @@ class TestOfInstallerMySQLDAO extends ThinkUpUnitTestCase {
     }
 
     public function testRunNewMigrationsSkipIfExists() {
+        $config = Config::getInstance();
+        $config_array = $config->getValuesArray();
         $dao = new InstallerMySQLDAO();
-        $this->testdb_helper->runSQL('CREATE TABLE `tu_test2` (`value` int(11) NOT NULL)');
-        $this->testdb_helper->runSQL('DROP TABLE IF EXISTS tu_completed_migrations');
+        $this->testdb_helper->runSQL('CREATE TABLE `#prefix#test2` (`value` int(11) NOT NULL)');
+        $this->testdb_helper->runSQL('DROP TABLE IF EXISTS #prefix#completed_migrations');
 
-        $dao->runMigrationSQL("insert into tu_test2 (value) VALUES (2);" .
-        "insert into tu_test2 (value) VALUES (3);" .
-        "DROP TABLE IF EXISTS tu_users_b16;" .
-        "insert into tu_test2 (value) VALUES (4);" .
-        "insert into tu_test2 (value) VALUES (5);", 
+        $dao->runMigrationSQL("insert into #prefix#test2 (value) VALUES (2);" .
+        "insert into #prefix#test2 (value) VALUES (3);" .
+        "DROP TABLE IF EXISTS #prefix#users_b16;" .
+        "insert into #prefix#test2 (value) VALUES (4);" .
+        "insert into #prefix#test2 (value) VALUES (5);",
         true, $filename = 'a_file');
 
         // migration should have run
-        $stmt = InstallerMySQLDAO::$PDO->query("select * from tu_test2");
+        $stmt = InstallerMySQLDAO::$PDO->query("select * from " . $config_array['table_prefix'] . "test2");
         $data = $stmt->fetchAll();
         $this->assertEqual(count($data), 4);
         $this->assertEqual(2, $data[0]['value']);
@@ -307,7 +318,7 @@ class TestOfInstallerMySQLDAO extends ThinkUpUnitTestCase {
         $this->assertEqual(5, $data[3]['value']);
 
         // tu_completed_migrations table should contain a record for our latest migration
-        $stmt = InstallerMySQLDAO::$PDO->query("select * from tu_completed_migrations");
+        $stmt = InstallerMySQLDAO::$PDO->query("select * from " . $config_array['table_prefix'] . "completed_migrations");
         $data = $stmt->fetchAll();
         $this->assertEqual(count($data), 4);
         $this->assertEqual($data[0]['migration'], 'a_file-0');
@@ -317,19 +328,21 @@ class TestOfInstallerMySQLDAO extends ThinkUpUnitTestCase {
     }
 
     public function testRunNewMigrationStripsVersionForStorage() {
+        $config = Config::getInstance();
+        $config_array = $config->getValuesArray();
         $dao = new InstallerMySQLDAO();
-        $this->testdb_helper->runSQL('CREATE TABLE `tu_test2` (`value` int(11) NOT NULL)');
-        $this->testdb_helper->runSQL('DROP TABLE IF EXISTS tu_completed_migrations');
+        $this->testdb_helper->runSQL('CREATE TABLE `#prefix#test2` (`value` int(11) NOT NULL)');
+        $this->testdb_helper->runSQL('DROP TABLE IF EXISTS #prefix#completed_migrations');
 
-        $dao->runMigrationSQL("insert into tu_test2 (value) VALUES (2);" .
-        "insert into tu_test2 (value) VALUES (3);" .
-        "DROP TABLE IF EXISTS tu_users_b16;" .
-        "insert into tu_test2 (value) VALUES (4);" .
-        "insert into tu_test2 (value) VALUES (5);", 
+        $dao->runMigrationSQL("insert into #prefix#test2 (value) VALUES (2);" .
+        "insert into #prefix#test2 (value) VALUES (3);" .
+        "DROP TABLE IF EXISTS #prefix#users_b16;" .
+        "insert into #prefix#test2 (value) VALUES (4);" .
+        "insert into #prefix#test2 (value) VALUES (5);",
         true, $filename = 'a_file_v0.13.sql');
 
         // migration should have run
-        $stmt = InstallerMySQLDAO::$PDO->query("select * from tu_test2");
+        $stmt = InstallerMySQLDAO::$PDO->query("select * from " . $config_array['table_prefix'] . "test2");
         $data = $stmt->fetchAll();
         $this->assertEqual(count($data), 4);
         $this->assertEqual(2, $data[0]['value']);
@@ -338,7 +351,7 @@ class TestOfInstallerMySQLDAO extends ThinkUpUnitTestCase {
         $this->assertEqual(5, $data[3]['value']);
 
         // tu_completed_migrations table should contain a record for our latest migration
-        $stmt = InstallerMySQLDAO::$PDO->query("select * from tu_completed_migrations");
+        $stmt = InstallerMySQLDAO::$PDO->query("select * from " . $config_array['table_prefix'] . "completed_migrations");
         $data = $stmt->fetchAll();
         $this->assertEqual(count($data), 4);
         $this->assertEqual($data[0]['migration'], 'a_file-0');

--- a/tests/TestOfInstanceMySQLDAO.php
+++ b/tests/TestOfInstanceMySQLDAO.php
@@ -182,7 +182,9 @@ class TestOfInstanceMySQLDAO extends ThinkUpUnitTestCase {
         $this->assertEqual($result->network_user_id, 10);
         $this->assertEqual($result->network_viewer_id, 10);
 
-        $q = "TRUNCATE TABLE tu_instances ";
+        $config = Config::getInstance();
+        $config_array = $config->getValuesArray();
+        $q = "TRUNCATE TABLE " . $config_array['table_prefix'] . "instances ";
         PDODAO::$PDO->exec($q);
 
         //Try empty

--- a/tests/TestOfLinkMySQLDAO.php
+++ b/tests/TestOfLinkMySQLDAO.php
@@ -409,15 +409,17 @@ class TestOfLinkMySQLDAO extends ThinkUpUnitTestCase {
      * Set counter higher to avoid clashes w/ prev inserts.
      */
     public function testUniqueConstraint1() {
+        $config = Config::getInstance();
+        $config_array = $config->getValuesArray();
         $counter = 2000;
         $pseudo_minute = str_pad($counter, 2, "0", STR_PAD_LEFT);
         $source = '<a href="http://twitter.com" rel="nofollow">Tweetie for Mac</a>';
-        $q  = "INSERT IGNORE INTO tu_links (url, title, clicks, post_id, network, image_src) ";
+        $q  = "INSERT IGNORE INTO " . $config_array['table_prefix'] . "links (url, title, clicks, post_id, network, image_src) ";
         $q .= " VALUES ('http://example.com/".$counter."', 'Link $counter', 0, $counter, 'twitter', '');";
         $res = PDODAO::$PDO->exec($q);
         $this->assertEqual($res, 1);
 
-        $q  = "INSERT IGNORE INTO tu_links (url, title, clicks, post_id, network, image_src) ";
+        $q  = "INSERT IGNORE INTO " . $config_array['table_prefix'] . "links (url, title, clicks, post_id, network, image_src) ";
         $q .= " VALUES ('http://example.com/".$counter."', 'Link $counter', 0, $counter, 'twitter', '');";
         $res = PDODAO::$PDO->exec($q);
         $this->assertEqual($res, 0);

--- a/tests/TestOfPDODAO.php
+++ b/tests/TestOfPDODAO.php
@@ -39,9 +39,11 @@ class TestOfPDODAO extends ThinkUpUnitTestCase {
     }
 
     protected function buildData() {
+        $config = Config::getInstance();
+        $config_array = $config->getValuesArray();
         $builders = array();
 
-        $test_table_sql = 'CREATE TABLE tu_test_table(' .
+        $test_table_sql = 'CREATE TABLE ' . $config_array['table_prefix'] . 'test_table(' .
             'id int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,' . 
             'test_name varchar(20),' .
             'test_id int(11),' .
@@ -272,10 +274,13 @@ class TestOfPDODAO extends ThinkUpUnitTestCase {
     }
 
     public function testInstantiateDaoWithoutConfigFile() {
+        $config = Config::getInstance();
+        $config_array = $config->getValuesArray();
         $this->builders = self::buildData();
+        try {
         $this->removeConfigFile();
         Config::destroyInstance();
-        $cfg_values = array("table_prefix"=>"tu_", "db_host"=>"localhost");
+        $cfg_values = array("table_prefix"=> $config_array['table_prefix'], "db_host"=>"localhost");
         $config = Config::getInstance($cfg_values);
         $test_dao = new TestMySQLDAO($cfg_values);
         $users = $test_dao->getUserCount(0, 'mary');
@@ -283,6 +288,11 @@ class TestOfPDODAO extends ThinkUpUnitTestCase {
         $this->assertEqual(count($users), 2);
         $this->assertEqual($users[0]['user_name'], 'mary');
         $this->assertEqual($users[1]['user_name'], 'sweetmary');
+        } catch (Exception $e) {
+            // restore config file if something goes wrong
+            $this->restoreConfigFile();
+            throw $e;
+        }
         $this->restoreConfigFile();
     }
 

--- a/tests/TestOfPostMySQLDAO.php
+++ b/tests/TestOfPostMySQLDAO.php
@@ -2067,17 +2067,19 @@ class TestOfPostMySQLDAO extends ThinkUpUnitTestCase {
      * Set counter higher to avoid clashes w/ prev post inserts.
      */
     public function testUniqueConstraint1() {
+        $config = Config::getInstance();
+        $config_array = $config->getValuesArray();
         $counter = 1000;
         $pseudo_minute = str_pad($counter, 2, "0", STR_PAD_LEFT);
         $source = '<a href="http://twitter.com" rel="nofollow">Tweetie for Mac</a>';
-        $q = "INSERT IGNORE INTO tu_posts (post_id, author_user_id, author_username, author_fullname, author_avatar,
+        $q = "INSERT IGNORE INTO " . $config_array['table_prefix'] . "posts (post_id, author_user_id, author_username, author_fullname, author_avatar,
         post_text, source, pub_date, reply_count_cache, retweet_count_cache, network) VALUES 
         ($counter, 13, 'ev', 'Ev Williams', 'avatar.jpg', 
         'This is post $counter', '$source', '2006-01-01 00:$pseudo_minute:00', ".rand(0, 4).", 5, 'twitter');";
         $res = PDODAO::$PDO->exec($q);
         $this->assertEqual($res, 1);
 
-        $q = "INSERT IGNORE INTO tu_posts (post_id, author_user_id, author_username, author_fullname, author_avatar,
+        $q = "INSERT IGNORE INTO " . $config_array['table_prefix'] . "posts (post_id, author_user_id, author_username, author_fullname, author_avatar,
         post_text, source, pub_date, reply_count_cache, retweet_count_cache, network) VALUES 
         ($counter, 13, 'ev', 'Ev Williams', 'avatar.jpg', 
         'This is post $counter', '$source', '2006-01-01 00:$pseudo_minute:00', ".rand(0, 4).", 5, 'twitter');";

--- a/tests/TestOfThinkUpEmbedController.php
+++ b/tests/TestOfThinkUpEmbedController.php
@@ -24,7 +24,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2011 Gina Trapani
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 

--- a/tests/TestOfThreadJSController.php
+++ b/tests/TestOfThreadJSController.php
@@ -24,7 +24,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2011 Gina Trapani
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 

--- a/tests/TestOfUtils.php
+++ b/tests/TestOfUtils.php
@@ -55,10 +55,10 @@ class TestOfUtils extends ThinkUpBasicUnitTestCase {
     public function testgetPluginViewDirectory() {
         $config = Config::getInstance();
         $path = Utils::getPluginViewDirectory('twitter');
-        $this->assertEqual($path, $config->getValue('source_root_path').'webapp/plugins/twitter/view/');
+        $this->assertEqual(realpath($path), realpath($config->getValue('source_root_path').'/webapp/plugins/twitter/view/'));
 
         $path = Utils::getPluginViewDirectory('sweetmaryjane');
-        $this->assertEqual($path, $config->getValue('source_root_path').'webapp/plugins/sweetmaryjane/view/');
+        $this->assertEqual(realpath($path), realpath($config->getValue('source_root_path').'/webapp/plugins/sweetmaryjane/view/'));
     }
 
     public function testGetPercentage(){

--- a/tests/all_model_tests.php
+++ b/tests/all_model_tests.php
@@ -25,7 +25,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2011 Gina Trapani
  */
-include 'init.tests.php';
+include dirname(__FILE__) . '/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/web_tester.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/mock_objects.php';

--- a/tests/all_tests.php
+++ b/tests/all_tests.php
@@ -25,7 +25,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2011 Gina Trapani
  */
-include 'init.tests.php';
+include dirname(__FILE__) . '/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/web_tester.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/mock_objects.php';

--- a/tests/classes/class.TestFauxDAO.php
+++ b/tests/classes/class.TestFauxDAO.php
@@ -27,7 +27,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2011 Christoffer Viken, Gina Trapani, Mark Wilkie
  */
-require_once 'tests/classes/interface.TestDAO.php';
+require_once dirname(__FILE__) . '/interface.TestDAO.php';
 
 /*
  * Faux TestDAO implementation for TestOfDAOFactory test

--- a/tests/classes/class.ThinkUpTestDatabaseHelper.php
+++ b/tests/classes/class.ThinkUpTestDatabaseHelper.php
@@ -42,6 +42,9 @@ class ThinkUpTestDatabaseHelper extends PDODAO {
         $create_statements = split(";", $create_db_script);
         foreach ($create_statements as $q) {
             if (trim($q) != '') {
+                if ($this->prefix != 'tu_') {
+                    $q = str_replace('tu_', $this->prefix, $q);
+                }
                 self::execute($q);
             }
         }

--- a/tests/classes/class.ThinkUpUnitTestCase.php
+++ b/tests/classes/class.ThinkUpUnitTestCase.php
@@ -57,9 +57,9 @@ class ThinkUpUnitTestCase extends ThinkUpBasicUnitTestCase {
 
         $this->testdb_helper = new ThinkUpTestDatabaseHelper();
         $this->testdb_helper->drop($this->test_database_name);
-        $this->testdb_helper->create($THINKUP_CFG['source_root_path']."webapp/install/sql/build-db_mysql.sql");
-
         $this->table_prefix = $config->getValue('table_prefix');
+        $this->testdb_helper->prefix = $this->table_prefix;
+        $this->testdb_helper->create($THINKUP_CFG['source_root_path']."/webapp/install/sql/build-db_mysql.sql");
     }
 
     /**

--- a/webapp/plugins/expandurls/tests/TestOfExpandURLsPlugin.php
+++ b/webapp/plugins/expandurls/tests/TestOfExpandURLsPlugin.php
@@ -26,7 +26,7 @@
  * @copyright 2009-2011 Gina Trapani, Guillaume Boudreau, Christoffer Viken
  * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 

--- a/webapp/plugins/expandurls/tests/TestOfExpandURLsPluginConfigurationController.php
+++ b/webapp/plugins/expandurls/tests/TestOfExpandURLsPluginConfigurationController.php
@@ -28,7 +28,7 @@
  * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 
 require_once THINKUP_ROOT_PATH.

--- a/webapp/plugins/expandurls/tests/TestOfFlickrAPIAccessor.php
+++ b/webapp/plugins/expandurls/tests/TestOfFlickrAPIAccessor.php
@@ -24,7 +24,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2011 Gina Trapani
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/web_tester.php';
 

--- a/webapp/plugins/facebook/tests/TestOfFacebookCrawler.php
+++ b/webapp/plugins/facebook/tests/TestOfFacebookCrawler.php
@@ -27,7 +27,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2011 Gina Trapani
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/web_tester.php';
 require_once THINKUP_ROOT_PATH.'webapp/plugins/facebook/model/class.FacebookCrawler.php';

--- a/webapp/plugins/facebook/tests/TestOfFacebookPlugin.php
+++ b/webapp/plugins/facebook/tests/TestOfFacebookPlugin.php
@@ -25,7 +25,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2011 Gina Trapani
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/web_tester.php';
 

--- a/webapp/plugins/facebook/tests/TestOfFacebookPluginConfigurationController.php
+++ b/webapp/plugins/facebook/tests/TestOfFacebookPluginConfigurationController.php
@@ -28,7 +28,7 @@
  * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/plugins/facebook/model/class.FacebookPlugin.php';
 require_once THINKUP_ROOT_PATH.'webapp/plugins/facebook/controller/class.FacebookPluginConfigurationController.php';

--- a/webapp/plugins/geoencoder/tests/TestOfGeoEncoderPlugin.php
+++ b/webapp/plugins/geoencoder/tests/TestOfGeoEncoderPlugin.php
@@ -28,7 +28,7 @@
  * @author Mark Wilkie <mwilkie[at]gmail[dot]com>
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/web_tester.php';
 

--- a/webapp/plugins/geoencoder/tests/TestOfGeoEncoderPluginConfigurationController.php
+++ b/webapp/plugins/geoencoder/tests/TestOfGeoEncoderPluginConfigurationController.php
@@ -28,7 +28,7 @@
  * @author Mark Wilkie <mwilkie[at]gmail[dot]com>
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/plugins/geoencoder/controller/class.GeoEncoderPluginConfigurationController.php';
 

--- a/webapp/plugins/geoencoder/tests/TestOfMapController.php
+++ b/webapp/plugins/geoencoder/tests/TestOfMapController.php
@@ -30,7 +30,7 @@
  * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/plugins/geoencoder/controller/class.MapController.php';
 

--- a/webapp/plugins/googleplus/tests/TestOfGooglePlusCrawler.php
+++ b/webapp/plugins/googleplus/tests/TestOfGooglePlusCrawler.php
@@ -26,7 +26,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2011 Henri Watson
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/web_tester.php';
 require_once THINKUP_ROOT_PATH.'webapp/plugins/googleplus/model/class.GooglePlusCrawler.php';

--- a/webapp/plugins/googleplus/tests/TestOfGooglePlusPlugin.php
+++ b/webapp/plugins/googleplus/tests/TestOfGooglePlusPlugin.php
@@ -28,7 +28,7 @@
  * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 require_once THINKUP_ROOT_PATH.'tests/classes/class.ThinkUpBasicUnitTestCase.php';

--- a/webapp/plugins/googleplus/tests/TestOfGooglePlusPluginConfigurationController.php
+++ b/webapp/plugins/googleplus/tests/TestOfGooglePlusPluginConfigurationController.php
@@ -27,7 +27,7 @@
  * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 require_once THINKUP_ROOT_PATH.'tests/classes/class.ThinkUpBasicUnitTestCase.php';

--- a/webapp/plugins/hellothinkup/tests/TestOfHelloThinkUpPlugin.php
+++ b/webapp/plugins/hellothinkup/tests/TestOfHelloThinkUpPlugin.php
@@ -28,7 +28,7 @@
  * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 require_once THINKUP_ROOT_PATH.'tests/classes/class.ThinkUpBasicUnitTestCase.php';

--- a/webapp/plugins/hellothinkup/tests/TestOfHelloThinkUpPluginConfigurationController.php
+++ b/webapp/plugins/hellothinkup/tests/TestOfHelloThinkUpPluginConfigurationController.php
@@ -28,7 +28,7 @@
  * @author Mark Wilkie <mwilkie[at]gmail[dot]com>
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 require_once THINKUP_ROOT_PATH.'tests/classes/class.ThinkUpBasicUnitTestCase.php';

--- a/webapp/plugins/twitter/tests/TestOfCrawlerTwitterAPIAccessorOAuth.php
+++ b/webapp/plugins/twitter/tests/TestOfCrawlerTwitterAPIAccessorOAuth.php
@@ -25,7 +25,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2011 Mark Wilkie
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'tests/classes/class.ThinkUpBasicUnitTestCase.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';

--- a/webapp/plugins/twitter/tests/TestOfRetweetDetector.php
+++ b/webapp/plugins/twitter/tests/TestOfRetweetDetector.php
@@ -25,7 +25,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2011 Gina Trapani
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'tests/classes/class.ThinkUpBasicUnitTestCase.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';

--- a/webapp/plugins/twitter/tests/TestOfTwitterAPIAccessorOAuth.php
+++ b/webapp/plugins/twitter/tests/TestOfTwitterAPIAccessorOAuth.php
@@ -25,7 +25,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2011 Gina Trapani, Mark Wilkie
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/plugins/twitter/tests/classes/mock.TwitterOAuth.php';
 require_once THINKUP_ROOT_PATH.'webapp/plugins/twitter/model/class.TwitterAPIAccessorOAuth.php';

--- a/webapp/plugins/twitter/tests/TestOfTwitterAuthController.php
+++ b/webapp/plugins/twitter/tests/TestOfTwitterAuthController.php
@@ -27,7 +27,7 @@
  * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 if (!class_exists('twitterOAuth')) {

--- a/webapp/plugins/twitter/tests/TestOfTwitterCrawler.php
+++ b/webapp/plugins/twitter/tests/TestOfTwitterCrawler.php
@@ -29,7 +29,7 @@
  * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/web_tester.php';
 require_once THINKUP_ROOT_PATH.'tests/classes/class.ThinkUpUnitTestCase.php';

--- a/webapp/plugins/twitter/tests/TestOfTwitterInstanceMySQLDAO.php
+++ b/webapp/plugins/twitter/tests/TestOfTwitterInstanceMySQLDAO.php
@@ -24,7 +24,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2011 Gina Trapani
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'tests/classes/class.ThinkUpBasicUnitTestCase.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
@@ -114,6 +114,8 @@ class TestOfTwitterInstanceMySQLDAO extends ThinkUpUnitTestCase {
     }
 
     public function testGetInstanceOneByLastRun(){
+        $config = Config::getInstance();
+        $config_array = $config->getValuesArray();
         //Try Newest
         $result = $this->DAO->getInstanceFreshestOne();
         $this->assertIsA($result, "Instance");
@@ -141,7 +143,7 @@ class TestOfTwitterInstanceMySQLDAO extends ThinkUpUnitTestCase {
         $this->assertEqual($result->network_viewer_id, 10);
         $this->assertEqual($result->last_page_fetched_replies, 10);
 
-        $q = "TRUNCATE TABLE tu_instances ";
+        $q = "TRUNCATE TABLE " . $config_array['table_prefix'] . "instances ";
         PDODAO::$PDO->exec($q);
 
         //Try empty

--- a/webapp/plugins/twitter/tests/TestOfTwitterOAuth.php
+++ b/webapp/plugins/twitter/tests/TestOfTwitterOAuth.php
@@ -25,7 +25,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2011 Gina Trapani
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 if (!class_exists('twitterOAuth')) {
     require_once THINKUP_ROOT_PATH.'webapp/plugins/twitter/tests/classes/mock.TwitterOAuth.php';

--- a/webapp/plugins/twitter/tests/TestOfTwitterPlugin.php
+++ b/webapp/plugins/twitter/tests/TestOfTwitterPlugin.php
@@ -27,7 +27,7 @@
  * @copyright 2009-2011 Gina Trapani, Guillaume Boudreau
  * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/web_tester.php';
 

--- a/webapp/plugins/twitter/tests/TestOfTwitterPluginConfigurationController.php
+++ b/webapp/plugins/twitter/tests/TestOfTwitterPluginConfigurationController.php
@@ -28,7 +28,7 @@
  * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/plugins/twitter/tests/classes/mock.TwitterOAuth.php';
 require_once THINKUP_ROOT_PATH.'webapp/plugins/twitter/model/class.TwitterOAuthThinkUp.php';

--- a/webapp/plugins/twitterrealtime/tests/TestOfConsumerStreamProcess.php
+++ b/webapp/plugins/twitterrealtime/tests/TestOfConsumerStreamProcess.php
@@ -25,7 +25,7 @@
  * @copyright 2009-2011 Gina Trapani, Amy Unruh, Mark Wilkie
  * @author Amy Unruh
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 

--- a/webapp/plugins/twitterrealtime/tests/TestOfConsumerUserStream.php
+++ b/webapp/plugins/twitterrealtime/tests/TestOfConsumerUserStream.php
@@ -26,7 +26,7 @@
  * @author Amy Unruh
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 

--- a/webapp/plugins/twitterrealtime/tests/TestOfStreamMessageQueueFactory.php
+++ b/webapp/plugins/twitterrealtime/tests/TestOfStreamMessageQueueFactory.php
@@ -26,7 +26,7 @@
  * @author Amy Unruh
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 

--- a/webapp/plugins/twitterrealtime/tests/TestOfStreamMessageQueueMySQL.php
+++ b/webapp/plugins/twitterrealtime/tests/TestOfStreamMessageQueueMySQL.php
@@ -26,7 +26,7 @@
  * @author Amy Unruh
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 

--- a/webapp/plugins/twitterrealtime/tests/TestOfStreamMessageQueueRedis.php
+++ b/webapp/plugins/twitterrealtime/tests/TestOfStreamMessageQueueRedis.php
@@ -26,7 +26,7 @@
  * @author Amy Unruh
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 

--- a/webapp/plugins/twitterrealtime/tests/TestOfTwitterJSONStreamParser.php
+++ b/webapp/plugins/twitterrealtime/tests/TestOfTwitterJSONStreamParser.php
@@ -25,7 +25,7 @@
  * @copyright 2011  Amy Unruh
  * @author Amy Unruh
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 

--- a/webapp/plugins/twitterrealtime/tests/TestOfTwitterRealtimePlugin.php
+++ b/webapp/plugins/twitterrealtime/tests/TestOfTwitterRealtimePlugin.php
@@ -28,7 +28,7 @@
  * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 require_once THINKUP_ROOT_PATH.'tests/classes/class.ThinkUpBasicUnitTestCase.php';

--- a/webapp/plugins/twitterrealtime/tests/TestOfTwitterRealtimePluginConfigurationController.php
+++ b/webapp/plugins/twitterrealtime/tests/TestOfTwitterRealtimePluginConfigurationController.php
@@ -28,7 +28,7 @@
  * @author Mark Wilkie <mwilkie[at]gmail[dot]com>
  *
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/plugins/twitterrealtime/model/class.TwitterRealtimePlugin.php';
 require_once THINKUP_ROOT_PATH.'webapp/plugins/twitterrealtime/controller/class.TwitterRealtimePluginConfigurationController.php';


### PR DESCRIPTION
- Make paths to init.tests.php relative to **FILE** so they don't make
  assumptions about the working directory
- Fix tests that assume the prefix is tu_
- Fix a few places that assume a trailing slash after directories
- Restore the configuration file if it's moved out of the way during
  testing and an exception occurs before it's moved back
- Minor updates to tests/README.md
