### PR TITLE
issue #505 add app_title_prefix config, change all references

### DIFF
--- a/tests/TestOfRegisterController.php
+++ b/tests/TestOfRegisterController.php
@@ -53,7 +53,7 @@ class TestOfRegisterController extends ThinkUpUnitTestCase {
         $this->assertTrue(isset($controller));
 
         $results = $controller->go();
-        $this->assertTrue(strpos( $results, "Register | ThinkUp") > 0);
+        $this->assertTrue(strpos( $results, "Register | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp") > 0);
     }
 
     public function testAlreadyLoggedIn() {
@@ -70,7 +70,7 @@ class TestOfRegisterController extends ThinkUpUnitTestCase {
 
         $controller = new RegisterController(true);
         $results = $controller->go();
-        $this->assertPattern("/thinkupapp's Dashboard | ThinkUp/", $results);
+        $this->assertPattern(("/thinkupapp's Dashboard | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp/"), $results);
     }
 
     public function testAllMissingFields() {

--- a/tests/TestOfSmartyThinkUp.php
+++ b/tests/TestOfSmartyThinkUp.php
@@ -73,7 +73,7 @@ class TestOfSmartyThinkUp extends ThinkUpBasicUnitTestCase {
         $v_mgr->assign('test_var_1', "Testing, testing, 123");
         $this->assertEqual($v_mgr->getTemplateDataItem('test_var_1'), "Testing, testing, 123");
 
-        $this->assertEqual($v_mgr->getTemplateDataItem('app_title'), 'Testy ThinkUp Custom Application Name');
+        $this->assertEqual($v_mgr->getTemplateDataItem('app_title'), ($cfg->getValue('app_title_prefix')  . 'ThinkUp'));
         $this->assertEqual($v_mgr->getTemplateDataItem('logo_link'), '');
         $this->assertEqual($v_mgr->getTemplateDataItem('site_root_path'), '/my/thinkup/folder/');
         $this->assertEqual($v_mgr->cache_lifetime, 1200);
@@ -100,7 +100,7 @@ class TestOfSmartyThinkUp extends ThinkUpBasicUnitTestCase {
         $cfg_array = array('debug'=>true,
         'site_root_path'=>'/my/thinkup/folder/test',
         'source_root_path'=>'/Users/gina/Sites/thinkup', 
-        'app_title'=>"My ThinkUp", 
+        'app_title_prefix'=>'My ', 
         'cache_pages'=>true, 'cache_lifetime'=>1000);
         $v_mgr = new SmartyThinkUp($cfg_array);
 

--- a/tests/WebTestOfApplicationSettings.php
+++ b/tests/WebTestOfApplicationSettings.php
@@ -54,7 +54,7 @@ class WebTestOfApplicationSettings extends ThinkUpWebTestCase {
 
         //Open registration
         $this->click("Settings");
-        $this->assertTitle("Configure Your Account | ThinkUp");
+        $this->assertTitle("Configure Your Account | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('Logged in as admin: me@example.com');
 
         // NOTE: this uses an ajax call, so we need to set up the post ourselves
@@ -85,7 +85,7 @@ class WebTestOfApplicationSettings extends ThinkUpWebTestCase {
 
         //Open registration bad token
         $this->click("Settings");
-        $this->assertTitle("Configure Your Account | ThinkUp");
+        $this->assertTitle("Configure Your Account | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('Logged in as admin: me@example.com');
 
         // we should have a global js token

--- a/tests/WebTestOfCSRFToken.php
+++ b/tests/WebTestOfCSRFToken.php
@@ -63,7 +63,7 @@ class WebTestOfCSRFToken extends ThinkUpWebTestCase {
 
         //Open setting page
         $this->click("Settings");
-        $this->assertTitle("Configure Your Account | ThinkUp");
+        $this->assertTitle("Configure Your Account | " .  Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('Logged in as admin: me@example.com');
 
         // look for global js token

--- a/tests/WebTestOfChangePassword.php
+++ b/tests/WebTestOfChangePassword.php
@@ -42,12 +42,13 @@ class WebTestOfChangePassword extends ThinkUpWebTestCase {
     }
 
     public function testChangePasswordSuccess() {
+        $cfg = Config::getInstance(;
         $this->get($this->url.'/session/login.php');
         $this->setField('email', 'me@example.com');
         $this->setField('pwd', 'secretpassword');
 
         $this->click("Log In");
-        $this->assertTitle("thinkupapp's Dashboard | ThinkUp");
+        $this->assertTitle("thinkupapp's Dashboard | " . $cfg->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('Logged in as admin: me@example.com');
 
         $this->click("Settings");
@@ -64,7 +65,7 @@ class WebTestOfChangePassword extends ThinkUpWebTestCase {
         $this->setField('pwd', 'secretpassword1');
 
         $this->click("Log In");
-        $this->assertTitle("thinkupapp's Dashboard | ThinkUp");
+        $this->assertTitle("thinkupapp's Dashboard | " . $cfg->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('Logged in as admin: me@example.com');
     }
 
@@ -74,7 +75,7 @@ class WebTestOfChangePassword extends ThinkUpWebTestCase {
         $this->setField('pwd', 'secretpassword');
 
         $this->click("Log In");
-        $this->assertTitle("thinkupapp's Dashboard | ThinkUp");
+        $this->assertTitle("thinkupapp's Dashboard | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('Logged in as admin: me@example.com');
 
         $this->click("Settings");
@@ -92,7 +93,7 @@ class WebTestOfChangePassword extends ThinkUpWebTestCase {
         $this->setField('pwd', 'secretpassword');
 
         $this->click("Log In");
-        $this->assertTitle("thinkupapp's Dashboard | ThinkUp");
+        $this->assertTitle("thinkupapp's Dashboard | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('Logged in as admin: me@example.com');
 
         $this->click("Settings");
@@ -109,7 +110,7 @@ class WebTestOfChangePassword extends ThinkUpWebTestCase {
         $this->setField('pwd', 'secretpassword');
 
         $this->click("Log In");
-        $this->assertTitle("thinkupapp's Dashboard | ThinkUp");
+        $this->assertTitle("thinkupapp's Dashboard | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('Logged in as admin: me@example.com');
 
         $this->click("Settings");
@@ -127,7 +128,7 @@ class WebTestOfChangePassword extends ThinkUpWebTestCase {
         $this->setField('pwd', 'secretpassword');
 
         $this->click("Log In");
-        $this->assertTitle("thinkupapp's Dashboard | ThinkUp");
+        $this->assertTitle("thinkupapp's Dashboard | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('Logged in as admin: me@example.com');
 
         $this->click("Settings");

--- a/tests/WebTestOfCrawlerRun.php
+++ b/tests/WebTestOfCrawlerRun.php
@@ -49,7 +49,7 @@ class WebTestOfCrawlerRun extends ThinkUpWebTestCase {
 
         $this->click("Log In");
 
-        $this->assertTitle("thinkupapp's Dashboard | ThinkUp");
+        $this->assertTitle("thinkupapp's Dashboard | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('Logged in as admin: me@example.com');
         $this->assertText('thinkupapp');
 

--- a/tests/WebTestOfDashboard.php
+++ b/tests/WebTestOfDashboard.php
@@ -49,7 +49,7 @@ class WebTestOfDashboard extends ThinkUpWebTestCase {
         $this->click("Log In");
         //        $this->showSource();
 
-        $this->assertTitle("thinkupapp's Dashboard | ThinkUp");
+        $this->assertTitle("thinkupapp's Dashboard | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('Logged in as admin: me@example.com');
         $this->assertText('thinkupapp');
     }
@@ -73,7 +73,7 @@ class WebTestOfDashboard extends ThinkUpWebTestCase {
 
         //make sure it takes you to posts view
         $this->assertText('No posts to display');
-        $this->assertTitle("thinkupapp on Twitter | ThinkUp");
+        $this->assertTitle("thinkupapp on Twitter | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
 
         //not the login screen
         $this->assertNoText("Password");
@@ -85,10 +85,10 @@ class WebTestOfDashboard extends ThinkUpWebTestCase {
         $this->setField('pwd', 'secretpassword');
 
         $this->click("Log In");
-        $this->assertTitle("thinkupapp's Dashboard | ThinkUp");
+        $this->assertTitle("thinkupapp's Dashboard | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
 
         $this->get($this->url.'/user/index.php?i=thinkupapp&u=ev&n=twitter');
-        $this->assertTitle('User Details: ev | ThinkUp');
+        $this->assertTitle('User Details: ev | ' . ['app_title_prefix'] . 'ThinkUp');
         $this->assertText('Logged in as admin: me@example.com');
         $this->assertText('ev');
 
@@ -102,10 +102,10 @@ class WebTestOfDashboard extends ThinkUpWebTestCase {
         $this->setField('pwd', 'secretpassword');
 
         $this->click("Log In");
-        $this->assertTitle("thinkupapp's Dashboard | ThinkUp");
+        $this->assertTitle("thinkupapp's Dashboard | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
 
         $this->click("Settings");
-        $this->assertTitle('Configure Your Account | ThinkUp');
+        $this->assertTitle('Configure Your Account | ' . ['app_title_prefix'] . 'ThinkUp');
         $this->assertText('Expand URLs');
 
         $this->click("Twitter");
@@ -119,7 +119,7 @@ class WebTestOfDashboard extends ThinkUpWebTestCase {
         $this->setField('pwd', 'secretpassword');
 
         $this->click("Log In");
-        $this->assertTitle("thinkupapp's Dashboard | ThinkUp");
+        $this->assertTitle("thinkupapp's Dashboard | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
 
         $this->get($this->url.'/index.php?v=tweets-all&u=thinkupapp&n=twitter');
         //        $this->showSource();

--- a/tests/WebTestOfDeleteInstance.php
+++ b/tests/WebTestOfDeleteInstance.php
@@ -52,7 +52,7 @@ class WebTestOfDeleteInstance extends ThinkUpWebTestCase {
         $this->setField('pwd', 'secretpassword');
 
         $this->click("Log In");
-        $this->assertTitle("thinkupapp's Dashboard | ThinkUp");
+        $this->assertTitle("thinkupapp's Dashboard | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('Logged in as admin: me@example.com');
 
         $this->click("Settings");

--- a/tests/WebTestOfInstallation.php
+++ b/tests/WebTestOfInstallation.php
@@ -131,7 +131,7 @@ class WebTestOfInstallation extends ThinkUpBasicWebTestCase {
 
         //Visit Settings page and assert content there
         $this->click("Settings");
-        $this->assertTitle('Configure Your Account | ThinkUp');
+        $this->assertTitle('Configure Your Account | ' . Config::getInstance()->getValue('app_title_prefix') . 'ThinkUp');
         $this->assertText('admin');
     }
 

--- a/tests/WebTestOfLogin.php
+++ b/tests/WebTestOfLogin.php
@@ -48,7 +48,7 @@ class WebTestOfLogin extends ThinkUpWebTestCase {
         $this->setField('pwd', 'secretpassword');
         $this->click("Log In");
 
-        $this->assertTitle("thinkupapp's Dashboard | ThinkUp");
+        $this->assertTitle("thinkupapp's Dashboard | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('Logged in as admin: me@example.com');
     }
 
@@ -70,7 +70,7 @@ class WebTestOfLogin extends ThinkUpWebTestCase {
         $this->setField('pwd', 'secretpassword');
         $this->click("Log In");
 
-        $this->assertTitle("thinkupapp's Dashboard | ThinkUp");
+        $this->assertTitle("thinkupapp's Dashboard | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('Logged in as admin: me@example.com');
     }
 

--- a/tests/WebTestOfPostDetailPage.php
+++ b/tests/WebTestOfPostDetailPage.php
@@ -43,8 +43,9 @@ class WebTestOfPostDetailPage extends ThinkUpWebTestCase {
     }
 
     public function testPostPageNotLoggedIn() {
+        $cfg = Config::getInstance();
         $this->get($this->url.'/post/index.php?t=10&n=twitter');
-        $this->assertTitle("Post Details | ThinkUp");
+        $this->assertTitle("Post Details | " . $cfg->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('This is post 10');
         // allow search for non logged in users
         $this->assertPattern('/Search/');
@@ -55,12 +56,13 @@ class WebTestOfPostDetailPage extends ThinkUpWebTestCase {
         $this->assertNoText('GeoEncoder');
 
         $this->click('Retweets');
-        $this->assertTitle("Post Details | ThinkUp");
+        $this->assertTitle("Post Details | " . $cfg->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('This is post 10');
         $this->assertNoText('GeoEncoder');
     }
 
     public function testPostPageLoggedIn() {
+        $cfg = Config::getInstance();
         $this->get($this->url.'/session/login.php');
         $this->setField('email', 'me@example.com');
         $this->setField('pwd', 'secretpassword');
@@ -68,7 +70,7 @@ class WebTestOfPostDetailPage extends ThinkUpWebTestCase {
         $this->click("Log In");
 
         $this->get($this->url.'/post/index.php?t=10&n=twitter');
-        $this->assertTitle("Post Details | ThinkUp");
+        $this->assertTitle("Post Details | " . $cfg->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('This is post 10');
 
         $this->assertField('Go', 'Go');
@@ -77,18 +79,20 @@ class WebTestOfPostDetailPage extends ThinkUpWebTestCase {
         $this->assertNoText('Response Map');
 
         $this->click('Retweets');
-        $this->assertTitle("Post Details | ThinkUp");
+        $this->assertTitle("Post Details | " . $cfg->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('This is post 10');
         $this->assertNoText('Response Map');
     }
 
     public function testPostPageWithGeoencoderEnabled() {
+        $cfg = Config::getInstance();
+
         //enable GeoEncoder plugin
         $builder = FixtureBuilder::build('plugins', array('name'=>'Geoencoder', 'folder_name'=>'geoencoder',
         'is_active'=>1));
 
         $this->get($this->url.'/post/index.php?t=10&n=twitter');
-        $this->assertTitle("Post Details | ThinkUp");
+        $this->assertTitle("Post Details | " . $cfg->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('This is post 10');
         $this->assertPattern('/Search/'); // we now allow search for non logged in users...
         $this->assertText('Retweets');
@@ -96,7 +100,7 @@ class WebTestOfPostDetailPage extends ThinkUpWebTestCase {
         $this->assertText('Nearest Replies');
 
         $this->click('Nearest replies');
-        $this->assertTitle("Post Details | ThinkUp");
+        $this->assertTitle("Post Details | " . $cfg->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('This is post 10');
     }
 

--- a/tests/WebTestOfTwitterDashboard.php
+++ b/tests/WebTestOfTwitterDashboard.php
@@ -70,14 +70,14 @@ class WebTestOfTwitterDashboard extends ThinkUpWebTestCase {
 
         $this->click("Log In");
 
-        $this->assertTitle("thinkupapp's Dashboard | ThinkUp");
+        $this->assertTitle("thinkupapp's Dashboard | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('Logged in as admin: me@example.com');
         $this->assertText('thinkupapp');
     }
 
     public function testAllTweets() {
         $this->get($this->url.'/index.php?v=tweets-all&u=ev&n=twitter');
-        $this->assertTitle("ev on Twitter | ThinkUp");
+        $this->assertTitle("ev on Twitter | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('This is post 39');
         $this->assertText('This is post 38');
         $this->assertText('This is post 37');
@@ -86,7 +86,7 @@ class WebTestOfTwitterDashboard extends ThinkUpWebTestCase {
 
     public function testLinksFromFriends() {
         $this->get($this->url.'/index.php?v=links-friends&u=ev&n=twitter');
-        $this->assertTitle("ev on Twitter | ThinkUp");
+        $this->assertTitle("ev on Twitter | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         //$this->showSource();
         $this->assertText('This is link post 25');
         $this->assertText('Link 25');
@@ -102,7 +102,7 @@ class WebTestOfTwitterDashboard extends ThinkUpWebTestCase {
         $this->click("Log In");
 
         $this->get($this->url.'/index.php?v=links-friends&u=ev&n=twitter');
-        $this->assertTitle("ev on Twitter | ThinkUp");
+        $this->assertTitle("ev on Twitter | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         //$this->showSource();
         $this->assertText('This is link post 39');
         $this->assertText('Link 39');
@@ -112,7 +112,7 @@ class WebTestOfTwitterDashboard extends ThinkUpWebTestCase {
 
     public function testPhotosByFriends() {
         $this->get($this->url.'/index.php?v=links-photos&u=ev&n=twitter');
-        $this->assertTitle("ev on Twitter | ThinkUp");
+        $this->assertTitle("ev on Twitter | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('This is image post 25');
         //not logged in, shouldn't display private image post
         $this->assertNoText('This is private image post 1');
@@ -126,7 +126,7 @@ class WebTestOfTwitterDashboard extends ThinkUpWebTestCase {
         $this->click("Log In");
 
         $this->get($this->url.'/index.php?v=links-photos&u=ev&n=twitter');
-        $this->assertTitle("ev on Twitter | ThinkUp");
+        $this->assertTitle("ev on Twitter | " . Config::getInstance()->getValue('app_title_prefix') . "ThinkUp");
         $this->assertText('This is image post 39');
         //logged in, should display private image post
         $this->assertText('This is private image post 1');

--- a/tests/WebTestOfUpgradeDatabase.php
+++ b/tests/WebTestOfUpgradeDatabase.php
@@ -254,7 +254,8 @@ class WebTestOfUpgradeDatabase extends ThinkUpBasicWebTestCase {
             $this->click("Configuration");
             $this->debug("Clicked Configuration");
         }
-        $this->assertTitle('Configure Your Account | ThinkUp');
+        $config = Config::getInstance();
+        $this->assertTitle('Configure Your Account | ' . $config->getValue('app_title_prefix') . 'ThinkUp');
         $this->assertText('admin');
 
         // run updates and migrations
@@ -263,7 +264,6 @@ class WebTestOfUpgradeDatabase extends ThinkUpBasicWebTestCase {
         // build latest  version for testing
         $migration_sql_dir = THINKUP_ROOT_PATH . 'webapp/install/sql/mysql_migrations/';
         $latest_migration_file = false;
-        $config = Config::getInstance();
 
         $current_version = $config->getValue('THINKUP_VERSION');
         $latest_migration = glob($migration_sql_dir . '*_v' . $LATEST_VERSION .'.sql.migration');

--- a/webapp/_lib/model/class.Config.php
+++ b/webapp/_lib/model/class.Config.php
@@ -52,6 +52,13 @@ class Config {
      * @var array
      */
     var $config = array();
+
+    /**
+     *
+     * @var array some reasonable defaults if null in config
+     */
+    protected static $defaults = array('app_title_prefix' => '');
+
     /**
      * Private Constructor
      * @param array $vals Optional values to override file config
@@ -74,6 +81,11 @@ class Config {
                 throw new Exception('ThinkUp\'s configuration file does not exist! Try <a href="'.THINKUP_BASE_URL.
                 'install/">installing ThinkUp.</a>');
             }
+        }
+        foreach (array_keys(self::$defaults) as $default) {
+          if (!isset($this->config[$default])) {
+            $this->config[$default] = self::$defaults[$default];
+          }
         }
     }
     /**

--- a/webapp/_lib/model/class.SmartyThinkUp.php
+++ b/webapp/_lib/model/class.SmartyThinkUp.php
@@ -95,7 +95,7 @@ class SmartyThinkUp extends Smarty {
 
         $src_root_path = $config_array['source_root_path'];
         $site_root_path = $config_array['site_root_path'];
-        $app_title = $config_array['app_title'];
+        $app_title = $config_array['app_title_prefix'] . 'ThinkUp';
         $cache_pages = $config_array['cache_pages'];
         $cache_lifetime = isset($config_array['cache_lifetime'])?$config_array['cache_lifetime']:600;
         $debug =  $config_array['debug'];

--- a/webapp/config.sample.inc.php
+++ b/webapp/config.sample.inc.php
@@ -3,8 +3,8 @@
 /***  APPLICATION CONFIG                      ***/
 /************************************************/
 
-// Application title
-$THINKUP_CFG['app_title']                 = 'ThinkUp';
+// Application title prefix - 'ThinkUp' will be appended to it in page titles
+$THINKUP_CFG['app_title_prefix']                 = '';
 
 // Public path of thinkup's /webapp/ folder on your web server.
 // For example, if the /webapp/ folder is located at http://yourdomain/thinkup/, set to '/thinkup/'.


### PR DESCRIPTION
replaces $THINKUP_CFG['app_title'] with $THINKUP_CFG['app_title_prefix'] and references in tests.
Smarty keeps 'app_title' variable which now accounts for the prefix.
