### PR TITLE
launchd cron config Mac OS X

### DIFF
--- a/extras/maccron/com.thinkupapp.plst
+++ b/extras/maccron/com.thinkupapp.plst
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.thinkupapp</string>
+  <key>UserName</key>
+  <string>youruser</string>
+  <!-- User to run cron as -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/local/bin/php</string>
+    <!-- Full path to PHP excecutable -->
+    <string>/path/to/thinkup/crawler/crawl.php</string>
+    <!-- Full path to thinkup crawler -->
+    <string>user@example.com</string>
+    <!-- Admin username -->
+    <string>myPassword</string>
+    <!-- Admin password -->
+  </array>
+  <key>KeepAlive</key>
+  <dict>
+    <key>NetworkState</key>
+    <true/>
+  </dict>
+  <!-- Does not run the deamon when not connected to the internet -->
+  <key>WorkingDirectory</key>
+  <string>/path/to/thinkup/</string>
+  <!-- Path to thinkup working directory -->
+  <key>Nice</key>
+  <integer>10</integer>
+  <!-- 
+    Nice level to run crawler at 
+    20 is lowest priority
+    -20 is highest priority
+    0 is default
+  -->
+  <key>StartInterval</key>
+  <integer>600</integer>
+  <!-- Time interval in seconds between runs -->
+  <key>Debug</key>
+  <false/>
+  <key>AbandonProcessGroup</key>
+  <true/>
+</dict>
+</plist>

--- a/extras/maccron/readme.md
+++ b/extras/maccron/readme.md
@@ -1,0 +1,11 @@
+# Mac OS X cron script
+
+This is a simple configuration file for setting up crons with the [launchd deamon in Mac OS X](https://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man8/launchd.8.html). The config as currently set up will log directly to the system log.
+
+## Installation
+- Edit the com.thinkupapp.plst in this directory according to commenting
+- Copy com.thinkupapp.plst into /System/Library/LaunchAgents/ to make the job load on system boot
+- Run "launchctl load /system/Library/LaunchAgents/com.thinkupapp.plst" to load the job
+
+## Limitations
+- May not be able to run properly as arbitrary user.


### PR DESCRIPTION
As the standard cron deamon apparently is deprecated in newer versions of Mac OS X, I took the liberty to write a configuration to run the cron jobs using the launchd deamon in Mac OS X.
