### PR TITLE
Make RSS crawler refresh apply to each owner

### DIFF
--- a/webapp/_lib/controller/class.RSSController.php
+++ b/webapp/_lib/controller/class.RSSController.php
@@ -52,11 +52,13 @@ class RSSController extends ThinkUpAuthAPIController {
 
         $crawler_launched = false;
         $instance_dao = DAOFactory::getDAO('InstanceDAO');
-        $freshest_instance = $instance_dao->getInstanceFreshestOne();
-        $crawler_last_run = strtotime($freshest_instance->crawler_last_run);
-        if ($crawler_last_run < time() - $rss_crawler_refresh_rate*60) {
-            $email = $this->getLoggedInUser();
-            $owner = parent::getOwner($email);
+        $email = $this->getLoggedInUser();
+        $owner = parent::getOwner($email);
+        $freshest_instance = $instance_dao->getFreshestByOwnerId($owner->id);
+        if ($freshest_instance) {
+            $crawler_last_run = strtotime($freshest_instance->crawler_last_run);
+        }
+        if ($freshest_instance && $crawler_last_run < time() - $rss_crawler_refresh_rate*60) {
             $crawler_run_url = $base_url.'run.php?'.sprintf('un=%s&as=%s', $email, $owner->api_key);
             $ch = curl_init();
             curl_setopt($ch, CURLOPT_URL, $crawler_run_url);


### PR DESCRIPTION
Make the RSS crawler refresh rate apply to each owner instead of being
system-wide.  Previously, it was possible for some instances to never be
crawled if another owner's crawler always ran before it.  Now, when
checking for stale instances that need to be crawled, only look at the
current user's instances rather than all of them.
