### PR TITLE
Fixed ThinkUp download link on upgrade document

### DIFF
--- a/docs/source/install/upgrade.rst
+++ b/docs/source/install/upgrade.rst
@@ -12,7 +12,7 @@ To upgrade ThinkUp, you'll need to update your installation's application code a
 Update ThinkUp's Application Code
 ---------------------------------
 
-First, `download ThinkUp's latest release <http://thinkupapp.com/downloads/>`_ and extract the zip archive on your
+First, `download ThinkUp's latest release <http://thinkupapp.com/download/>`_ and extract the zip archive on your
 computer.  Then, log into your ThinkUp installation as an administrator. 
 
 Using your favorite FTP program, connect to your web hosting provider, and rename your existing ThinkUp folder to


### PR DESCRIPTION
Fixed the download link from http://thinkupapp.com/downloads/ to http://thinkupapp.com/download/ 
