### PR TITLE
Issue #1381: Autofocus on Email field on Login page

### DIFF
--- a/tests/WebTestOfLogin.php
+++ b/tests/WebTestOfLogin.php
@@ -94,4 +94,9 @@ class WebTestOfLogin extends ThinkUpWebTestCase {
             $i = $i + 1;
         }
     }
+
+    public function testAutofocusOnUserField() {
+      $this->get($this->url.'/session/login.php');
+      $this->assertPattern('/autofocus="autofocus"/');
+    }
 }

--- a/webapp/_lib/view/session.login.tpl
+++ b/webapp/_lib/view/session.login.tpl
@@ -22,7 +22,7 @@
                 </label>
               </div>
               <div class="grid_10 left">
-                <input type="text" name="email" id="email"{if isset($email)} value="{$email|filter_xss}"{/if}>
+                <input type="text" name="email" id="email"{if isset($email)} value="{$email|filter_xss}"{/if} autofocus="autofocus">
               </div>
             </div>
             <div class="clearfix">


### PR DESCRIPTION
Wrote a simple test to check for the autofocus attribute on the Login page -
there isn't another way to check for this behaviour using SimpleTest as far as I can tell. Also, I'm not sure the test is hugely useful, since we can _actually_ test the _behaviour_

Added the attribute to the user field on the login page to make compatible browsers focus the field.
