### PR TITLE
Add Admin Facebook pages separately

### DIFF
--- a/webapp/plugins/facebook/controller/class.FacebookPluginConfigurationController.php
+++ b/webapp/plugins/facebook/controller/class.FacebookPluginConfigurationController.php
@@ -80,6 +80,11 @@ class FacebookPluginConfigurationController extends PluginConfigurationControlle
         return $this->generateView();
     }
 
+    public function isAccountPage($account_id, $access_token) {
+        $account = FacebookGraphAPIAccessor::apiRequest('/' . $account_id . '?metadata=true', $access_token);
+        return !empty($account) && !empty($account->type) && $account->type == 'page';
+    }
+
     protected function setUpFacebookInteractions($options) {
         // Create our Facebook Application instance
         $facebook = new Facebook(array(
@@ -103,7 +108,7 @@ class FacebookPluginConfigurationController extends PluginConfigurationControlle
         }
 
         $params = array('scope'=>
-        'offline_access,read_stream,user_likes,user_location,user_website,read_friendlists,friends_location',
+        'offline_access,read_stream,user_likes,user_location,user_website,read_friendlists,friends_location,manage_pages,read_insights',
         'state'=>SessionCache::get('facebook_auth_csrf'));
 
         $fbconnect_link = $facebook->getLoginUrl($params);
@@ -118,6 +123,8 @@ class FacebookPluginConfigurationController extends PluginConfigurationControlle
 
         $ownerinstance_dao = DAOFactory::getDAO('OwnerInstanceDAO');
         foreach ($owner_instances as $instance) {
+            // TODO: figure out if the scope has changed since this instance last got its tokens,
+            // and we need to get re-request permission with the new scope
             $tokens = $ownerinstance_dao->getOAuthTokens($instance->id);
             $access_token = $tokens['oauth_access_token'];
             if ($instance->network == 'facebook') { //not a page
@@ -125,9 +132,20 @@ class FacebookPluginConfigurationController extends PluginConfigurationControlle
                 if (@$pages->data) {
                     $user_pages[$instance->network_user_id] = $pages->data;
                 }
+
+                $sub_accounts = FacebookGraphAPIAccessor::apiRequest('/'.$instance->network_user_id.'/accounts', $access_token);
+                if (!empty($sub_accounts->data)) {
+                    $user_admin_pages[$instance->network_user_id] = array();
+                    foreach ($sub_accounts->data as $act) {
+                        if (self::isAccountPage($act->id, $access_token)) {
+                            $user_admin_pages[$instance->network_user_id][] = $act;
+                        }
+                    }
+                }
             }
         }
         $this->addToView('user_pages', $user_pages);
+        $this->addToView('user_admin_pages', $user_admin_pages);
 
         $owner_instance_pages = $instance_dao->getByOwnerAndNetwork($this->owner, 'facebook page');
         if (count($owner_instance_pages) > 0) {

--- a/webapp/plugins/facebook/view/facebook.account.index.tpl
+++ b/webapp/plugins/facebook/view/facebook.account.index.tpl
@@ -16,7 +16,7 @@
     </div>
 </div>
 
-    {if count($owner_instances) > 0 }
+{if count($owner_instances) > 0 }
     <h2 class="subhead">Facebook User Profiles</h2>
      {include file="_usermessage.tpl" field="user_add"}
     {foreach from=$owner_instances key=iid item=i name=foo}
@@ -63,6 +63,38 @@
     <br />
     {/if}
 
+<h2 class="subhead">Add a Facebook Page You Manage</h2>
+{foreach from=$owner_instances key=iid item=i name=foo}
+  {assign var='facebook_user_id' value=$i->network_user_id}
+  {if $user_admin_pages.$facebook_user_id}
+    <div class="clearfix">
+        <div class="grid_4 right" style="padding-top:.5em;">
+            {$i->network_username}&nbsp;manages:
+        </div>
+        <form name="addpage" action="index.php?p=facebook">
+        <div class="grid_8">
+            {if $user_admin_pages.$facebook_user_id}
+            <input type="hidden" name="instance_id" value="{$i->id}">
+            <input type="hidden" name="p" value="facebook">
+            <input type="hidden" name ="viewer_id" value="{$i->network_user_id}" />
+            <input type="hidden" name ="owner_id" value="{$owner->id}" />
+            <select name="facebook_page_id">
+                {foreach from=$user_admin_pages.$facebook_user_id key=page_id item=page name=p}
+                    <option value="{$page->id}">{if strlen($page->name)>27}{$page->name|substr:0:27}...{else}{$page->name}{/if}</option> <br />
+                {/foreach}
+             </select>
+             {/if}
+        </div>
+        <div class="grid_7">
+             <span id="divaddadminpage{$i->network_username}"><input type="submit" name="action" class="tt-button ui-state-default ui-priority-secondary ui-corner-all
+addPage"  id="{$i->network_username}" value="add page" /></span>
+        </div>
+        </form>
+    </div>
+    {else}
+    To add a Facebook page to ThinkUp, create a page on Facebook.com or ask the administrator to make you an admin, and refresh this page.
+    {/if}
+{/foreach}
 
 <h2 class="subhead">Add a Facebook Page You "Like"</h2>
 {foreach from=$owner_instances key=iid item=i name=foo}
@@ -96,6 +128,7 @@ addPage"  id="{$i->network_username}" value="add page" /></span>
     To add a Facebook page to ThinkUp, "like" it on Facebook.com and refresh this page.
     {/if}
 {/foreach}
+
 {/if}
 </div> 
 


### PR DESCRIPTION
On the Facebook admin page, show pages for which you are the
administrator separately from ones you just "like".

This is in preparation for pulling some Insights data for pages that
requires that the instance user be a page admin, but is useful by
itself.
