### PR TITLE
Issue #1396: Fixed mailing list link on Reporting page in documentation

### DIFF
--- a/docs/source/troubleshoot/report.rst
+++ b/docs/source/troubleshoot/report.rst
@@ -9,7 +9,7 @@ Step 1: Search
 --------------
 
 To avoid duplicate work, search `ThinkUp's documentation <http://thinkupapp.com/docs/>`_, 
-`mailing list archive <https://github.com/ginatrapani/ThinkUp/issues>`_ and
+`mailing list archive <https://groups.google.com/forum/?pli=1#!forum/thinkupapp>`_ and
 `issue tracker <https://github.com/ginatrapani/ThinkUp/issues>`_ to make sure your
 problem or idea hasn't already been documented, discussed or reported. If it has, follow up on the existing mailing
 list thread thread or issue tracker comment thread to discuss further.


### PR DESCRIPTION
Used to point at the Github issue tracker, now points at the Thinkupapp Google Group
