### PR TITLE
General error: 1032 Can't find record in 'tu_posts' when no posts is retrieved.

### DIFF
--- a/webapp/_lib/model/class.PostMySQLDAO.php
+++ b/webapp/_lib/model/class.PostMySQLDAO.php
@@ -811,6 +811,7 @@ class PostMySQLDAO extends PDODAO implements PostDAO  {
         $q .= $protected;
         $q .= " AND in_reply_to_post_id IS NULL ";
         $q .= " AND p.in_reply_to_user_id = :user_id ";
+        $q .= " OR p.author_user_id = :user_id ";
         $q .= "ORDER BY p.id DESC ";
         $q .= "LIMIT :start_on_record, :limit";
         $vars = array(


### PR DESCRIPTION
Hello

Was attempting to retrieve posts related to some facebook pages, like http://mydomain.com/?u=Name+of+Facebook+Page&n=facebook+page, and have to face the intermittent "General error: 1032 Can't find record in 'tu_posts'" messages. Therefore, I added another SQL statement to fix it.

Cheers,
Brennan
