### PR TITLE
Fix "OauthException class already defined" when trying to activate account

### DIFF
--- a/webapp/plugins/twitter/extlib/twitteroauth/OAuth.php
+++ b/webapp/plugins/twitter/extlib/twitteroauth/OAuth.php
@@ -3,8 +3,10 @@
 
 /* Generic exception class
  */
-class OAuthException extends Exception {
-  // pass
+if (!class_exists('OAuthException')) {
+  class OAuthException extends Exception {
+    // pass
+  }
 }
 
 class OAuthConsumer {


### PR DESCRIPTION
When I first got this running today, I received the above error after clicking on the activate link in the e-mail sent.  This quickie fix allowed me to complete my activation.

This was on OS X Lion, PHP 5.3.6, and MySQL 5.5.15.
