### PR TITLE
Added date ranges for some API calls

### DIFF
--- a/docs/source/userguide/api/posts/post_replies_in_range.rst
+++ b/docs/source/userguide/api/posts/post_replies_in_range.rst
@@ -1,0 +1,223 @@
+Post Replies
+============
+Gets the replies to a post in a given time range.
+
+**API call type slug:** ``post_replies_in_range``
+
+**Example Usage:** ``api/v1/post.php?type=post_replies_in_range&from=29-03-2011&until=04-04-2011&post_id=12345``
+
+==================
+Required arguments
+==================
+
+* **post_id**
+
+    The ID of the post to retrieve replies to.
+
+* **from**
+
+    The date/time to start searching from. This can either be a
+    `valid date string <http://www.php.net/manual/en/datetime.formats.php>`_ or a Unix timestamp.
+
+* **until**
+
+    The date/time to search until. This can either be a
+    `valid date string <http://www.php.net/manual/en/datetime.formats.php>`_ or a Unix timestamp.
+
+==================
+Optional Arguments
+==================
+
+* **network**
+
+    The network to use in the call. Defaults to 'twitter'.
+
+* **order_by**
+
+    The column to order the results by. Defaults to chronological order ("date"). The default direction to order
+    results from this call are descending.
+
+* **unit**
+
+    Sets the unit of measurement to return the ``reply_retweet_distance`` in. Can be either "mi" for miles or "km"
+    for kilometres. Defaults to "km".
+
+* **include_entities**
+
+    Whether or not to include `Tweet Entities <http://dev.twitter.com/pages/tweet_entities>`_ in the output. Defaults
+    to false. This argument can be set to true by making it equal to either **1**, **t** or **true**.
+
+* **include_replies**
+
+    Whether or not to include replies to this post in the output. This argument is recursive and will retrieve replies
+    to replies also. Defaults to false. This argument can be set to true by making it equal to either **1**, **t** or
+    **true**.
+
+* **trim_user**
+
+    If set to true, this flag strips the user part of the output to just the user's ID and nothing else. Defaults to
+    false. This argument can be set to true by making it equal to either **1**, **t** or **true**.
+
+.. warning::
+    The method 'post_replies_in_range', along with user_replies_in_range, user_questions_in_range, 
+    user_mentions_in_range and user_posts_in_range are the ThinkUp Post API methods which do not enforce a cap of 
+    200 post results returned per call. 
+    As such, when querying time ranges which contain more than 200 posts, keep in mind that processing that amount of
+    data may exceed your server's memory limits. 
+
+==============
+Example output
+==============
+
+``/api/v1/post.php?type=post_replies_in_range&post_id=242576686674223106&from=2012-09-03T11:00:00GMT+02:00&until=2012-09-03T017:00:00%20GMT+02:00&include_entities=t&include_replies=t``::
+
+
+
+[
+    {
+        "id":242578744764690432,
+        "author_follower_count":null,
+        "source":"web",
+        "location":"Tordera-Barcelona",
+        "place":null,
+        "place_id":null,
+        "geo":null,
+        "in_reply_to_user_id":227641758,
+        "in_reply_to_post_id":242576686674223106,
+        "is_reply_by_friend":false,
+        "is_retweet_by_friend":false,
+        "reply_retweet_distance":0,
+        "in_rt_of_user_id":null,
+        "retweet_count_api":0,
+        "favlike_count_cache":0,
+        "links":[
+            
+        ],
+        "favorited":false,
+        "all_retweets":0,
+        "text":"@penia19 #fcb",
+        "created_at":"Mon Sep 03 11:04:14 +0200 2012",
+        "annotations":null,
+        "truncated":false,
+        "protected":false,
+        "thinkup":{
+            "retweet_count_cache":0,
+            "retweet_count_api":0,
+            "reply_count_cache":0,
+            "old_retweet_count_cache":0,
+            "is_geo_encoded":0
+        },
+        "user":{
+            "id":256559225,
+            "location":"Tordera-Barcelona",
+            "description":"Llicenciada en Ci\u00e8ncies Pol\u00edtiques i de l'Administraci\u00f3, a la Universtat Pompeu Fabra. Membre de la JNC, Deba-t i R\u00e0dio Tordera",
+            "url":"",
+            "friend_count":520,
+            "last_updated":"2012-09-03 13:23:58",
+            "followers_count":283,
+            "profile_image_url":"http://a0.twimg.com/profile_images/2169909420/ji_normal.jpg",
+            "name":"Judith",
+            "screen_name":"judithtoronjo",
+            "statuses_count":585,
+            "created_at":"Wed Feb 23 15:58:39 +0100 2011",
+            "avg_tweets_per_day":1.05,
+            "thinkup":{
+                "last_post":"0000-00-00 00:00:00",
+                "last_post_id":"",
+                "found_in":"mentions"
+            }
+        },
+        "entities":{
+            "hashtags":[
+                {
+                    "text":"fcb",
+                    "indices":[
+                        9,
+                        13
+                    ]
+                }
+            ],
+            "user_mentions":[
+                {
+                    "name":"Daniel Pe\u00f1a Pizarro",
+                    "id":227641758,
+                    "screen_name":"penia19",
+                    "indices":[
+                        0,
+                        8
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "id":242579576025403392,
+        "author_follower_count":null,
+        "source":"web",
+        "location":"Barcelona",
+        "place":null,
+        "place_id":null,
+        "geo":null,
+        "in_reply_to_user_id":227641758,
+        "in_reply_to_post_id":242576686674223106,
+        "is_reply_by_friend":false,
+        "is_retweet_by_friend":false,
+        "reply_retweet_distance":0,
+        "in_rt_of_user_id":null,
+        "retweet_count_api":0,
+        "favlike_count_cache":0,
+        "links":[
+            
+        ],
+        "favorited":false,
+        "all_retweets":0,
+        "text":"@penia19 me too!",
+        "created_at":"Mon Sep 03 11:07:32 +0200 2012",
+        "annotations":null,
+        "truncated":false,
+        "protected":false,
+        "thinkup":{
+            "retweet_count_cache":0,
+            "retweet_count_api":0,
+            "reply_count_cache":0,
+            "old_retweet_count_cache":0,
+            "is_geo_encoded":0
+        },
+        "user":{
+            "id":302708860,
+            "location":"Barcelona",
+            "description":"Research Project Manager @ TVC - I never think of the future. It comes soon enough. Albert Einstein\n",
+            "url":"http://es.linkedin.com/in/eusebiocarasusan",
+            "friend_count":247,
+            "last_updated":"2012-09-03 13:23:58",
+            "followers_count":113,
+            "profile_image_url":"http://a0.twimg.com/profile_images/2432460341/810fonvgxd8c9z65pgdi_normal.jpeg",
+            "name":"Eusebio Carasus\u00e1n",
+            "screen_name":"ecarasusan",
+            "statuses_count":417,
+            "created_at":"Sat May 21 16:40:17 +0200 2011",
+            "avg_tweets_per_day":0.89,
+            "thinkup":{
+                "last_post":"2012-08-23 17:51:19",
+                "last_post_id":"",
+                "found_in":"mentions"
+            }
+        },
+        "entities":{
+            "hashtags":[
+                
+            ],
+            "user_mentions":[
+                {
+                    "name":"Daniel Pe\u00f1a Pizarro",
+                    "id":227641758,
+                    "screen_name":"penia19",
+                    "indices":[
+                        0,
+                        8
+                    ]
+                }
+            ]
+        }
+    }
+]    

--- a/docs/source/userguide/api/posts/user_mentions_in_range.rst
+++ b/docs/source/userguide/api/posts/user_mentions_in_range.rst
@@ -1,0 +1,518 @@
+User Mentions
+=============
+Gets posts that a user is mentioned in a given time range.
+
+**API call type slug:** ``user_mentions_in_range``
+
+**Example Usage:** ``api/v1/post.php?type=user_mentions_in_range&from=29-03-2011&until=04-04-2011&username=samwhoo``
+
+==================
+Required arguments
+==================
+
+* **user_id** or **username**
+
+    Only one of these is required. They are to specify the user to gather posts for in this call.
+
+* **from**
+
+    The date/time to start searching from. This can either be a
+    `valid date string <http://www.php.net/manual/en/datetime.formats.php>`_ or a Unix timestamp.
+
+* **until**
+
+    The date/time to search until. This can either be a
+    `valid date string <http://www.php.net/manual/en/datetime.formats.php>`_ or a Unix timestamp.
+    
+    
+==================
+Optional Arguments
+==================
+
+* **network**
+
+    The network to use in the call. Defaults to 'twitter'.
+
+* **order_by**
+
+    The column to order the results by. Defaults to chronological order ("date").
+
+* **direction**
+
+    The direction to order the results in. Can be either DESC or ASC. Defaults to DESC.
+
+* **include_rts**
+
+    Whether or not to include retweets as mentions. Defaults to false. This argument can be set to true by making it
+    equal to either **1**, **t** or **true**.
+
+* **include_entities**
+
+    Whether or not to include `Tweet Entities <http://dev.twitter.com/pages/tweet_entities>`_ in the output. Defaults
+    to false. This argument can be set to true by making it equal to either **1**, **t** or **true**.
+
+* **include_replies**
+
+    Whether or not to include replies to this post in the output. This argument is recursive and will retrieve replies
+    to replies also. Defaults to false. This argument can be set to true by making it equal to either **1**, **t** or
+    **true**.
+
+* **trim_user**
+
+    If set to true, this flag strips the user part of the output to just the user's ID and nothing else. Defaults to
+    false. This argument can be set to true by making it equal to either **1**, **t** or **true**.
+
+.. warning::
+    The method 'user_mentions_in_range', along with user_replies_in_range, post_replies_in_range, 
+    user_questions_in_range and user_posts_in_range are the ThinkUp Post API methods which do not enforce a cap of 
+    200 post results returned per call. 
+    As such, when querying time ranges which contain more than 200 posts, keep in mind that processing that amount of
+    data may exceed your server's memory limits.
+ 
+==============
+Example output
+==============
+
+``/api/v1/post.php?type=user_mentions_in_range&username=penia19&from=2012-09-03T11:00:00GMT+02:00&until=2012-09-03T017:00:00%20GMT+02:00&include_entities=t&include_replies=t``::
+    
+[
+    {
+        "id":242580106491596801,
+        "author_follower_count":null,
+        "source":"web",
+        "location":"Barcelona",
+        "place":null,
+        "place_id":null,
+        "geo":null,
+        "in_reply_to_user_id":null,
+        "in_reply_to_post_id":null,
+        "is_reply_by_friend":false,
+        "is_retweet_by_friend":false,
+        "reply_retweet_distance":0,
+        "in_rt_of_user_id":null,
+        "retweet_count_api":0,
+        "favlike_count_cache":0,
+        "links":[
+            
+        ],
+        "favorited":false,
+        "all_retweets":0,
+        "text":"1.500 alojamientos rurales han echado el cierre este a\u00f1o http://t.co/ZxbcJAqt Qu\u00e8 tal per les terres de Lleida @penia19 ?",
+        "created_at":"Mon Sep 03 11:09:38 +0200 2012",
+        "annotations":null,
+        "truncated":false,
+        "protected":false,
+        "thinkup":{
+            "retweet_count_cache":0,
+            "retweet_count_api":0,
+            "reply_count_cache":0,
+            "old_retweet_count_cache":0,
+            "is_geo_encoded":0
+        },
+        "user":{
+            "id":302708860,
+            "location":"Barcelona",
+            "description":"Research Project Manager @ TVC - I never think of the future. It comes soon enough. Albert Einstein\n",
+            "url":"http://es.linkedin.com/in/eusebiocarasusan",
+            "friend_count":247,
+            "last_updated":"2012-09-03 13:23:58",
+            "followers_count":113,
+            "profile_image_url":"http://a0.twimg.com/profile_images/2432460341/810fonvgxd8c9z65pgdi_normal.jpeg",
+            "name":"Eusebio Carasus\u00e1n",
+            "screen_name":"ecarasusan",
+            "statuses_count":417,
+            "created_at":"Sat May 21 16:40:17 +0200 2011",
+            "avg_tweets_per_day":0.89,
+            "thinkup":{
+                "last_post":"2012-08-23 17:51:19",
+                "last_post_id":"",
+                "found_in":"mentions"
+            }
+        },
+        "entities":{
+            "hashtags":[
+                
+            ],
+            "user_mentions":[
+                {
+                    "name":"Daniel Pe\u00f1a Pizarro",
+                    "id":227641758,
+                    "screen_name":"penia19",
+                    "indices":[
+                        113,
+                        121
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "id":242579576025403392,
+        "author_follower_count":null,
+        "source":"web",
+        "location":"Barcelona",
+        "place":null,
+        "place_id":null,
+        "geo":null,
+        "in_reply_to_user_id":227641758,
+        "in_reply_to_post_id":242576686674223106,
+        "is_reply_by_friend":false,
+        "is_retweet_by_friend":false,
+        "reply_retweet_distance":0,
+        "in_rt_of_user_id":null,
+        "retweet_count_api":0,
+        "favlike_count_cache":0,
+        "links":[
+            
+        ],
+        "favorited":false,
+        "all_retweets":0,
+        "text":"@penia19 me too!",
+        "created_at":"Mon Sep 03 11:07:32 +0200 2012",
+        "annotations":null,
+        "truncated":false,
+        "protected":false,
+        "thinkup":{
+            "retweet_count_cache":0,
+            "retweet_count_api":0,
+            "reply_count_cache":0,
+            "old_retweet_count_cache":0,
+            "is_geo_encoded":0
+        },
+        "user":{
+            "id":302708860,
+            "location":"Barcelona",
+            "description":"Research Project Manager @ TVC - I never think of the future. It comes soon enough. Albert Einstein\n",
+            "url":"http://es.linkedin.com/in/eusebiocarasusan",
+            "friend_count":247,
+            "last_updated":"2012-09-03 13:23:58",
+            "followers_count":113,
+            "profile_image_url":"http://a0.twimg.com/profile_images/2432460341/810fonvgxd8c9z65pgdi_normal.jpeg",
+            "name":"Eusebio Carasus\u00e1n",
+            "screen_name":"ecarasusan",
+            "statuses_count":417,
+            "created_at":"Sat May 21 16:40:17 +0200 2011",
+            "avg_tweets_per_day":0.89,
+            "thinkup":{
+                "last_post":"2012-08-23 17:51:19",
+                "last_post_id":"",
+                "found_in":"mentions"
+            }
+        },
+        "entities":{
+            "hashtags":[
+                
+            ],
+            "user_mentions":[
+                {
+                    "name":"Daniel Pe\u00f1a Pizarro",
+                    "id":227641758,
+                    "screen_name":"penia19",
+                    "indices":[
+                        0,
+                        8
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "id":242579461676101632,
+        "author_follower_count":null,
+        "source":"web",
+        "location":"Barcelona",
+        "place":null,
+        "place_id":null,
+        "geo":null,
+        "in_reply_to_user_id":227641758,
+        "in_reply_to_post_id":242576991033888768,
+        "is_reply_by_friend":false,
+        "is_retweet_by_friend":false,
+        "reply_retweet_distance":0,
+        "in_rt_of_user_id":null,
+        "retweet_count_api":0,
+        "favlike_count_cache":0,
+        "links":[
+            
+        ],
+        "favorited":false,
+        "all_retweets":0,
+        "text":"@penia19 he's gonna win a lot of titles with FCB",
+        "created_at":"Mon Sep 03 11:07:05 +0200 2012",
+        "annotations":null,
+        "truncated":false,
+        "protected":false,
+        "thinkup":{
+            "retweet_count_cache":0,
+            "retweet_count_api":0,
+            "reply_count_cache":0,
+            "old_retweet_count_cache":0,
+            "is_geo_encoded":0
+        },
+        "user":{
+            "id":302708860,
+            "location":"Barcelona",
+            "description":"Research Project Manager @ TVC - I never think of the future. It comes soon enough. Albert Einstein\n",
+            "url":"http://es.linkedin.com/in/eusebiocarasusan",
+            "friend_count":247,
+            "last_updated":"2012-09-03 13:23:58",
+            "followers_count":113,
+            "profile_image_url":"http://a0.twimg.com/profile_images/2432460341/810fonvgxd8c9z65pgdi_normal.jpeg",
+            "name":"Eusebio Carasus\u00e1n",
+            "screen_name":"ecarasusan",
+            "statuses_count":417,
+            "created_at":"Sat May 21 16:40:17 +0200 2011",
+            "avg_tweets_per_day":0.89,
+            "thinkup":{
+                "last_post":"2012-08-23 17:51:19",
+                "last_post_id":"",
+                "found_in":"mentions"
+            }
+        },
+        "entities":{
+            "hashtags":[
+                
+            ],
+            "user_mentions":[
+                {
+                    "name":"Daniel Pe\u00f1a Pizarro",
+                    "id":227641758,
+                    "screen_name":"penia19",
+                    "indices":[
+                        0,
+                        8
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "id":242578915867111424,
+        "author_follower_count":null,
+        "source":"web",
+        "location":"Tordera-Barcelona",
+        "place":null,
+        "place_id":null,
+        "geo":null,
+        "in_reply_to_user_id":227641758,
+        "in_reply_to_post_id":242576991033888768,
+        "is_reply_by_friend":false,
+        "is_retweet_by_friend":false,
+        "reply_retweet_distance":0,
+        "in_rt_of_user_id":null,
+        "retweet_count_api":0,
+        "favlike_count_cache":0,
+        "links":[
+            
+        ],
+        "favorited":false,
+        "all_retweets":0,
+        "text":"@penia19 I don't like Alex Song",
+        "created_at":"Mon Sep 03 11:04:55 +0200 2012",
+        "annotations":null,
+        "truncated":false,
+        "protected":false,
+        "thinkup":{
+            "retweet_count_cache":0,
+            "retweet_count_api":0,
+            "reply_count_cache":0,
+            "old_retweet_count_cache":0,
+            "is_geo_encoded":0
+        },
+        "user":{
+            "id":256559225,
+            "location":"Tordera-Barcelona",
+            "description":"Llicenciada en Ci\u00e8ncies Pol\u00edtiques i de l'Administraci\u00f3, a la Universtat Pompeu Fabra. Membre de la JNC, Deba-t i R\u00e0dio Tordera",
+            "url":"",
+            "friend_count":520,
+            "last_updated":"2012-09-03 13:23:58",
+            "followers_count":283,
+            "profile_image_url":"http://a0.twimg.com/profile_images/2169909420/ji_normal.jpg",
+            "name":"Judith",
+            "screen_name":"judithtoronjo",
+            "statuses_count":585,
+            "created_at":"Wed Feb 23 15:58:39 +0100 2011",
+            "avg_tweets_per_day":1.05,
+            "thinkup":{
+                "last_post":"0000-00-00 00:00:00",
+                "last_post_id":"",
+                "found_in":"mentions"
+            }
+        },
+        "entities":{
+            "hashtags":[
+                
+            ],
+            "user_mentions":[
+                {
+                    "name":"Daniel Pe\u00f1a Pizarro",
+                    "id":227641758,
+                    "screen_name":"penia19",
+                    "indices":[
+                        0,
+                        8
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "id":242578744764690432,
+        "author_follower_count":null,
+        "source":"web",
+        "location":"Tordera-Barcelona",
+        "place":null,
+        "place_id":null,
+        "geo":null,
+        "in_reply_to_user_id":227641758,
+        "in_reply_to_post_id":242576686674223106,
+        "is_reply_by_friend":false,
+        "is_retweet_by_friend":false,
+        "reply_retweet_distance":0,
+        "in_rt_of_user_id":null,
+        "retweet_count_api":0,
+        "favlike_count_cache":0,
+        "links":[
+            
+        ],
+        "favorited":false,
+        "all_retweets":0,
+        "text":"@penia19 #fcb",
+        "created_at":"Mon Sep 03 11:04:14 +0200 2012",
+        "annotations":null,
+        "truncated":false,
+        "protected":false,
+        "thinkup":{
+            "retweet_count_cache":0,
+            "retweet_count_api":0,
+            "reply_count_cache":0,
+            "old_retweet_count_cache":0,
+            "is_geo_encoded":0
+        },
+        "user":{
+            "id":256559225,
+            "location":"Tordera-Barcelona",
+            "description":"Llicenciada en Ci\u00e8ncies Pol\u00edtiques i de l'Administraci\u00f3, a la Universtat Pompeu Fabra. Membre de la JNC, Deba-t i R\u00e0dio Tordera",
+            "url":"",
+            "friend_count":520,
+            "last_updated":"2012-09-03 13:23:58",
+            "followers_count":283,
+            "profile_image_url":"http://a0.twimg.com/profile_images/2169909420/ji_normal.jpg",
+            "name":"Judith",
+            "screen_name":"judithtoronjo",
+            "statuses_count":585,
+            "created_at":"Wed Feb 23 15:58:39 +0100 2011",
+            "avg_tweets_per_day":1.05,
+            "thinkup":{
+                "last_post":"0000-00-00 00:00:00",
+                "last_post_id":"",
+                "found_in":"mentions"
+            }
+        },
+        "entities":{
+            "hashtags":[
+                {
+                    "text":"fcb",
+                    "indices":[
+                        9,
+                        13
+                    ]
+                }
+            ],
+            "user_mentions":[
+                {
+                    "name":"Daniel Pe\u00f1a Pizarro",
+                    "id":227641758,
+                    "screen_name":"penia19",
+                    "indices":[
+                        0,
+                        8
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "id":242577856054587392,
+        "author_follower_count":null,
+        "source":"web",
+        "location":"",
+        "place":null,
+        "place_id":null,
+        "geo":null,
+        "in_reply_to_user_id":227641758,
+        "in_reply_to_post_id":242576991033888768,
+        "is_reply_by_friend":false,
+        "is_retweet_by_friend":false,
+        "reply_retweet_distance":0,
+        "in_rt_of_user_id":null,
+        "retweet_count_api":0,
+        "favlike_count_cache":0,
+        "links":[
+            
+        ],
+        "favorited":false,
+        "all_retweets":0,
+        "text":"@penia19 I think he's doing great so far. #Song's contributions to the team have only just started #fcb",
+        "created_at":"Mon Sep 03 11:00:42 +0200 2012",
+        "annotations":null,
+        "truncated":false,
+        "protected":false,
+        "thinkup":{
+            "retweet_count_cache":0,
+            "retweet_count_api":0,
+            "reply_count_cache":0,
+            "old_retweet_count_cache":0,
+            "is_geo_encoded":0
+        },
+        "user":{
+            "id":45437435,
+            "location":"",
+            "description":"Powering the next Renaissance",
+            "url":"http://dani.calidos.com",
+            "friend_count":142,
+            "last_updated":"2012-09-03 13:23:59",
+            "followers_count":141,
+            "profile_image_url":"http://a0.twimg.com/profile_images/268758740/dani_normal.jpg",
+            "name":"Daniel Giribet",
+            "screen_name":"danielgiri",
+            "statuses_count":625,
+            "created_at":"Sun Jun 07 22:19:14 +0200 2009",
+            "avg_tweets_per_day":0.53,
+            "thinkup":{
+                "last_post":"0000-00-00 00:00:00",
+                "last_post_id":"",
+                "found_in":"mentions"
+            }
+        },
+        "entities":{
+            "hashtags":[
+                {
+                    "text":"Song",
+                    "indices":[
+                        42,
+                        47
+                    ]
+                },
+                {
+                    "text":"fcb",
+                    "indices":[
+                        99,
+                        103
+                    ]
+                }
+            ],
+            "user_mentions":[
+                {
+                    "name":"Daniel Pe\u00f1a Pizarro",
+                    "id":227641758,
+                    "screen_name":"penia19",
+                    "indices":[
+                        0,
+                        8
+                    ]
+                }
+            ]
+        }
+    }
+]

--- a/docs/source/userguide/api/posts/user_posts_in_range.rst
+++ b/docs/source/userguide/api/posts/user_posts_in_range.rst
@@ -57,7 +57,9 @@ Optional Arguments
     false. This argument can be set to true by making it equal to either **1**, **t** or **true**.
 
 .. warning::
-    This is the only ThinkUp Post API method which does not enforce a cap of 200 post results returned per call. 
+    The method 'user_questions_in_range', along with user_replies_in_range, post_replies_in_range, 
+    user_mentions_in_range and user_posts_in_range are the ThinkUp Post API methods which do not enforce a cap of 
+    200 post results returned per call. 
     As such, when querying time ranges which contain more than 200 posts, keep in mind that processing that amount of
     data may exceed your server's memory limits.
 

--- a/docs/source/userguide/api/posts/user_questions_in_range.rst
+++ b/docs/source/userguide/api/posts/user_questions_in_range.rst
@@ -1,0 +1,367 @@
+User Questions
+==============
+Gets question posts by a user in a given time range. This will return all of the posts a user has made that contain questions in a given time range.
+
+**API call type slug:** ``user_questions_in_range``
+
+**Example Usage:** ``api/v1/post.php?type=user_questions_in_range&from=29-03-2011&until=04-04-2011&username=samwhoo``
+
+==================
+Required arguments
+==================
+
+* **user_id** or **username**
+
+    Only one of these is required. They are to specify the user to gather posts for in this call.
+
+    * **from**
+
+    The date/time to start searching from. This can either be a
+    `valid date string <http://www.php.net/manual/en/datetime.formats.php>`_ or a Unix timestamp.
+
+* **until**
+
+    The date/time to search until. This can either be a
+    `valid date string <http://www.php.net/manual/en/datetime.formats.php>`_ or a Unix timestamp.
+
+==================
+Optional Arguments
+==================
+
+* **network**
+
+    The network to use in the call. Defaults to 'twitter'.
+
+* **order_by**
+
+    The column to order the results by. Defaults to chronological order ("date").
+
+* **direction**
+
+    The direction to order the results in. Can be either DESC or ASC. Defaults to DESC.
+
+* **include_entities**
+
+    Whether or not to include `Tweet Entities <http://dev.twitter.com/pages/tweet_entities>`_ in the output. Defaults
+    to false. This argument can be set to true by making it equal to either **1**, **t** or **true**.
+
+* **include_replies**
+
+    Whether or not to include replies to this post in the output. This argument is recursive and will retrieve replies
+    to replies also. Defaults to false. This argument can be set to true by making it equal to either **1**, **t** or
+    **true**.
+
+* **trim_user**
+
+    If set to true, this flag strips the user part of the output to just the user's ID and nothing else. Defaults to
+    false. This argument can be set to true by making it equal to either **1**, **t** or **true**.
+
+.. warning::
+    The method 'user_posts_in_range', along with user_replies_in_range, post_replies_in_range, 
+    user_mentions_in_range and user_questions_in_range are the ThinkUp Post API methods which do not enforce a cap of 
+    200 post results returned per call. 
+    As such, when querying time ranges which contain more than 200 posts, keep in mind that processing that amount of
+    data may exceed your server's memory limits.
+
+==============
+Example output
+==============    
+    
+``/api/v1/post.php?type=user_questions_in_range&username=penia19&from=2012-09-03T10:50:00GMT+02:00&until=2012-09-17T017:00:00%20GMT+02:00&include_entities=t&include_replies=t``::
+
+
+[
+    {
+        "id":242576991033888768,
+        "author_follower_count":null,
+        "source":"web",
+        "location":"Alcarr\u00e0s",
+        "place":null,
+        "place_id":null,
+        "geo":null,
+        "in_reply_to_user_id":null,
+        "in_reply_to_post_id":null,
+        "is_reply_by_friend":false,
+        "is_retweet_by_friend":false,
+        "reply_retweet_distance":0,
+        "in_rt_of_user_id":null,
+        "retweet_count_api":0,
+        "favlike_count_cache":0,
+        "links":[
+            
+        ],
+        "favorited":false,
+        "all_retweets":0,
+        "replies":[
+            {
+                "id":242578915867111424,
+                "author_follower_count":null,
+                "source":"web",
+                "location":"Tordera-Barcelona",
+                "place":null,
+                "place_id":null,
+                "geo":null,
+                "in_reply_to_user_id":227641758,
+                "in_reply_to_post_id":242576991033888768,
+                "is_reply_by_friend":false,
+                "is_retweet_by_friend":false,
+                "reply_retweet_distance":0,
+                "in_rt_of_user_id":null,
+                "retweet_count_api":0,
+                "favlike_count_cache":0,
+                "links":[
+                    
+                ],
+                "favorited":false,
+                "all_retweets":0,
+                "text":"@penia19 I don't like Alex Song",
+                "created_at":"Mon Sep 03 11:04:55 +0200 2012",
+                "annotations":null,
+                "truncated":false,
+                "protected":false,
+                "thinkup":{
+                    "retweet_count_cache":0,
+                    "retweet_count_api":0,
+                    "reply_count_cache":0,
+                    "old_retweet_count_cache":0,
+                    "is_geo_encoded":0
+                },
+                "user":{
+                    "id":256559225,
+                    "location":"Tordera-Barcelona",
+                    "description":"Llicenciada en Ci\u00e8ncies Pol\u00edtiques i de l'Administraci\u00f3, a la Universtat Pompeu Fabra. Membre de la JNC, Deba-t i R\u00e0dio Tordera",
+                    "url":"",
+                    "friend_count":520,
+                    "last_updated":"2012-09-03 13:23:58",
+                    "followers_count":283,
+                    "profile_image_url":"http://a0.twimg.com/profile_images/2169909420/ji_normal.jpg",
+                    "name":"Judith",
+                    "screen_name":"judithtoronjo",
+                    "statuses_count":585,
+                    "created_at":"Wed Feb 23 15:58:39 +0100 2011",
+                    "avg_tweets_per_day":1.05,
+                    "thinkup":{
+                        "last_post":"0000-00-00 00:00:00",
+                        "last_post_id":"",
+                        "found_in":"mentions"
+                    }
+                },
+                "entities":{
+                    "hashtags":[
+                        
+                    ],
+                    "user_mentions":[
+                        {
+                            "name":"Daniel Pe\u00f1a Pizarro",
+                            "id":227641758,
+                            "screen_name":"penia19",
+                            "indices":[
+                                0,
+                                8
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "id":242577856054587392,
+                "author_follower_count":null,
+                "source":"web",
+                "location":null,
+                "place":null,
+                "place_id":null,
+                "geo":null,
+                "in_reply_to_user_id":227641758,
+                "in_reply_to_post_id":242576991033888768,
+                "is_reply_by_friend":false,
+                "is_retweet_by_friend":false,
+                "reply_retweet_distance":0,
+                "in_rt_of_user_id":null,
+                "retweet_count_api":0,
+                "favlike_count_cache":0,
+                "links":[
+                    
+                ],
+                "favorited":false,
+                "all_retweets":0,
+                "text":"@penia19 I think he's doing great so far. #Song's contributions to the team have only just started #fcb",
+                "created_at":"Mon Sep 03 11:00:42 +0200 2012",
+                "annotations":null,
+                "truncated":false,
+                "protected":false,
+                "thinkup":{
+                    "retweet_count_cache":0,
+                    "retweet_count_api":0,
+                    "reply_count_cache":0,
+                    "old_retweet_count_cache":0,
+                    "is_geo_encoded":0
+                },
+                "user":{
+                    "id":45437435,
+                    "location":"",
+                    "description":"Powering the next Renaissance",
+                    "url":"http://dani.calidos.com",
+                    "friend_count":142,
+                    "last_updated":"2012-09-03 13:23:59",
+                    "followers_count":141,
+                    "profile_image_url":"http://a0.twimg.com/profile_images/268758740/dani_normal.jpg",
+                    "name":"Daniel Giribet",
+                    "screen_name":"danielgiri",
+                    "statuses_count":625,
+                    "created_at":"Sun Jun 07 22:19:14 +0200 2009",
+                    "avg_tweets_per_day":0.53,
+                    "thinkup":{
+                        "last_post":"0000-00-00 00:00:00",
+                        "last_post_id":"",
+                        "found_in":"mentions"
+                    }
+                },
+                "entities":{
+                    "hashtags":[
+                        {
+                            "text":"Song",
+                            "indices":[
+                                42,
+                                47
+                            ]
+                        },
+                        {
+                            "text":"fcb",
+                            "indices":[
+                                99,
+                                103
+                            ]
+                        }
+                    ],
+                    "user_mentions":[
+                        {
+                            "name":"Daniel Pe\u00f1a Pizarro",
+                            "id":227641758,
+                            "screen_name":"penia19",
+                            "indices":[
+                                0,
+                                8
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "id":242579461676101632,
+                "author_follower_count":null,
+                "source":"web",
+                "location":"Barcelona",
+                "place":null,
+                "place_id":null,
+                "geo":null,
+                "in_reply_to_user_id":227641758,
+                "in_reply_to_post_id":242576991033888768,
+                "is_reply_by_friend":false,
+                "is_retweet_by_friend":false,
+                "reply_retweet_distance":0,
+                "in_rt_of_user_id":null,
+                "retweet_count_api":0,
+                "favlike_count_cache":0,
+                "links":[
+                    
+                ],
+                "favorited":false,
+                "all_retweets":0,
+                "text":"@penia19 he's gonna win a lot of titles with FCB",
+                "created_at":"Mon Sep 03 11:07:05 +0200 2012",
+                "annotations":null,
+                "truncated":false,
+                "protected":false,
+                "thinkup":{
+                    "retweet_count_cache":0,
+                    "retweet_count_api":0,
+                    "reply_count_cache":0,
+                    "old_retweet_count_cache":0,
+                    "is_geo_encoded":0
+                },
+                "user":{
+                    "id":302708860,
+                    "location":"Barcelona",
+                    "description":"Research Project Manager @ TVC - I never think of the future. It comes soon enough. Albert Einstein\n",
+                    "url":"http://es.linkedin.com/in/eusebiocarasusan",
+                    "friend_count":247,
+                    "last_updated":"2012-09-03 13:23:58",
+                    "followers_count":113,
+                    "profile_image_url":"http://a0.twimg.com/profile_images/2432460341/810fonvgxd8c9z65pgdi_normal.jpeg",
+                    "name":"Eusebio Carasus\u00e1n",
+                    "screen_name":"ecarasusan",
+                    "statuses_count":417,
+                    "created_at":"Sat May 21 16:40:17 +0200 2011",
+                    "avg_tweets_per_day":0.89,
+                    "thinkup":{
+                        "last_post":"2012-08-23 17:51:19",
+                        "last_post_id":"",
+                        "found_in":"mentions"
+                    }
+                },
+                "entities":{
+                    "hashtags":[
+                        
+                    ],
+                    "user_mentions":[
+                        {
+                            "name":"Daniel Pe\u00f1a Pizarro",
+                            "id":227641758,
+                            "screen_name":"penia19",
+                            "indices":[
+                                0,
+                                8
+                            ]
+                        }
+                    ]
+                }
+            }
+        ],
+        "text":"#fcb What are your thoughts about Alex Song so far?",
+        "created_at":"Mon Sep 03 10:57:16 +0200 2012",
+        "annotations":null,
+        "truncated":false,
+        "protected":false,
+        "thinkup":{
+            "retweet_count_cache":0,
+            "retweet_count_api":0,
+            "reply_count_cache":0,
+            "old_retweet_count_cache":0,
+            "is_geo_encoded":0
+        },
+        "user":{
+            "id":227641758,
+            "location":"Alcarr\u00e0s",
+            "description":"he anat creixent...",
+            "url":"",
+            "friend_count":100,
+            "last_updated":"2012-09-03 14:43:25",
+            "followers_count":45,
+            "profile_image_url":"http://a0.twimg.com/profile_images/1830063000/IMG_0539_normal.JPG",
+            "name":"Daniel Pe\u00f1a Pizarro",
+            "screen_name":"penia19",
+            "statuses_count":91,
+            "created_at":"Fri Dec 17 11:40:19 +0100 2010",
+            "avg_tweets_per_day":0.15,
+            "thinkup":{
+                "last_post":"0000-00-00 00:00:00",
+                "last_post_id":"",
+                "found_in":"Owner Status"
+            }
+        },
+        "entities":{
+            "hashtags":[
+                {
+                    "text":"fcb",
+                    "indices":[
+                        0,
+                        4
+                    ]
+                }
+            ],
+            "user_mentions":[
+                
+            ]
+        }
+    }
+]

--- a/docs/source/userguide/api/posts/user_replies_in_range.rst
+++ b/docs/source/userguide/api/posts/user_replies_in_range.rst
@@ -1,0 +1,444 @@
+User Replies
+============
+Gets the replies to a specific user in a given time range.
+
+**API call type slug:** ``user_replies_in_range``
+
+**Example Usage:** ``api/v1/post.php?type=user_replies_in_range&from=29-03-2011&until=04-04-2011&username=samwhoo``
+
+==================
+Required arguments
+==================
+
+* **user_id** or **username**
+
+    Only one of these is required. They are to specify the user to gather posts for in this call.
+
+* **from**
+
+    The date/time to start searching from. This can either be a
+    `valid date string <http://www.php.net/manual/en/datetime.formats.php>`_ or a Unix timestamp.
+
+* **until**
+
+    The date/time to search until. This can either be a
+    `valid date string <http://www.php.net/manual/en/datetime.formats.php>`_ or a Unix timestamp.
+
+==================
+Optional Arguments
+==================
+
+* **network**
+
+    The network to use in the call. Defaults to 'twitter'.
+
+* **order_by**
+
+    The column to order the results by. Defaults to chronological order ("date").
+
+* **direction**
+
+    The direction to order the results in. Can be either DESC or ASC. Defaults to DESC.
+
+* **include_entities**
+
+    Whether or not to include `Tweet Entities <http://dev.twitter.com/pages/tweet_entities>`_ in the output. Defaults
+    to false. This argument can be set to true by making it equal to either **1**, **t** or **true**.
+
+* **include_replies**
+
+    Whether or not to include replies to this post in the output. This argument is recursive and will retrieve replies
+    to replies also. Defaults to false. This argument can be set to true by making it equal to either **1**, **t** or
+    **true**.
+
+* **trim_user**
+
+    If set to true, this flag strips the user part of the output to just the user's ID and nothing else. Defaults to
+    false. This argument can be set to true by making it equal to either **1**, **t** or **true**.
+
+.. warning::
+    The method 'user_replies_in_range', along with user_questions_in_range, post_replies_in_range, 
+    user_mentions_in_range and user_posts_in_range are the ThinkUp Post API methods which do not enforce a cap of 
+    200 post results returned per call. 
+    As such, when querying time ranges which contain more than 200 posts, keep in mind that processing that amount of
+    data may exceed your server's memory limits.
+    
+
+==============
+Example output
+==============
+
+``/api/v1/post.php?type=user_replies_in_range&username=penia19&from=2012-09-03T11:00:00GMT+02:00&until=2012-09-03T017:00:00%20GMT+02:00&include_entities=t&include_replies=t``::
+
+	
+[
+    {
+        "id":242579576025403392,
+        "author_follower_count":null,
+        "source":"web",
+        "location":"Barcelona",
+        "place":null,
+        "place_id":null,
+        "geo":null,
+        "in_reply_to_user_id":227641758,
+        "in_reply_to_post_id":242576686674223106,
+        "is_reply_by_friend":false,
+        "is_retweet_by_friend":false,
+        "reply_retweet_distance":0,
+        "in_rt_of_user_id":null,
+        "retweet_count_api":0,
+        "favlike_count_cache":0,
+        "links":[
+            
+        ],
+        "favorited":false,
+        "all_retweets":0,
+        "text":"@penia19 me too!",
+        "created_at":"Mon Sep 03 11:07:32 +0200 2012",
+        "annotations":null,
+        "truncated":false,
+        "protected":false,
+        "thinkup":{
+            "retweet_count_cache":0,
+            "retweet_count_api":0,
+            "reply_count_cache":0,
+            "old_retweet_count_cache":0,
+            "is_geo_encoded":0
+        },
+        "user":{
+            "id":302708860,
+            "location":"Barcelona",
+            "description":"Research Project Manager @ TVC - I never think of the future. It comes soon enough. Albert Einstein\n",
+            "url":"http://es.linkedin.com/in/eusebiocarasusan",
+            "friend_count":247,
+            "last_updated":"2012-09-03 13:23:58",
+            "followers_count":113,
+            "profile_image_url":"http://a0.twimg.com/profile_images/2432460341/810fonvgxd8c9z65pgdi_normal.jpeg",
+            "name":"Eusebio Carasus\u00e1n",
+            "screen_name":"ecarasusan",
+            "statuses_count":417,
+            "created_at":"Sat May 21 16:40:17 +0200 2011",
+            "avg_tweets_per_day":0.89,
+            "thinkup":{
+                "last_post":"2012-08-23 17:51:19",
+                "last_post_id":"",
+                "found_in":"mentions"
+            }
+        },
+        "entities":{
+            "hashtags":[
+                
+            ],
+            "user_mentions":[
+                {
+                    "name":"Daniel Pe\u00f1a Pizarro",
+                    "id":227641758,
+                    "screen_name":"penia19",
+                    "indices":[
+                        0,
+                        8
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "id":242579461676101632,
+        "author_follower_count":null,
+        "source":"web",
+        "location":"Barcelona",
+        "place":null,
+        "place_id":null,
+        "geo":null,
+        "in_reply_to_user_id":227641758,
+        "in_reply_to_post_id":242576991033888768,
+        "is_reply_by_friend":false,
+        "is_retweet_by_friend":false,
+        "reply_retweet_distance":0,
+        "in_rt_of_user_id":null,
+        "retweet_count_api":0,
+        "favlike_count_cache":0,
+        "links":[
+            
+        ],
+        "favorited":false,
+        "all_retweets":0,
+        "text":"@penia19 he's gonna win a lot of titles with FCB",
+        "created_at":"Mon Sep 03 11:07:05 +0200 2012",
+        "annotations":null,
+        "truncated":false,
+        "protected":false,
+        "thinkup":{
+            "retweet_count_cache":0,
+            "retweet_count_api":0,
+            "reply_count_cache":0,
+            "old_retweet_count_cache":0,
+            "is_geo_encoded":0
+        },
+        "user":{
+            "id":302708860,
+            "location":"Barcelona",
+            "description":"Research Project Manager @ TVC - I never think of the future. It comes soon enough. Albert Einstein\n",
+            "url":"http://es.linkedin.com/in/eusebiocarasusan",
+            "friend_count":247,
+            "last_updated":"2012-09-03 13:23:58",
+            "followers_count":113,
+            "profile_image_url":"http://a0.twimg.com/profile_images/2432460341/810fonvgxd8c9z65pgdi_normal.jpeg",
+            "name":"Eusebio Carasus\u00e1n",
+            "screen_name":"ecarasusan",
+            "statuses_count":417,
+            "created_at":"Sat May 21 16:40:17 +0200 2011",
+            "avg_tweets_per_day":0.89,
+            "thinkup":{
+                "last_post":"2012-08-23 17:51:19",
+                "last_post_id":"",
+                "found_in":"mentions"
+            }
+        },
+        "entities":{
+            "hashtags":[
+                
+            ],
+            "user_mentions":[
+                {
+                    "name":"Daniel Pe\u00f1a Pizarro",
+                    "id":227641758,
+                    "screen_name":"penia19",
+                    "indices":[
+                        0,
+                        8
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "id":242578915867111424,
+        "author_follower_count":null,
+        "source":"web",
+        "location":"Tordera-Barcelona",
+        "place":null,
+        "place_id":null,
+        "geo":null,
+        "in_reply_to_user_id":227641758,
+        "in_reply_to_post_id":242576991033888768,
+        "is_reply_by_friend":false,
+        "is_retweet_by_friend":false,
+        "reply_retweet_distance":0,
+        "in_rt_of_user_id":null,
+        "retweet_count_api":0,
+        "favlike_count_cache":0,
+        "links":[
+            
+        ],
+        "favorited":false,
+        "all_retweets":0,
+        "text":"@penia19 I don't like Alex Song",
+        "created_at":"Mon Sep 03 11:04:55 +0200 2012",
+        "annotations":null,
+        "truncated":false,
+        "protected":false,
+        "thinkup":{
+            "retweet_count_cache":0,
+            "retweet_count_api":0,
+            "reply_count_cache":0,
+            "old_retweet_count_cache":0,
+            "is_geo_encoded":0
+        },
+        "user":{
+            "id":256559225,
+            "location":"Tordera-Barcelona",
+            "description":"Llicenciada en Ci\u00e8ncies Pol\u00edtiques i de l'Administraci\u00f3, a la Universtat Pompeu Fabra. Membre de la JNC, Deba-t i R\u00e0dio Tordera",
+            "url":"",
+            "friend_count":520,
+            "last_updated":"2012-09-03 13:23:58",
+            "followers_count":283,
+            "profile_image_url":"http://a0.twimg.com/profile_images/2169909420/ji_normal.jpg",
+            "name":"Judith",
+            "screen_name":"judithtoronjo",
+            "statuses_count":585,
+            "created_at":"Wed Feb 23 15:58:39 +0100 2011",
+            "avg_tweets_per_day":1.05,
+            "thinkup":{
+                "last_post":"0000-00-00 00:00:00",
+                "last_post_id":"",
+                "found_in":"mentions"
+            }
+        },
+        "entities":{
+            "hashtags":[
+                
+            ],
+            "user_mentions":[
+                {
+                    "name":"Daniel Pe\u00f1a Pizarro",
+                    "id":227641758,
+                    "screen_name":"penia19",
+                    "indices":[
+                        0,
+                        8
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "id":242578744764690432,
+        "author_follower_count":null,
+        "source":"web",
+        "location":"Tordera-Barcelona",
+        "place":null,
+        "place_id":null,
+        "geo":null,
+        "in_reply_to_user_id":227641758,
+        "in_reply_to_post_id":242576686674223106,
+        "is_reply_by_friend":false,
+        "is_retweet_by_friend":false,
+        "reply_retweet_distance":0,
+        "in_rt_of_user_id":null,
+        "retweet_count_api":0,
+        "favlike_count_cache":0,
+        "links":[
+            
+        ],
+        "favorited":false,
+        "all_retweets":0,
+        "text":"@penia19 #fcb",
+        "created_at":"Mon Sep 03 11:04:14 +0200 2012",
+        "annotations":null,
+        "truncated":false,
+        "protected":false,
+        "thinkup":{
+            "retweet_count_cache":0,
+            "retweet_count_api":0,
+            "reply_count_cache":0,
+            "old_retweet_count_cache":0,
+            "is_geo_encoded":0
+        },
+        "user":{
+            "id":256559225,
+            "location":"Tordera-Barcelona",
+            "description":"Llicenciada en Ci\u00e8ncies Pol\u00edtiques i de l'Administraci\u00f3, a la Universtat Pompeu Fabra. Membre de la JNC, Deba-t i R\u00e0dio Tordera",
+            "url":"",
+            "friend_count":520,
+            "last_updated":"2012-09-03 13:23:58",
+            "followers_count":283,
+            "profile_image_url":"http://a0.twimg.com/profile_images/2169909420/ji_normal.jpg",
+            "name":"Judith",
+            "screen_name":"judithtoronjo",
+            "statuses_count":585,
+            "created_at":"Wed Feb 23 15:58:39 +0100 2011",
+            "avg_tweets_per_day":1.05,
+            "thinkup":{
+                "last_post":"0000-00-00 00:00:00",
+                "last_post_id":"",
+                "found_in":"mentions"
+            }
+        },
+        "entities":{
+            "hashtags":[
+                {
+                    "text":"fcb",
+                    "indices":[
+                        9,
+                        13
+                    ]
+                }
+            ],
+            "user_mentions":[
+                {
+                    "name":"Daniel Pe\u00f1a Pizarro",
+                    "id":227641758,
+                    "screen_name":"penia19",
+                    "indices":[
+                        0,
+                        8
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "id":242577856054587392,
+        "author_follower_count":null,
+        "source":"web",
+        "location":"",
+        "place":null,
+        "place_id":null,
+        "geo":null,
+        "in_reply_to_user_id":227641758,
+        "in_reply_to_post_id":242576991033888768,
+        "is_reply_by_friend":false,
+        "is_retweet_by_friend":false,
+        "reply_retweet_distance":0,
+        "in_rt_of_user_id":null,
+        "retweet_count_api":0,
+        "favlike_count_cache":0,
+        "links":[
+            
+        ],
+        "favorited":false,
+        "all_retweets":0,
+        "text":"@penia19 I think he's doing great so far. #Song's contributions to the team have only just started #fcb",
+        "created_at":"Mon Sep 03 11:00:42 +0200 2012",
+        "annotations":null,
+        "truncated":false,
+        "protected":false,
+        "thinkup":{
+            "retweet_count_cache":0,
+            "retweet_count_api":0,
+            "reply_count_cache":0,
+            "old_retweet_count_cache":0,
+            "is_geo_encoded":0
+        },
+        "user":{
+            "id":45437435,
+            "location":"",
+            "description":"Powering the next Renaissance",
+            "url":"http://dani.calidos.com",
+            "friend_count":142,
+            "last_updated":"2012-09-03 13:23:59",
+            "followers_count":141,
+            "profile_image_url":"http://a0.twimg.com/profile_images/268758740/dani_normal.jpg",
+            "name":"Daniel Giribet",
+            "screen_name":"danielgiri",
+            "statuses_count":625,
+            "created_at":"Sun Jun 07 22:19:14 +0200 2009",
+            "avg_tweets_per_day":0.53,
+            "thinkup":{
+                "last_post":"0000-00-00 00:00:00",
+                "last_post_id":"",
+                "found_in":"mentions"
+            }
+        },
+        "entities":{
+            "hashtags":[
+                {
+                    "text":"Song",
+                    "indices":[
+                        42,
+                        47
+                    ]
+                },
+                {
+                    "text":"fcb",
+                    "indices":[
+                        99,
+                        103
+                    ]
+                }
+            ],
+            "user_mentions":[
+                {
+                    "name":"Daniel Pe\u00f1a Pizarro",
+                    "id":227641758,
+                    "screen_name":"penia19",
+                    "indices":[
+                        0,
+                        8
+                    ]
+                }
+            ]
+        }
+    }
+]

--- a/tests/TestOfPostAPIController.php
+++ b/tests/TestOfPostAPIController.php
@@ -1026,6 +1026,81 @@ class TestOfPostAPIController extends ThinkUpUnitTestCase {
         $this->assertTrue(array_search($prefix . "posts", $installer_dao->getTables()) !== false);
     }
 
+    public function testPostRepliesInRange() {
+        $_GET['type'] = 'post_replies_in_range';
+        $_GET['post_id'] = 41;
+        $_GET['from'] = '2006-02-01 00:00:00';
+        $_GET['until'] = '2006-03-02 00:59:59';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+
+        // test the object type is correct
+        $this->assertTrue(is_array($output));
+        foreach($output as $post) {
+            $this->assertTrue($post instanceof stdClass);
+            $this->assertEqual($post->protected, false);
+            /**
+             * The following two assertions evaluate differently depending on whether your MySQL server supports
+             * SET timezone statement in PDODAO::connect function
+             */
+            $this->assertTrue(strtotime($post->created_at) >= strtotime($_GET['from']));
+            $this->assertTrue(strtotime($post->created_at) < strtotime($_GET['until']));
+        }
+               
+        $this->assertEqual(sizeof($output), 2);
+        $this->assertEqual($output[0]->id, 131);
+        $this->assertEqual($output[1]->id, 133);
+
+        // test order_by
+        $_GET['order_by'] = 'location';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+
+        $distance = $output[0]->reply_retweet_distance;
+        foreach ($output as $post) {
+            $this->assertTrue($post->reply_retweet_distance >= $distance);
+            $distance = $post->reply_retweet_distance;
+        }
+
+        // test unit
+        $_GET['post_id'] = 41;
+        $_GET['unit'] = 'mi';
+        $controller = new PostAPIController(true);
+        $output_mi = json_decode($controller->go());
+        $_GET['unit'] = 'km';
+        $controller = new PostAPIController(true);
+        $output_km = json_decode($controller->go());
+
+        foreach ($output_km as $key=>$post) {
+            $this->assertEqual($output_mi[$key]->reply_retweet_distance,
+            round($output_km[$key]->reply_retweet_distance/1.609));
+        }
+
+        // test trim user
+        unset($_GET['count'], $_GET['page']);
+        $_GET['trim_user'] = true;
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $this->assertEqual(sizeof($output), 2);
+
+        foreach($output as $post) {
+            $this->assertEqual(sizeof($post->user), 1);
+        }
+
+        // test sql injection
+        $_GET = array('type' => 'post_replies');
+        $prefix = Config::getInstance()->getValue('table_prefix');
+        foreach(get_object_vars($controller) as $key => $value) {
+            if ($key == 'type' || $key == 'app_session') continue;
+            $_GET[$key] = "'; DROP TABLE " . $prefix . "posts--";
+            $controller = new PostAPIController(true);
+            $output = json_decode($controller->go());
+            unset($_GET[$key]);
+        }
+        $installer_dao = DAOFactory::getDAO('InstallerDAO');
+        $this->assertTrue(array_search($prefix . "posts", $installer_dao->getTables()) !== false);
+    }
+        
     public function testRelatedPosts() {
         $_GET['type'] = 'related_posts';
         $_GET['post_id'] = 41;
@@ -1638,6 +1713,169 @@ class TestOfPostAPIController extends ThinkUpUnitTestCase {
         $this->assertTrue(array_search($prefix . "posts", $installer_dao->getTables()) !== false);
     }
 
+   public function testUserMentionsInRange() {
+        $_GET['type'] = 'user_mentions_in_range';
+        $_GET['user_id'] = 18;
+        $_GET['from'] = '2006-03-01 00:00:00';
+        $_GET['until'] = '2006-03-02 00:59:59';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+
+        // test the object type is correct
+        $this->assertTrue(is_array($output));
+        foreach($output as $post) {
+            $this->assertTrue($post instanceof stdClass);
+            $this->assertEqual($post->protected, false);
+            /**
+             * The following two assertions evaluate differently depending on whether your MySQL server supports
+             * SET timezone statement in PDODAO::connect function
+             */
+            $this->assertTrue(strtotime($post->created_at) >= strtotime($_GET['from']));
+            $this->assertTrue(strtotime($post->created_at) < strtotime($_GET['until']));
+        }
+
+        // test order_by
+        $_GET['order_by'] = 'date';
+        $_GET['direction'] = 'DESC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $date = strtotime($output[0]->created_at);
+        foreach ($output as $post) {
+            $this->assertTrue(strtotime($post->created_at) <= $date);
+            $date = strtotime($post->created_at);
+        }
+
+        $_GET['order_by'] = 'date';
+        $_GET['direction'] = 'ASC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $date = strtotime($output[0]->created_at);
+        foreach ($output as $post) {
+            $this->assertTrue(strtotime($post->created_at) >= $date);
+            $date = strtotime($post->created_at);
+        }
+
+        $_GET['order_by'] = 'source';
+        $_GET['direction'] = 'DESC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->source;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->source, $str) <= 0);
+            $str = $post->source;
+        }
+
+        $_GET['order_by'] = 'source';
+        $_GET['direction'] = 'ASC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->source;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->source, $str) >= 0);
+            $str = $post->source;
+        }
+
+        $_GET['order_by'] = 'follower_count';
+        $_GET['direction'] = 'DESC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $count = $output[0]->user->followers_count;
+        foreach ($output as $post) {
+            $this->debug("Count ".$post->user->followers_count . ' <= ' . $count);
+            $this->assertTrue($post->user->followers_count <= $count);
+            $count = $post->user->followers_count;
+        }
+
+        $_GET['order_by'] = 'follower_count';
+        $_GET['direction'] = 'ASC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $count = $output[0]->user->followers_count;
+        foreach ($output as $post) {
+            $this->debug($post->id . " - Count ".$post->user->followers_count . ' >= ' . $count);
+            $this->assertTrue($post->user->followers_count >= $count);
+            $count = $post->user->followers_count;
+        }
+
+        $_GET['order_by'] = 'post_text';
+        $_GET['direction'] = 'DESC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->text;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->text, $str) <= 0);
+            $str = $post->text;
+        }
+
+        $_GET['order_by'] = 'post_text';
+        $_GET['direction'] = 'ASC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->text;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->text, $str) >= 0);
+            $str = $post->text;
+        }
+
+        $_GET['order_by'] = 'author_username';
+        $_GET['direction'] = 'DESC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->user->screen_name;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->user->screen_name, $str) <= 0);
+            $str = $post->user->screen_name;
+        }
+
+        $_GET['order_by'] = 'author_username';
+        $_GET['direction'] = 'ASC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->user->screen_name;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->user->screen_name, $str) >= 0);
+            $str = $post->user->screen_name;
+        }
+
+        // test tweet entities
+        $_GET['include_entities'] = true;
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $this->assertEqual(sizeof($output), 2);
+
+      // test trim user
+        unset($_GET['include_entities']);
+        $_GET['trim_user'] = true;
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $this->assertEqual(sizeof($output), 2);
+        $this->assertEqual(sizeof($output[0]->user), 1);
+
+        // test sql injection
+        $_GET = array('type' => 'user_mentions_in_range');
+        $prefix = Config::getInstance()->getValue('table_prefix');
+        foreach(get_object_vars($controller) as $key => $value) {
+            if ($key == 'type' || $key == 'app_session') continue;
+            $_GET[$key] = "'; DROP TABLE " . $prefix . "posts--";
+            $controller = new PostAPIController(true);
+            $output = json_decode($controller->go());
+            unset($_GET[$key]);
+        }
+        $installer_dao = DAOFactory::getDAO('InstallerDAO');
+        $this->assertTrue(array_search($prefix . "posts", $installer_dao->getTables()) !== false);
+
+        // test posts contain a links object
+        $_GET['type'] = 'user_mentions_in_range';
+        $_GET['user_id'] = 18;
+        $_GET['from'] = '2006-03-01 00:01:00';
+        $_GET['until'] = '2006-03-01 00:23:01';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        foreach($output as $post) {
+            $this->assertTrue($post->links instanceof stdClass);
+        }
+    }
+
     public function testUserMentionsProtectedOnNetwork() {
         $_GET['type'] = 'user_mentions';
         $_GET['user_id'] = 24;
@@ -1845,6 +2083,145 @@ class TestOfPostAPIController extends ThinkUpUnitTestCase {
         $this->assertEqual($output->error->message, "The requested user data is not available.");
     }
 
+    public function testUserRepliesInRange() {
+        $_GET['type'] = 'user_replies_in_range';
+        $_GET['user_id'] = 18;
+        $_GET['from'] = '2006-02-01 00:00:00';
+        $_GET['until'] = '2006-03-02 00:59:59';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        // test the object type is correct
+        $this->assertTrue(is_array($output));
+        foreach($output as $post) {
+            $this->assertTrue($post instanceof stdClass);
+            $this->assertEqual($post->protected, false);
+            $this->assertEqual($post->in_reply_to_user_id, 18);
+            /**
+             * The following two assertions evaluate differently depending on whether your MySQL server supports
+             * SET timezone statement in PDODAO::connect function
+             */
+            $this->assertTrue(strtotime($post->created_at) >= strtotime($_GET['from']));
+            $this->assertTrue(strtotime($post->created_at) < strtotime($_GET['until']));
+        }
+
+        $this->assertEqual(sizeof($output), 2);
+        
+        // test order_by
+        $_GET['order_by'] = 'date';
+        $_GET['direction'] = 'DESC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $date = strtotime($output[0]->created_at);
+        foreach ($output as $post) {
+            $this->assertTrue(strtotime($post->created_at) <= $date);
+            $date = strtotime($post->created_at);
+        }
+
+        $_GET['order_by'] = 'date';
+        $_GET['direction'] = 'ASC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $date = strtotime($output[0]->created_at);
+        foreach ($output as $post) {
+            $this->assertTrue(strtotime($post->created_at) >= $date);
+            $date = strtotime($post->created_at);
+        }
+
+        $_GET['order_by'] = 'source';
+        $_GET['direction'] = 'DESC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->source;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->source, $str) <= 0);
+            $str = $post->source;
+        }
+
+        $_GET['order_by'] = 'source';
+        $_GET['direction'] = 'ASC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->source;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->source, $str) >= 0);
+            $str = $post->source;
+        }
+
+        $_GET['order_by'] = 'follower_count';
+        $_GET['direction'] = 'DESC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $count = $output[0]->user->followers_count;
+        foreach ($output as $post) {
+            $this->debug("Count ".$post->user->followers_count);
+            $this->assertTrue($post->user->followers_count <= $count);
+            $count = $post->user->followers_count;
+        }
+
+        $_GET['order_by'] = 'follower_count';
+        $_GET['direction'] = 'ASC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $count = $output[0]->user->followers_count;
+        foreach ($output as $post) {
+            $this->assertTrue($post->user->followers_count >= $count);
+            $count = $post->user->followers_count;
+        }
+
+        $_GET['order_by'] = 'post_text';
+        $_GET['direction'] = 'DESC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->text;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->text, $str) <= 0);
+            $str = $post->text;
+        }
+
+        $_GET['order_by'] = 'post_text';
+        $_GET['direction'] = 'ASC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->text;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->text, $str) >= 0);
+            $str = $post->text;
+        }
+
+        $_GET['order_by'] = 'author_username';
+        $_GET['direction'] = 'DESC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->user->screen_name;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->user->screen_name, $str) <= 0);
+            $str = $post->user->screen_name;
+        }
+
+        $_GET['order_by'] = 'author_username';
+        $_GET['direction'] = 'ASC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->user->screen_name;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->user->screen_name, $str) >= 0);
+            $str = $post->user->screen_name;
+        }
+
+        // test sql injection
+        $_GET = array('type' => 'user_replies');
+        $prefix = Config::getInstance()->getValue('table_prefix');
+        foreach(get_object_vars($controller) as $key => $value) {
+            if ($key == 'type' || $key == 'app_session') continue;
+            $_GET[$key] = "'; DROP TABLE " . $prefix . "posts--";
+            $controller = new PostAPIController(true);
+            $output = json_decode($controller->go());
+            unset($_GET[$key]);
+        }
+        $installer_dao = DAOFactory::getDAO('InstallerDAO');
+        $this->assertTrue(array_search($prefix . "posts", $installer_dao->getTables()) !== false);
+    }
+    
     public function testUserQuestions() {
         $_GET['type'] = 'user_questions';
         $_GET['user_id'] = 20;
@@ -2001,6 +2378,143 @@ class TestOfPostAPIController extends ThinkUpUnitTestCase {
         $this->assertTrue(array_search($prefix . "posts", $installer_dao->getTables()) !== false);
     }
 
+   public function testUserQuestionsInRange() {
+        $_GET['type'] = 'user_questions_in_range';
+        $_GET['user_id'] = 20; 
+        $_GET['from'] = '2006-03-01 00:00:00';
+        $_GET['until'] = '2006-03-02 00:59:59';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+
+        // test the object type is correct
+        $this->assertTrue(is_array($output));
+        foreach($output as $post) {
+            $this->assertTrue($post instanceof stdClass);
+            $this->assertEqual($post->protected, false);
+            $this->assertEqual(preg_match('/\?/', $post->text), 1);
+            /**
+             * The following two assertions evaluate differently depending on whether your MySQL server supports
+             * SET timezone statement in PDODAO::connect function
+             */
+            $this->assertTrue(strtotime($post->created_at) >= strtotime($_GET['from']));
+            $this->assertTrue(strtotime($post->created_at) < strtotime($_GET['until']));            
+        }
+
+        // test order_by
+        $_GET['order_by'] = 'date';
+        $_GET['direction'] = 'DESC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $date = strtotime($output[0]->created_at);
+        foreach ($output as $post) {
+            $this->assertTrue(strtotime($post->created_at) <= $date);
+            $date = strtotime($post->created_at);
+        }
+
+        $_GET['order_by'] = 'date';
+        $_GET['direction'] = 'ASC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $date = strtotime($output[0]->created_at);
+        foreach ($output as $post) {
+            $this->assertTrue(strtotime($post->created_at) >= $date);
+            $date = strtotime($post->created_at);
+        }
+
+        $_GET['order_by'] = 'source';
+        $_GET['direction'] = 'DESC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->source;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->source, $str) <= 0);
+            $str = $post->source;
+        }
+
+        $_GET['order_by'] = 'source';
+        $_GET['direction'] = 'ASC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->source;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->source, $str) >= 0);
+            $str = $post->source;
+        }
+
+        $_GET['order_by'] = 'follower_count';
+        $_GET['direction'] = 'DESC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $count = $output[0]->user->followers_count;
+        foreach ($output as $post) {
+            $this->assertTrue($post->user->followers_count <= $count);
+            $count = $post->user->followers_count;
+        }
+
+        $_GET['order_by'] = 'follower_count';
+        $_GET['direction'] = 'ASC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $count = $output[0]->user->followers_count;
+        foreach ($output as $post) {
+            $this->assertTrue($post->user->followers_count >= $count);
+            $count = $post->user->followers_count;
+        }
+
+        $_GET['order_by'] = 'post_text';
+        $_GET['direction'] = 'DESC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->text;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->text, $str) <= 0);
+            $str = $post->text;
+        }
+
+        $_GET['order_by'] = 'post_text';
+        $_GET['direction'] = 'ASC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->text;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->text, $str) >= 0);
+            $str = $post->text;
+        }
+
+        $_GET['order_by'] = 'author_username';
+        $_GET['direction'] = 'DESC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->user->screen_name;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->user->screen_name, $str) <= 0);
+            $str = $post->user->screen_name;
+        }
+
+        $_GET['order_by'] = 'author_username';
+        $_GET['direction'] = 'ASC';
+        $controller = new PostAPIController(true);
+        $output = json_decode($controller->go());
+        $str = $output[0]->user->screen_name;
+        foreach ($output as $post) {
+            $this->assertTrue(strcmp($post->user->screen_name, $str) >= 0);
+            $str = $post->user->screen_name;
+        }
+
+        // test sql injection
+        $_GET = array('type' => 'user_questions');
+        $prefix = Config::getInstance()->getValue('table_prefix');
+        foreach(get_object_vars($controller) as $key => $value) {
+            if ($key == 'type' || $key == 'app_session') continue;
+            $_GET[$key] = "'; DROP TABLE " . $prefix . "posts--";
+            $controller = new PostAPIController(true);
+            $output = json_decode($controller->go());
+            unset($_GET[$key]);
+        }
+        $installer_dao = DAOFactory::getDAO('InstallerDAO');
+        $this->assertTrue(array_search($prefix . "posts", $installer_dao->getTables()) !== false);
+    }    
+    
     public function testUserQuestionsProtectedOnNetwork() {
         $_GET['type'] = 'user_questions';
         $_GET['user_id'] = 24;

--- a/webapp/_lib/controller/class.PostAPIController.php
+++ b/webapp/_lib/controller/class.PostAPIController.php
@@ -388,7 +388,29 @@ class PostAPIController extends ThinkUpController {
                 }
                 break;
 
+ 
                 /*
+                 * Gets replies to a post within a date range.
+                 *
+                 * Required arguments: post_id, from and until
+                 *
+                 * Optional arguments: network, order_by, unit, count, page, include_entities, include_replies, trim_user
+                 *
+                 * Ordering can only be done by either location or follower count.
+                 *
+                 * Docs: http://thinkupapp.com/docs/userguide/api/posts/post_replies.html
+                 */
+            case 'post_replies_in_range':
+                if (is_null($this->post_id) || is_null($this->from) || is_null($this->until)) {
+                    $m = 'A request of type ' . $this->type . ' requires a post_id to be specified.';
+                    throw new RequiredArgumentMissingException($m);
+                } else {
+                    $data = $this->post_dao->getRepliesToPostInRange($this->post_id, $this->network, $this->from, $this->until, $this->order_by,
+                    $this->unit, $this->is_public, $this->count, $this->page);
+                }
+                break;
+                
+               /*
                  * Get posts related to a post (replies to it, retweets of it).
                  *
                  * Required arguments: post_id
@@ -486,6 +508,26 @@ class PostAPIController extends ThinkUpController {
                 $this->page, $this->is_public, $this->include_rts, $this->order_by, $this->direction);
                 break;
 
+                
+                /*
+                 * Gets posts a user is mentioned in.within a date range
+                 *
+                 * Required arguments: user_id or username, from and until
+                 *
+                 * Optional arguments: network, count, page, include_rts, include_entities, include_replies, trim_user
+                 */
+            case 'user_mentions_in_range':
+              	if (is_null($this->from) || is_null($this->until)) {
+                    $m = 'A request of type ' . $this->type . ' requires valid from and until parameters to be ';
+                    $m .= 'specified.';
+                    throw new RequiredArgumentMissingException($m);
+                } else {                
+                	$data = $this->post_dao->getAllMentionsInRange($this->user->username, $this->count, $this->network,
+                		$this->from, $this->until, $this->page, $this->is_public, $this->include_rts,$this->order_by, 
+                		$this->direction);
+                }
+                break;
+                
                 /*
                  * Gets question posts a user has made.
                  *
@@ -502,6 +544,21 @@ class PostAPIController extends ThinkUpController {
                 break;
 
                 /*
+                 * Gets question posts a user has made within a date range
+                 *
+                 * Required arguments: user_id or username, from and until
+                 *
+                 * Optional arguments: network, count, page, order_by, direction, include_entities, include_replies,
+                 * trim_user
+                 *
+                 * Docs: http://thinkupapp.com/docs/userguide/api/posts/user_questions.html
+                 */                
+            case 'user_questions_in_range':
+                $data = $this->post_dao->getAllQuestionPostsInRange($this->user->user_id, $this->network, $this->count, $this->from, $this->until,
+                $this->page, $this->order_by, $this->direction, $this->is_public);
+                break;
+                
+                /*
                  * Gets replies to a user.
                  *
                  * Required arguments: user_id or username
@@ -515,7 +572,22 @@ class PostAPIController extends ThinkUpController {
                 $data = $this->post_dao->getAllReplies($this->user->user_id, $this->network, $this->count,
                 $this->page, $this->order_by, $this->direction, $this->is_public);
                 break;
-
+                
+                /*
+                 * Gets replies to a user within a date range.
+                 *
+                 * Required arguments: user_id or username, from and until
+                 *
+                 * Optional arguments: network, count, page, order_by, direction, include_entities, include_replies,
+                 * trim_user
+                 *
+                 * http://thinkupapp.com/docs/userguide/api/posts/user_replies.html
+                 */
+            case 'user_replies_in_range':
+                $data = $this->post_dao->getAllRepliesInRange($this->user->user_id, $this->network, $this->count,$this->from, $this->until,
+                $this->page, $this->order_by, $this->direction, $this->is_public);
+                break;
+                
                 /*
                  * Generate an error because the API call type was not recognized.
                  *

--- a/webapp/_lib/dao/class.PostMySQLDAO.php
+++ b/webapp/_lib/dao/class.PostMySQLDAO.php
@@ -207,6 +207,81 @@ class PostMySQLDAO extends PDODAO implements PostDAO  {
         return $replies;
     }
 
+        public function getRepliesToPostInRange($post_id, $network, $from, $until, $order_by = 'default', $unit = 'km', $is_public = false,
+    $count = 350, $page = 1) {
+        $start_on_record = ($page - 1) * $count;
+
+        $q = "SELECT u.*, p.*, (CASE p.is_geo_encoded WHEN 0 THEN 9 ELSE p.is_geo_encoded END) AS geo_status, ";
+        $q .= "pub_date + interval #gmt_offset# hour as adj_pub_date ";
+        $q .= "FROM #prefix#posts p ";
+        $q .= "INNER JOIN #prefix#users AS u ON p.author_user_id = u.user_id AND u.network = :user_network ";
+        $q .= "WHERE p.network=:network AND in_reply_to_post_id=:post_id AND pub_date BETWEEN :from AND :until ";
+        if ($is_public) {
+            $q .= "AND u.is_protected = 0 ";
+        }
+
+        $class_name = ucfirst($network) . 'Plugin';
+        $ordering = @call_user_func($class_name.'::repliesOrdering', $order_by);
+        if (empty($ordering)) {
+            $ordering = 'pub_date ASC ';
+        } else {
+            $ordering .= ', pub_date ASC ';
+        }
+        $q .= 'ORDER BY ' . $ordering. ';';
+
+
+        $vars = array(
+            ':post_id'=>(string)$post_id,
+            ':network'=>$network,
+            ':user_network'=>($network == 'facebook page') ? 'facebook' : $network,
+            ':from' => $from,
+            ':until' => $until
+            
+        );
+
+
+        if ($this->profiler_enabled) Profiler::setDAOMethod(__METHOD__);
+        $ps = $this->execute($q, $vars);
+        $all_post_rows = $this->getDataRowsAsArrays($ps);
+
+        $replies = array();
+        if ($all_post_rows) {
+            $post_keys_array = array();
+            foreach ($all_post_rows as $row) {
+                $post_keys_array[] = $row['id'];
+            }
+
+            // Get links
+            $q = "SELECT * FROM #prefix#links WHERE post_key in (".implode(',', $post_keys_array).")";
+            if ($this->profiler_enabled) Profiler::setDAOMethod(__METHOD__);
+            $ps = $this->execute($q);
+            $all_link_rows = $this->getDataRowsAsArrays($ps);
+
+            // Combine posts and links
+            $location = array();
+            foreach ($all_post_rows as $post_row) {
+                if ($post_row['is_geo_encoded'] == 1) {
+                    $post_row['short_location'] = $this->processLocationRows($post_row['location']);
+                    if ($unit == 'mi') {
+                        $post_row['reply_retweet_distance'] =
+                        $this->calculateDistanceInMiles($post_row['reply_retweet_distance']);
+                    }
+                }
+
+                $post = new Post($post_row);
+                $user = new User($post_row, '');
+                $post->author = $user;
+                foreach ($all_link_rows as $link_row) {
+                    if ($link_row['post_key'] == $post->id) {
+                        $post->addLink(new Link($link_row));
+                    }
+                }
+                $replies[] = $post;
+            }
+        }
+        return $replies;
+    }
+    
     public function getRepliesToPostIterator($post_id, $network, $order_by = 'default', $unit = 'km',
     $is_public = false, $count = 350, $page = 1) {
         $start_on_record = ($page - 1) * $count;
@@ -911,6 +986,65 @@ class PostMySQLDAO extends PDODAO implements PostDAO  {
         return $posts;
     }
 
+    public function getAllQuestionPostsInRange($author_id, $network, $count, $from, $until, $page=1, $order_by = 'pub_date',
+    $direction = 'DESC', $is_public = false) {
+
+        $order_by = $this->sanitizeOrderBy($order_by);
+
+        $direction = $direction == 'DESC' ? 'DESC' : 'ASC';
+
+        if ($is_public) {
+            $protected = 'AND p.is_protected = 0';
+        } else {
+            $protected = '';
+        }
+
+        $q = "SELECT p.*, pub_date + interval #gmt_offset# hour as adj_pub_date FROM ( SELECT * ";
+        $q .= "FROM #prefix#posts p ";
+        $q .= "WHERE p.author_user_id = :author_id AND p.network=:network AND pub_date BETWEEN :from AND :until ";
+        $q .= "AND (in_reply_to_post_id IS null OR in_reply_to_post_id = 0) $protected) AS p ";
+        $q .= "WHERE post_text RLIKE :format1 OR post_text like :format2 ";
+        $q .= "ORDER BY " . $order_by. ' ' . $direction . ' ';
+        $vars = array(
+            ':author_id'=>(string)$author_id,
+            ':network'=>$network,
+            ':format1'=>"\\?$",
+            ':format2'=>"%\\? %",
+            ':from' => $from,
+            ':until' => $until 
+            
+        );
+        if ($this->profiler_enabled) Profiler::setDAOMethod(__METHOD__);
+        $ps = $this->execute($q, $vars);
+        $all_post_rows = $this->getDataRowsAsArrays($ps);
+        $posts = array();
+
+        if ($all_post_rows) {
+            $post_keys_array = array();
+            foreach ($all_post_rows as $row) {
+                $post_keys_array[] = $row['id'];
+            }
+
+            // Get links
+            $q = "SELECT * FROM #prefix#links WHERE post_key in (".implode(',', $post_keys_array).")";
+            if ($this->profiler_enabled) Profiler::setDAOMethod(__METHOD__);
+            $ps = $this->execute($q);
+            $all_link_rows = $this->getDataRowsAsArrays($ps);
+
+            // Combine posts and links
+            foreach ($all_post_rows as $post_row) {
+                $post = new Post($post_row);
+                foreach ($all_link_rows as $link_row) {
+                    if ($link_row['post_key'] == $post->id) {
+                        $post->addLink(new Link($link_row));
+                    }
+                }
+                $posts[] = $post;
+            }
+        }
+        return $posts;
+    }    
+    
     /**
      * Get all posts by a given user with configurable order by field and direction
      * @param int $author_id
@@ -1317,6 +1451,81 @@ class PostMySQLDAO extends PDODAO implements PostDAO  {
         return $posts;
     }
 
+    public function getAllMentionsInRange($author_username, $count, $network = "twitter", $from, $until, $page=1, 
+    	$public=false, $include_rts = true, $order_by = 'pub_date', $direction = 'DESC') {
+        return $this->getMentionsInRange($author_username, $count, $network, $from, $until, $iterator = false, $page, 
+        $public, $include_rts, $order_by, $direction);
+    }
+
+    private function getMentionsInRange($author_username, $count, $network, $from, $until, $iterator, $page=1, $public=false,
+    $include_rts = true, $order_by = 'pub_date', $direction = 'DESC') {
+        $start_on_record = ($page - 1) * $count;
+
+        $order_by = $this->sanitizeOrderBy($order_by);
+
+        $direction = ($direction == 'DESC') ? 'DESC' : 'ASC';
+
+        $author_username = '@'.$author_username;
+        $q = " SELECT p.*, u.*, pub_date + interval #gmt_offset# hour as adj_pub_date ";
+        $q .= "FROM #prefix#posts AS p ";
+        $q .= "INNER JOIN #prefix#users AS u ON p.author_user_id = u.user_id ";
+       	$q .= "WHERE p.network = :network AND pub_date BETWEEN :from AND :until ";
+                
+        if ( strlen($author_username) > PostMySQLDAO::FULLTEXT_CHAR_MINIMUM ) {
+            $q .= "AND MATCH (`post_text`) AGAINST(:author_username IN BOOLEAN MODE) ";
+        } else {
+            $author_username = '%'.$author_username .'%';
+            $q .= "AND post_text LIKE :author_username ";
+        }
+        if ($public) {
+            $q .= "AND u.is_protected = 0 ";
+        }
+
+        if ($include_rts == false) {
+            $q .= 'AND p.in_retweet_of_post_id IS NULL ';
+        }
+        $q .= "ORDER BY $order_by $direction ";
+        $vars = array(
+            ':author_username'=>$author_username,
+            ':network'=>$network,
+            ':from' => $from,
+            ':until' => $until
+        );
+        if ($this->profiler_enabled) Profiler::setDAOMethod(__METHOD__);
+        $ps = $this->execute($q, $vars);
+        if ($iterator) {
+            return (new PostIterator($ps));
+        }
+        $all_post_rows = $this->getDataRowsAsArrays($ps);
+        $posts = array();
+
+        if ($all_post_rows) {
+            $post_keys_array = array();
+            foreach ($all_post_rows as $row) {
+                $post_keys_array[] = $row['id'];
+            }
+
+            // Get links
+            $q = "SELECT * FROM #prefix#links WHERE post_key in (".implode(',', $post_keys_array).")";
+            if ($this->profiler_enabled) Profiler::setDAOMethod(__METHOD__);
+            $ps = $this->execute($q);
+            $all_link_rows = $this->getDataRowsAsArrays($ps);
+
+            // Combine posts and links
+            $posts = array();
+            foreach ($all_post_rows as $post_row) {
+                $post = new Post($post_row);
+                foreach ($all_link_rows as $link_row) {
+                    if ($link_row['post_key'] == $post->id) {
+                        $post->addLink(new Link($link_row));
+                    }
+                }
+                $posts[] = $post;
+            }
+        }
+        return $posts;
+    }
+
     public function getAllReplies($user_id, $network, $count, $page = 1, $order_by = 'pub_date', $direction = 'DESC',
     $is_public = false) {
         $start_on_record = ($page - 1) * $count;
@@ -1371,6 +1580,61 @@ class PostMySQLDAO extends PDODAO implements PostDAO  {
         return $posts;
     }
 
+     public function getAllRepliesInRange($user_id, $network, $count, $from, $until,$page = 1, $order_by = 'pub_date', $direction = 'DESC',
+    $is_public = false) {
+        $start_on_record = ($page - 1) * $count;
+
+        $order_by = $this->sanitizeOrderBy($order_by);
+
+        $direction = $direction == 'DESC' ? 'DESC' : 'ASC';
+
+        $q = "SELECT p.*, u.*, pub_date + interval #gmt_offset# hour as adj_pub_date ";
+        $q .= "FROM #prefix#posts p ";
+        $q .= "INNER JOIN #prefix#users u ON p.author_user_id = u.user_id ";
+        $q .= "WHERE in_reply_to_user_id = :user_id AND p.network=:network AND pub_date BETWEEN :from AND :until ";
+        if ($is_public) {
+            $q .= 'AND p.is_protected = 0 ';
+        }
+        $q .= "ORDER BY " . $order_by. ' ' . $direction . ' ';
+        $vars = array(
+            ':user_id'=>(string)$user_id,
+            ':network'=>$network,
+            ':from' => $from,
+            ':until' => $until
+        );
+               
+        if ($this->profiler_enabled) Profiler::setDAOMethod(__METHOD__);
+        $ps = $this->execute($q, $vars);
+        $all_post_rows = $this->getDataRowsAsArrays($ps);
+        $posts = array();
+
+        if ($all_post_rows) {
+            $post_keys_array = array();
+            foreach ($all_post_rows as $row) {
+                $post_keys_array[] = $row['id'];
+            }
+
+            // Get links
+            $q = "SELECT * FROM #prefix#links WHERE post_key in (".implode(',', $post_keys_array).")";
+            if ($this->profiler_enabled) Profiler::setDAOMethod(__METHOD__);
+            $ps = $this->execute($q);
+            $all_link_rows = $this->getDataRowsAsArrays($ps);
+
+            // Combine posts and links
+            $posts = array();
+            foreach ($all_post_rows as $post_row) {
+                $post = new Post($post_row);
+                foreach ($all_link_rows as $link_row) {
+                    if ($link_row['post_key'] == $post->id) {
+                        $post->addLink(new Link($link_row));
+                    }
+                }
+                $posts[] = $post;
+            }
+        }
+        return $posts;
+    }
+    
     public function getMostRepliedToPosts($user_id, $network, $count, $page=1, $is_public = false) {
         return $this->getAllPostsByUserID($user_id, $network, $count, "reply_count_cache", "DESC", true, $page,
         $iterator = false, $is_public);

--- a/webapp/_lib/dao/interface.PostDAO.php
+++ b/webapp/_lib/dao/interface.PostDAO.php
@@ -53,6 +53,21 @@ interface PostDAO {
     $count = 350, $page = 1);
 
     /**
+     * Get replies to a post on a given time frame.
+     * @param str $post_id
+     * @param str $network
+     * @param str $order_by Order of sorting posts
+     * @param int $unit Defaults to km
+     * @param bool $public Defaults to false
+     * @param int $count Defaults to 350
+     * @param int $page The page of results to return. Defaults to 1. Pages start
+     * at 1, not 0.
+     * @return array Posts with author object set, and optional link object set
+     */
+    public function getRepliesToPostInRange($post_id, $network, $from, $until, $order_by = 'default', $unit = 'km', $is_public = false,
+    $count = 350, $page = 1);
+   
+    /**
      * Get replies Iterator to a post
      * @param str $post_id
      * @param str $network
@@ -346,6 +361,22 @@ interface PostDAO {
     $include_rts = true, $order_by = 'pub_date', $direction = 'DESC');
 
     /**
+     * Get a certain number of mentions of a username on a given network and on a given time frame.
+     * @param str  $author_username
+     * @param int $count
+     * @param str $network defaults to "twitter"
+     * @param int $page Page number, defaults to 1
+     * @param bool $public Public mentions only, defaults to false
+     * @param bool $include_rts Whether or not to include retweets. Defaults to true.
+     * @param str $order_by The database column to order the results by.
+     * @param str $direction The direction with which to order the results. Defaults
+     * to "DESC".
+     * @return array of Post objects with author and link set
+     */
+    public function getAllMentionsInRange($author_username, $count, $network = "twitter", $from, $until, $page=1, $public=false,
+    $include_rts = true, $order_by = 'pub_date', $direction = 'DESC');
+    
+    /**
      * Get all replies to a given user ID
      * @param int $user_id
      * @param str $network
@@ -360,7 +391,23 @@ interface PostDAO {
      */
     public function getAllReplies($user_id, $network, $count, $page = 1, $order_by = 'pub_date', $direction = 'DESC',
     $is_public = false);
-
+  
+    /**
+     * Get all replies to a given user ID on a given time frame.
+     * @param int $user_id
+     * @param str $network
+     * @param int $count
+     * @param int $page Page number, defaults to 1
+     * @param str $order_by The database column to order the results by.
+     * @param str $direction The direction with which to order the results. Defaults
+     * to "DESC".
+     * @param bool $is_public Whether or not the result of the method call will be displayed publicly. Defaults to
+     * false.
+     * @return array Posts with author and link set
+     */
+    public function getAllRepliesInRange($user_id, $network, $count, $from, $until, $page = 1, $order_by = 'pub_date', $direction = 'DESC',
+    $is_public = false);
+ 
     /**
      * Get posts by a user ordered by reply count desc
      * @param int $user_id


### PR DESCRIPTION
API date range calls for: user_mentions, user_questions, user_replies and
post replies.

Following up on your comments from (https://github.com/ginatrapani/ThinkUp/pull/1376):
- Cleaned up code formatting n' stuff. 
- Contains appropriate tests and documentation for the added calls.
- Code is pretty straightforward and tries to follow existing style.

_API calls do not have a configurable count limit, following up on the
philosophy for the other range calls. Documentation has been tweaked
to reflect this._

Please let me know if all is correct and if it's OK to do the pull request
on your master. Used latest code this time =)

Thanks!

_Powered by Televisió de Catalunya - SOCIALMEDIA PROJECT - CEN-20101037 - This contribution has been kindly sponsored by the Centro para el Desarrollo Tecnológico Industrial within the Programa de Investigación Nacional Español CENIT. - http://www.cenitsocialmedia.es/_
