### PR TITLE
Warn user of slow web migration

### DIFF
--- a/tests/TestOfTableStatsMySQLDAO.php
+++ b/tests/TestOfTableStatsMySQLDAO.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ *
+ * ThinkUp/tests/TestOfTableStatsMySQLDAO.php
+ *
+ * Copyright (c) 2009-2011 Mark Wilkie
+ *
+ * LICENSE:
+ *
+ * This file is part of ThinkUp (http://thinkupapp.com).
+ *
+ * ThinkUp is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * ThinkUp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with ThinkUp.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @author Mark Wilkie <mark[at]bitterpill[dot]org>
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2009-2011 Mark Wilkie
+ */
+require_once dirname(__FILE__).'/init.tests.php';
+require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
+require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
+
+class TestOfTableStatsMySQLDAO extends ThinkUpUnitTestCase {
+
+
+    public function setUp() {
+        parent::setUp();
+        $this->logger = Logger::getInstance();
+        $this->config = Config::getInstance();
+        $optiondao = new OptionMySQLDAO();
+        $this->pdo = $optiondao->connect();
+    }
+
+    public function tearDown() {
+        parent::tearDown();
+        $this->logger->close();
+    }
+
+    public function testDAOFactory() {
+        $this->assertIsA(DAOFactory::getDAO('TableStatsDAO'), 'TableStatsMySQLDAO');
+    }
+
+    public function testGetCounts() {
+        $table_stats_daa =  new TableStatsMySQLDAO();
+        // no counts...
+        $counts = $table_stats_daa->getTableRowCounts();
+        foreach($counts as $table) {
+            if($table['table'] == $this->table_prefix . 'options') {
+                $this->assertEqual($table['count'], 1);
+            } else if($table['table'] == $this->table_prefix . 'plugins') {
+                $this->assertEqual($table['count'], 3);
+            } else {
+                $this->assertEqual($table['count'], 0);
+            }
+        }
+
+        // are we sorted by count desc?
+        $this->assertEqual(3,$counts[0]['count']);
+        $this->assertEqual(1,$counts[1]['count']);
+        $this->assertEqual(0,$counts[2]['count']);
+
+    }
+
+}

--- a/tests/TestOfUpgradeController.php
+++ b/tests/TestOfUpgradeController.php
@@ -115,6 +115,34 @@ class TestOfUpgradeController extends ThinkUpUnitTestCase {
         $this->assertEqual(file_get_contents($this->test_migrations[1]), $queries[0]['sql']);
     }
 
+    public function testDatabaseMigrationNeededHighTableCount() {
+        // create test migration sql
+        $this->migrationFiles(1);
+
+        // table row counts are good
+        $this->simulateLogin('me@example.com', true);
+        $controller = new UpgradeController(true);
+        $results = $controller->go();
+        $this->assertPattern('/needs 1 database update/', $results);
+        $v_mgr = $controller->getViewManager();
+        $this->assertNull($v_mgr->getTemplateDataItem('high_table_row_count') ) ;
+
+        // table row counts are bad
+        $old_count = UpgradeController::$WARN_TABLE_ROW_COUNT;
+        UpgradeController::$WARN_TABLE_ROW_COUNT = 2;
+        $this->simulateLogin('me@example.com', true);
+        $controller = new UpgradeController(true);
+        $results = $controller->go();
+        $this->assertPattern('/We recommend that you use the.*Command Line Upgrade Tool.*when upgrading Thinkup/sm', 
+        $results);
+        $this->assertPattern('/needs 1 database update/', $results);
+        $v_mgr = $controller->getViewManager();
+        $table_counts = $v_mgr->getTemplateDataItem('high_table_row_count');
+        $this->assertNotNull($table_counts);
+        $this->assertNotNull(3, $table_counts['count']); // tu_plugins, defaults to three
+        UpgradeController::$WARN_TABLE_ROW_COUNT = $old_count;
+    }
+
     public function testGetMigrationList() {
         $this->simulateLogin('me@example.com', true);
         $controller = new UpgradeController(true);

--- a/tests/all_model_tests.php
+++ b/tests/all_model_tests.php
@@ -80,6 +80,7 @@ $model_tests->add(new TestOfMentionMySQLDAO());
 $model_tests->add(new TestOfPlaceMySQLDAO());
 $model_tests->add(new TestOfPDODAO());
 $model_tests->add(new TestOfURLProcessor());
+$model_tests->add(new TestOfTableStatsMySQLDAO());
 
 $tr = new TextReporter();
 $model_tests->run( $tr );

--- a/webapp/_lib/controller/class.BackupController.php
+++ b/webapp/_lib/controller/class.BackupController.php
@@ -50,6 +50,12 @@ class BackupController extends ThinkUpAdminController {
         if (! self::checkForZipSupport()) {
             $this->addToView('no_zip_support', true);
         }
+        // pass the count of the table with  the most records
+        $table_stats_dao = DAOFactory::getDAO('TableStatsDAO');
+        $table_counts = $table_stats_dao->getTableRowCounts();
+        if($table_counts[0]['count'] > UpgradeController::$WARN_TABLE_ROW_COUNT) {
+            $this->addToView('high_table_row_count',$table_counts[0]);
+        }
         try {
             $backup_dao = DAOFactory::getDAO('BackupDAO');
             if (isset($_GET['backup'])) {

--- a/webapp/_lib/controller/class.UpgradeController.php
+++ b/webapp/_lib/controller/class.UpgradeController.php
@@ -66,6 +66,11 @@ class UpgradeController extends ThinkUpAuthController {
     const TOKEN_KEY = 'a_token_key';
 
     /**
+     * max table rows before we warn users to use the CLI upgrade interface
+     */
+    static $WARN_TABLE_ROW_COUNT = 250000;
+
+    /**
      * Constructor
      * @param bool $session_started
      * @return UpgradeController
@@ -141,6 +146,13 @@ class UpgradeController extends ThinkUpAuthController {
                     }
                     $this->addToView('version_updated', true);
                     $this->deleteTokenFile();
+                } else {
+                    // pass the count of the table with  the most records
+                    $table_stats_dao = DAOFactory::getDAO('TableStatsDAO');
+                    $table_counts = $table_stats_dao->getTableRowCounts();
+                    if($table_counts[0]['count'] > self::$WARN_TABLE_ROW_COUNT) {
+                        $this->addToView('high_table_row_count',$table_counts[0]);
+                    }
                 }
             }
         }

--- a/webapp/_lib/model/class.DAOFactory.php
+++ b/webapp/_lib/model/class.DAOFactory.php
@@ -155,7 +155,11 @@ class DAOFactory {
     //Mutex MySQL DAO
         'MutexDAO' => array (
     //MySQL Version
-            'mysql' => 'MutexMySQLDAO')
+            'mysql' => 'MutexMySQLDAO'),
+    //TableStats MySQL DAO
+        'TableStatsDAO' => array (
+    //MySQL Version
+            'mysql' => 'TableStatsMySQLDAO')
     );
 
     /*

--- a/webapp/_lib/model/class.TableStatsMySQLDAO.php
+++ b/webapp/_lib/model/class.TableStatsMySQLDAO.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ *
+ * ThinkUp/webapp/_lib/model/class.TableStatsMySQLDAO.php
+ *
+ * Copyright (c) 2009-2011 Mark Wilkie
+ *
+ * LICENSE:
+ *
+ * This file is part of ThinkUp (http://thinkupapp.com).
+ *
+ * ThinkUp is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * ThinkUp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with ThinkUp.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2009-2011 Mark Wilkie, Gina Trapani
+ * @author Mark Wilkie <mwilkie[at]gmail[dot]com>
+ */
+class TableStatsMySQLDAO extends PDODAO implements TableStatsDAO {
+
+    public function getTableRowCounts() {
+        $q = "show tables";
+        $stmt = $this->execute($q);
+        $data = $this->getDataRowsAsArrays($stmt);
+        $counts = array();
+        foreach($data as $table) {
+            foreach($table as $key => $value) {
+                $q = "SELECT count(*) AS count FROM $value";
+                $stmt = $this->execute($q);
+                $data = $this->getDataRowsAsArrays($stmt);
+                $counts[] = array('table' => $value, 'count' => $data[0]['count']);
+            }
+        }
+        usort($counts, 'tableCountSort');
+        return $counts;
+    }
+}
+
+// for our count sort by count desc
+function tableCountSort($a,$b) {
+    return $a['count'] < $b['count'];
+}

--- a/webapp/_lib/model/interface.OptionDAO.php
+++ b/webapp/_lib/model/interface.OptionDAO.php
@@ -21,8 +21,6 @@
  * <http://www.gnu.org/licenses/>.
  *
  *
- * Option Data Access Object interface
- *
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2011 Mark Wilkie, Gina Trapani
  * @author Mark Wilkie <mwilkie[at]gmail[dot]com>

--- a/webapp/_lib/model/interface.TableStatsDAO.php
+++ b/webapp/_lib/model/interface.TableStatsDAO.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ *
+ * ThinkUp/webapp/_lib/model/interface.TableStatsDAO.php
+ *
+ * Copyright (c) 2009-2011 Mark Wilkie
+ *
+ * LICENSE:
+ *
+ * This file is part of ThinkUp (http://thinkupapp.com).
+ *
+ * ThinkUp is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * ThinkUp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with ThinkUp.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Option Data Access Object interface
+ *
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2009-2011 Mark Wilkie, Gina Trapani
+ * @author Mark Wilkie <mwilkie[at]gmail[dot]com>
+ */
+interface TableStatsDAO {
+
+    /**
+     * Get row counts for all tables
+     * @return array List of table row count hashes sorted by count desc
+     */
+    public function getTableRowCounts();
+
+}

--- a/webapp/_lib/view/install.backup.tpl
+++ b/webapp/_lib/view/install.backup.tpl
@@ -21,7 +21,7 @@
     </p>
 </div>
 {else}
- 
+
 <div class="ui-state-highlight ui-corner-all" style="margin-top: 10px; padding: 0.5em 0.7em;"> 
     <p>
         <span class="ui-icon ui-icon-info" style="float: left; margin: 0.3em 0.3em 0pt 0pt;"></span>
@@ -29,6 +29,20 @@
         if it doesn't work, run a mysqldump manually on your ThinkUp server.
     </p>
 </div>
+
+{if $high_table_row_count}
+<!-- too many db records, use CLI interface? -->
+<div class="ui-state-highlight ui-corner-all" style="margin-top: 10px; padding: 0.5em 0.7em;"> 
+    <p>
+        <span class="ui-icon ui-icon-info" style="float: left; margin: 0.3em 0.3em 0pt 0pt;"></span>
+        The table <b>{$high_table_row_count.table}</b> has a row count of 
+        <b>{$high_table_row_count.count|number_format:0:".":","}</b>.
+        We recommend that you use the <a href="http://thinkupapp.com/docs/install/backup.html">
+        <b>Command Line Backup Tool</b></a> when upgrading Thinkup.
+    </p>
+</div>
+<br />
+{/if}
 
 <input type="button" id="login-save" name="Submit" style="margin: 20px 0px 0px 20px;"
 onclick="document.location.href='?backup=true'" 

--- a/webapp/_lib/view/install.upgrade.tpl
+++ b/webapp/_lib/view/install.upgrade.tpl
@@ -10,6 +10,22 @@
     </div>
   </div>
 
+    {if $high_table_row_count}
+    <!-- too many db records, use CLI interface? -->
+    <div id="info-parent" class="ui-state-highlight ui-corner-all" style="margin: 0px 50px 0px 50px; padding: 0.5em 0.7em;">
+        <div id="migration-info">
+           <p>
+            <span class="ui-icon ui-icon-info" style="float: left; margin: 0.3em 0.3em 0pt 0pt;"></span>
+            The table <b>{$high_table_row_count.table}</b> has a row count of 
+            <b>{$high_table_row_count.count|number_format:0:".":","}</b>.
+            We recommend that you use the <a href="http://thinkupapp.com/docs/install/upgrade.html">
+            <b>Command Line Upgrade Tool</b></a> when upgrading Thinkup.
+            </p>
+        </div>
+    </div>
+    <br />
+    {/if}
+
     {if ! $migrations[0]}
     <!-- no upgrade needed -->
      <div class="ui-state-success ui-corner-all" style="margin: 20px 0px; padding: 0.5em 0.7em;">
@@ -39,7 +55,7 @@
     {if $migrations[0]}
     <div class="clearfix">
     <br /><br />
-        <div class="grid_10 prefix_9 left">
+    <div class="grid_10 prefix_9 left">
         <form name="upgrade" method="get" action="" id="upgrade-form" onsubmit="return false;">
         <input id="migration-submit" 
         name="Submit" class="tt-button ui-state-default ui-priority-secondary ui-corner-all" 


### PR DESCRIPTION
- Added TableStatsDOA and tests to glean table row counts
- Added check for high table row counts to upgrade controller
- Warn user of high row counts, and suggest CLI upgrade instead
- Added check for high table row counts to backup controller
- Warn user of high row counts, and suggest CLI backup instead
  Closes #688
