### PR TITLE
Fixes #1302 - undefined variable resultset

### DIFF
--- a/webapp/_lib/model/class.GroupMembershipCountMySQLDAO.php
+++ b/webapp/_lib/model/class.GroupMembershipCountMySQLDAO.php
@@ -88,6 +88,7 @@ class GroupMembershipCountMySQLDAO extends PDODAO implements GroupMembershipCoun
         $ps = $this->execute($q, $vars);
         $history_rows = $this->getDataRowsAsArrays($ps);
 
+        $resultset = array();
         foreach ($history_rows as $row) {
             $timestamp = strtotime($row['full_date']);
             $resultset[] = array('c' => array(


### PR DESCRIPTION
One-line fix that was dumping warnings at the top of the page on first visit.
