### PR TITLE
Strip tags in post text to fix social buttons

### DIFF
--- a/webapp/_lib/view/_header.tpl
+++ b/webapp/_lib/view/_header.tpl
@@ -85,7 +85,7 @@
 
 {if $post->post_text} 
 <meta itemprop="name" content="{$post->network|ucwords} post by {$post->author_username} on ThinkUp">
-<meta itemprop="description" content="{$post->post_text}">
+<meta itemprop="description" content="{$post->post_text|strip_tags}">
 <meta itemprop="image" content="http://thinkupapp.com/assets/img/thinkup-logo_sq.png">
 {/if}
 </head>

--- a/webapp/_lib/view/post.index.tpl
+++ b/webapp/_lib/view/post.index.tpl
@@ -74,7 +74,7 @@ thisfield.value = defaulttext;
 
    <a href="https://twitter.com/share" class="twitter-share-button"
       data-via="thinkupapp"
-      data-text="{$post->post_text}"
+      data-text="{$post->post_text|strip_tags}"
       data-related="thinkupapp,expertlabs,ginatrapani"
       data-count="none">Tweet</a>
 {literal}


### PR DESCRIPTION
The problem was both in the Tweet button and in the meta description.
