### PR TITLE
Separated DB-spesific tests from DB-generic tests

### DIFF
--- a/tests/all_MySQL_model_tests.php
+++ b/tests/all_MySQL_model_tests.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ *
+ * ThinkUp/tests/all_MySQL_model_tests.php
+ *
+ * Copyright (c) 2009-2012 Gina Trapani
+ *
+ * LICENSE:
+ *
+ * This file is part of ThinkUp (http://thinkupapp.com).
+ *
+ * ThinkUp is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * ThinkUp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with ThinkUp.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
+ * @author Christoffer Viken <christoffer[at]viken[dot]me>
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2009-2012 Gina Trapani
+ */
+include dirname(__FILE__) . '/init.tests.php';
+require_once THINKUP_WEBAPP_PATH.'_lib/extlib/simpletest/autorun.php';
+require_once THINKUP_WEBAPP_PATH.'_lib/extlib/simpletest/web_tester.php';
+require_once THINKUP_WEBAPP_PATH.'_lib/extlib/simpletest/mock_objects.php';
+
+/* MySQL MODEL TESTS */
+$model_tests = new TestSuite('MySQL Model tests');
+$model_tests->add(new TestOfFollowMySQLDAO());
+$model_tests->add(new TestOfFollowerCountMySQLDAO());
+$model_tests->add(new TestOfGroupMySQLDAO());
+$model_tests->add(new TestOfGroupMemberMySQLDAO());
+$model_tests->add(new TestOfGroupMembershipCountMySQLDAO());
+$model_tests->add(new TestOfInsightBaselineMySQLDAO());
+$model_tests->add(new TestOfInsightMySQLDAO());
+$model_tests->add(new TestOfInstanceMySQLDAO());
+$model_tests->add(new TestOfInsightMySQLDAO());
+$model_tests->add(new TestOfInstallerMySQLDAO());
+$model_tests->add(new TestOfInviteMySQLDAO());
+$model_tests->add(new TestOfLinkMySQLDAO());
+$model_tests->add(new TestOfLocationMySQLDAO());
+$model_tests->add(new TestOfOptionMySQLDAO());
+$model_tests->add(new TestOfOwnerMySQLDAO());
+$model_tests->add(new TestOfOwnerInstanceMySQLDAO());
+$model_tests->add(new TestOfPluginMySQLDAO());
+$model_tests->add(new TestOfPluginOptionMySQLDAO());
+$model_tests->add(new TestOfPostMySQLDAO());
+$model_tests->add(new TestOfExportMySQLDAO());
+$model_tests->add(new TestOfPostErrorMySQLDAO());
+$model_tests->add(new TestOfUserMySQLDAO());
+$model_tests->add(new TestOfUserErrorMySQLDAO());
+$model_tests->add(new TestOfMutexMySQLDAO());
+$model_tests->add(new TestOfBackupMySQLDAO());
+$model_tests->add(new TestOfFavoritePostMySQLDAO());
+$model_tests->add(new TestOfStreamDataMySQLDAO());
+$model_tests->add(new TestOfStreamProcMySQLDAO());
+$model_tests->add(new TestOfHashtagMySQLDAO());
+$model_tests->add(new TestOfMentionMySQLDAO());
+$model_tests->add(new TestOfPlaceMySQLDAO());
+$model_tests->add(new TestOfTableStatsMySQLDAO());
+$model_tests->add(new TestOfShortLinkMySQLDAO());
+
+$tr = new TextReporter();
+list($usec, $sec) = explode(" ", microtime());
+$start =  ((float)$usec + (float)$sec);
+$model_tests->run( $tr );
+
+if (getenv("TEST_TIMING")=="1") {
+    list($usec, $sec) = explode(" ", microtime());
+    $finish =  ((float)$usec + (float)$sec);
+    $runtime = round($finish - $start);
+    printf("Tests completed run in $runtime seconds\n");
+}
+if (isset($RUNNING_ALL_TESTS) && $RUNNING_ALL_TESTS) {
+    $TOTAL_PASSES = $TOTAL_PASSES + $tr->getPassCount();
+    $TOTAL_FAILURES = $TOTAL_FAILURES + $tr->getFailCount();
+}

--- a/tests/all_model_tests.php
+++ b/tests/all_model_tests.php
@@ -21,7 +21,8 @@
  * <http://www.gnu.org/licenses/>.
  *
  *
- * @author Gina Trapani <ginatrapani[at]gmail[dot]com>
+ * @author Gina Trapani <ginatrapani[at]gmail[dot]com> 
+ * @author Christoffer Viken <christoffer[at]viken[dot]me>
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2009-2012 Gina Trapani
  */
@@ -38,58 +39,25 @@ $model_tests->add(new TestOfDAOFactory());
 $model_tests->add(new TestOfConfig());
 $model_tests->add(new TestOfFileDataManager());
 $model_tests->add(new TestOfCrawler());
-$model_tests->add(new TestOfFollowMySQLDAO());
-$model_tests->add(new TestOfFollowerCountMySQLDAO());
-$model_tests->add(new TestOfGroupMySQLDAO());
-$model_tests->add(new TestOfGroupMemberMySQLDAO());
-$model_tests->add(new TestOfGroupMembershipCountMySQLDAO());
-$model_tests->add(new TestOfInsightBaselineMySQLDAO());
-$model_tests->add(new TestOfInsightMySQLDAO());
-$model_tests->add(new TestOfInstanceMySQLDAO());
-$model_tests->add(new TestOfInsightMySQLDAO());
 $model_tests->add(new TestOfDashboardModuleCacher());
 $model_tests->add(new TestOfInstaller());
-$model_tests->add(new TestOfInstallerMySQLDAO());
-$model_tests->add(new TestOfInviteMySQLDAO());
-$model_tests->add(new TestOfLinkMySQLDAO());
 $model_tests->add(new TestOfLoader());
-$model_tests->add(new TestOfLocationMySQLDAO());
 $model_tests->add(new TestOfMailer());
-$model_tests->add(new TestOfOptionMySQLDAO());
 $model_tests->add(new TestOfOwner());
-$model_tests->add(new TestOfOwnerMySQLDAO());
-$model_tests->add(new TestOfOwnerInstanceMySQLDAO());
 $model_tests->add(new TestOfPlugin());
-$model_tests->add(new TestOfPluginMySQLDAO());
-$model_tests->add(new TestOfPluginOptionMySQLDAO());
 $model_tests->add(new TestOfPluginRegistrar());
 $model_tests->add(new TestOfPost());
-$model_tests->add(new TestOfPostMySQLDAO());
-$model_tests->add(new TestOfExportMySQLDAO());
-$model_tests->add(new TestOfPostErrorMySQLDAO());
 $model_tests->add(new TestOfProfiler());
 $model_tests->add(new TestOfSession());
 $model_tests->add(new TestOfSessionCache());
 $model_tests->add(new TestOfViewManager());
-$model_tests->add(new TestOfUserMySQLDAO());
-$model_tests->add(new TestOfUserErrorMySQLDAO());
 $model_tests->add(new TestOfUtils());
 $model_tests->add(new TestOfWebapp());
 $model_tests->add(new TestOfMenuItem());
 $model_tests->add(new TestOfDataset());
 $model_tests->add(new TestOfPostIterator());
-$model_tests->add(new TestOfMutexMySQLDAO());
-$model_tests->add(new TestOfBackupMySQLDAO());
-$model_tests->add(new TestOfFavoritePostMySQLDAO());
-$model_tests->add(new TestOfStreamDataMySQLDAO());
-$model_tests->add(new TestOfStreamProcMySQLDAO());
-$model_tests->add(new TestOfHashtagMySQLDAO());
-$model_tests->add(new TestOfMentionMySQLDAO());
-$model_tests->add(new TestOfPlaceMySQLDAO());
 $model_tests->add(new TestOfPDODAO());
 $model_tests->add(new TestOfURLProcessor());
-$model_tests->add(new TestOfTableStatsMySQLDAO());
-$model_tests->add(new TestOfShortLinkMySQLDAO());
 
 $tr = new TextReporter();
 list($usec, $sec) = explode(" ", microtime());

--- a/tests/all_tests.php
+++ b/tests/all_tests.php
@@ -55,6 +55,8 @@ $start_time = microtime(true);
 
 require_once THINKUP_ROOT_PATH.'tests/all_model_tests.php';
 
+require_once THINKUP_ROOT_PATH.'tests/all_MySQL_model_tests.php';
+
 require_once THINKUP_ROOT_PATH.'tests/all_plugin_tests.php';
 
 require_once THINKUP_ROOT_PATH.'tests/all_integration_tests.php';

--- a/tests/all_unit_tests.php
+++ b/tests/all_unit_tests.php
@@ -55,6 +55,8 @@ $start_time = microtime(true);
 
 require_once THINKUP_ROOT_PATH.'tests/all_model_tests.php';
 
+require_once THINKUP_ROOT_PATH.'tests/all_MySQL_model_tests.php';
+
 require_once THINKUP_ROOT_PATH.'tests/all_plugin_tests.php';
 
 require_once THINKUP_ROOT_PATH.'tests/all_controller_tests.php';


### PR DESCRIPTION
Makes it easier to run tests on multiple DB engines.
Shouldn't introduce test failures but I could be mistaken

As it turns out I am mistaken:
http://travis-ci.org/#!/CVi/ThinkUp/jobs/2514060
Gives out the same set of error as:
https://groups.google.com/a/expertlabs.org/forum/#!topic/thinkup-dev/1Gz2M8Pe-f4
That turned out to be a MySQL version issue.

Anyone willing to figure out how this happened, or if it is just me.

Actually, if it fails for real (and it is not just me) let's open an issue on it. (and just close this Pull request)
