### PR TITLE
Fix PHP Notice in all_tests.php

### DIFF
--- a/tests/all_tests.php
+++ b/tests/all_tests.php
@@ -30,7 +30,7 @@ require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/web_tester.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/mock_objects.php';
 
-if (isset($argv) && ($argv[1] == '--usage' || $argv[1] == '-h' || $argv[1] == '-help')) {
+if (isset($argv[1]) && ($argv[1] == '--usage' || $argv[1] == '-h' || $argv[1] == '-help')) {
     echo "ThinkUp test suite runner
 Usage: [environment vars...] php tests/all_tests.php [args...]
 


### PR DESCRIPTION
Fixes a Notice that occurs if no arguments are passed to all_tests.php.
