### PR TITLE
A correction to the 'isAccountPage' function

### DIFF
--- a/webapp/plugins/facebook/controller/class.FacebookPluginConfigurationController.php
+++ b/webapp/plugins/facebook/controller/class.FacebookPluginConfigurationController.php
@@ -86,7 +86,9 @@ class FacebookPluginConfigurationController extends PluginConfigurationControlle
 
     public function isAccountPage($account_id, $access_token) {
         $account = FacebookGraphAPIAccessor::apiRequest('/' . $account_id . '?metadata=true', $access_token);
-        return !empty($account) && !empty($account->type) && $account->type == 'page';
+        return !empty($account) &&
+                ((!empty($account->type)  && (strcmp($account->type, 'page')==0)) ||
+                 (!empty($account->metadata->type) && (strcmp($account->metadata->type, 'page')==0)));
     }
 
     protected function setUpFacebookInteractions($options) {


### PR DESCRIPTION
Hello, we are working in a research project (SOCIALMEDIA PROJECT, http://www.cenitsocialmedia.es/) which uses thinkUp. During our work we have found a little bug in your code, and we have also found a possible solution for it.

The return value of the isAccoutPage function seems to be wrong. The 'type' attribute belongs to the account metadata.

With this new conditional expression, both places are evaluated, and if in any one the attribute is present and the value is 'page', then the return value is true.

DISCLAIMER: SOCIALMEDIA PROJECT - CEN-20101037 - This contribution has been kindly sponsored by the Centro para el Desarrollo Tecnológico Industrial within the Programa de Investigación Nacional Español CENIT. - http://www.cenitsocialmedia.es/
