### PR TITLE
Fix Twitter plugin error handling

### DIFF
--- a/webapp/plugins/twitter/model/class.TwitterAPIAccessorOAuth.php
+++ b/webapp/plugins/twitter/model/class.TwitterAPIAccessorOAuth.php
@@ -214,7 +214,7 @@ class TwitterAPIAccessorOAuth {
         $parsed_payload = array();
         try {
             $xml = $this->createParserFromString(utf8_encode($data));
-            if ($xml != false) {
+            if ($xml !== false) {
                 $root = $xml->getName();
                 switch ($root) {
                     case 'hash':
@@ -250,7 +250,7 @@ class TwitterAPIAccessorOAuth {
         $parsed_payload = array();
         try {
             $xml = $this->createParserFromString(utf8_encode($data));
-            if ($xml != false) {
+            if ($xml !== false) {
                 $root = $xml->getName();
                 switch ($root) {
                     case 'user':


### PR DESCRIPTION
As described in https://groups.google.com/forum/?fromgroups#!topic/thinkupapp/xJZ7wAyo-xg, fix for "Undefined index:  error in /path/to/thinkup/plugins/twitter/model/class.TwitterCrawler.php on line 342 ... Column 'error_text' cannot be null"

In PHP, != and !== are two different operators, correct flaw in parsing error message XML.
