### PR TITLE
Click Stats charting functionality needs conditional logic to avoid trying to chart null table data.

### DIFF
--- a/webapp/_lib/view/dashboard.tpl
+++ b/webapp/_lib/view/dashboard.tpl
@@ -253,7 +253,10 @@
                       }
                   });
                   hot_posts_chart.draw();
+                  {/literal}
 
+                  {if $click_stats_data}
+                  {literal}
                   formatter.format(click_stats_data, 1);
                   var click_stats_chart = new google.visualization.ChartWrapper({
                       containerId: 'click_stats',
@@ -278,7 +281,10 @@
                       }
                   });
                   click_stats_chart.draw();
-
+                  {/literal}
+                  {/if}
+                  
+                  {literal}
                   formatter.format(follower_count_history_by_day_data, 1);
                   formatter_date.format(follower_count_history_by_day_data, 0);
 


### PR DESCRIPTION
Wrap the click stats chart code in a conditional statement that ensures the code isn't trying to create a chart object from null table data. The fix was provided by @anildash via http://groups.google.com/group/thinkupapp/msg/7fa6d1db5e55e9cb on the Thinkup list.
