### PR TITLE
Show git revision instead of version number

### DIFF
--- a/webapp/_lib/view/_footer.tpl
+++ b/webapp/_lib/view/_footer.tpl
@@ -6,7 +6,7 @@
     <div id="ft" role="contentinfo">
     <div id="">
       <p>
-       <a href="http://thinkupapp.com">ThinkUp</a>{if $thinkup_version} beta {$thinkup_version}{/if} | 
+       <a href="http://thinkupapp.com">ThinkUp</a>{if $thinkup_version} {$thinkup_version}{/if} |
        <a href="http://thinkupapp.com/docs/">Documentation</a> 
        | <a href="http://groups.google.com/group/thinkupapp">Mailing List</a> 
        | <a href="http://webchat.freenode.net/?channels=thinkup">IRC Channel</a><br>

--- a/webapp/install/version.php
+++ b/webapp/install/version.php
@@ -26,6 +26,10 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2011 Dwi Widiastuti, Gina Trapani, Guillaume Boudreau
  */
-$THINKUP_VERSION = '0.17';
+if (file_exists(dirname(__FILE__) . '/../../.git')) {
+    $THINKUP_VERSION = 'git ' . shell_exec('git log -1 --pretty=format:%h%d');
+} else {
+    $THINKUP_VERSION = 'beta 0.17';
+}
 $THINKUP_VERSION_REQUIRED['php'] = '5.2';
 $THINKUP_VERSION_REQUIRED['mysql'] = '5';


### PR DESCRIPTION
If running ThinkUp from a git working tree, show the git revision rather
than (usually) incorrect version number.  This should help avoid
confusion seen on the mailing list about what version users are running.
