### PR TITLE
Fix uncaught API budget exception in twitter crawler

### DIFF
--- a/webapp/plugins/twitter/model/class.TwitterCrawler.php
+++ b/webapp/plugins/twitter/model/class.TwitterCrawler.php
@@ -824,7 +824,11 @@ class TwitterCrawler {
                 }
                 $args['cursor'] = strval($next_cursor);
 
-                list($cURL_status, $twitter_data) = $this->api->apiRequest($groups, $args);
+                try {
+                    list($cURL_status, $twitter_data) = $this->api->apiRequest($groups, $args);
+                } catch (APICallLimitExceededException $e) {
+                    break;
+                }
 
                 if ($cURL_status > 200) {
                     $continue_fetching = false;

--- a/webapp/plugins/twitter/tests/TestOfTwitterCrawler.php
+++ b/webapp/plugins/twitter/tests/TestOfTwitterCrawler.php
@@ -496,6 +496,23 @@ class TestOfTwitterCrawler extends ThinkUpUnitTestCase {
         $this->assertEqual(count($history['history']), 1);
     }
 
+    public function testFetchInstanceUserGroupsBudget() {
+        self::setUpInstanceUserAnilDash();
+        // set up crawl limit budget
+        $crawl_limit = array('fetchInstanceUserGroups' => array('count' => 2, 'remaining' => 0) );
+        $this->api->setCallerLimits($crawl_limit);
+        $twitter_crawler = new TwitterCrawler($this->instance, $this->api);
+
+        $twitter_crawler->fetchInstanceUserGroups();
+        $group_dao = DAOFactory::getDAO('GroupDAO');
+        $this->assertFalse($group_dao->isGroupInStorage($group = '1234566', 'twitter'), 'group does not exist');
+
+        $group_member_dao = DAOFactory::getDAO('GroupMemberDAO');
+        $this->assertFalse($group_member_dao->isGroupMemberInStorage($user = '36823', $group = '1234566', 'twitter'),
+        'group member does not exists');
+
+    }
+
     public function testUpdateStaleGroupMemberships() {
         self::setUpInstanceUserAnilDash();
         $twitter_crawler = new TwitterCrawler($this->instance, $this->api);


### PR DESCRIPTION
- Catch APICallLimitExceededException for TwitterCrawler->fetchInstanceUserGroups()
  Closes #1061
