### PR TITLE
Issue #1395: Removed the extra 'main' and 'page' from the Style Guide 

### DIFF
--- a/docs/source/contribute/developers/writecode/styleguide/php.rst
+++ b/docs/source/contribute/developers/writecode/styleguide/php.rst
@@ -1,8 +1,8 @@
 PHP Code Style Guide
 ====================
 
-This is the Code Style guide for PHP. See the main :doc:`main page </contribute/developers/writecode/styleguide/index>` 
-page for general guidelines and guides specific to other languages.
+This is the Code Style guide for PHP. See the :doc:`main page </contribute/developers/writecode/styleguide/index>` 
+for general guidelines and guides specific to other languages.
 
 Assume we're using `the Drupal PHP coding style <http://drupal.org/coding-standards>`_ unless otherwise noted here.
 


### PR DESCRIPTION
We had repeated text, left over from when the 'main page' link was put into place in the PHP Style Guide documentation
