### PR TITLE
Fix ability to add a Facebook account under https

### DIFF
--- a/webapp/plugins/facebook/controller/class.FacebookPluginConfigurationController.php
+++ b/webapp/plugins/facebook/controller/class.FacebookPluginConfigurationController.php
@@ -152,7 +152,8 @@ class FacebookPluginConfigurationController extends PluginConfigurationControlle
                 //First, prep redirect URI
                 $config = Config::getInstance();
                 $site_root_path = $config->getValue('site_root_path');
-                $redirect_uri = urlencode('http://'.$_SERVER['SERVER_NAME'].$site_root_path.'account/?p=facebook');
+                $redirect_uri = urlencode(sprintf('%s://%s%s%s', !empty($_SERVER['HTTPS']) ? 'https' : 'http',
+                  $_SERVER['SERVER_NAME'], $site_root_path, 'account/?p=facebook'));
 
                 //Build API request URL
                 $api_req = 'https://graph.facebook.com/oauth/access_token?client_id='.

--- a/webapp/plugins/facebook/tests/testdata/oauth_access_token-client_id=77-client_secret=scrt-redirect_uri=http%3A%2F%2Fsrvr%2Faccount%2F%3Fp%3Dfacebook-state=123-code=789
+++ b/webapp/plugins/facebook/tests/testdata/oauth_access_token-client_id=77-client_secret=scrt-redirect_uri=http%3A%2F%2Fsrvr%2Faccount%2F%3Fp%3Dfacebook-state=123-code=789
@@ -1,0 +1,1 @@
+{"error":{"message":"Invalid redirect_uri: Given URL is not allowed by the Application configuration.","type":"OAuthException"}}

--- a/webapp/plugins/facebook/tests/testdata/oauth_access_token-client_id=77-client_secret=scrt-redirect_uri=https%3A%2F%2Fsrvr%2Faccount%2F%3Fp%3Dfacebook-state=123-code=789
+++ b/webapp/plugins/facebook/tests/testdata/oauth_access_token-client_id=77-client_secret=scrt-redirect_uri=https%3A%2F%2Fsrvr%2Faccount%2F%3Fp%3Dfacebook-state=123-code=789
@@ -1,0 +1,1 @@
+access_token=newfauxaccesstoken11234567890


### PR DESCRIPTION
When running under https, the redirect url generated when creating an
authorization url correctly set the protocol to https if the ThinkUp web
server is running under https, but always set the redirect url protocol
to http when creating the url to request an access token.  This caused
Facebook to reject the request for the access token if the app was
configured with the https url.
