### PR TITLE
Issue #1291: Minor Issues in Documentation for Test Env Setup

### DIFF
--- a/docs/source/contribute/developers/tests.rst
+++ b/docs/source/contribute/developers/tests.rst
@@ -23,8 +23,8 @@ In order for the tests to pass, you must:
 
 -  Have a ``tests/config.tests.inc.php`` file with the correct values
    set
--  Set the crawler log file in ``webapp/config.inc.php`` and make that
-   file writable
+-  Setup the crawler, stream and sql log files in ``webapp/config.inc.php``
+   and make those files writable
 -  Set the test database name to an empty tests database which the tests
    will destroy each run in ``webapp/config.inc.php``
 -  Set the test database user to a user with all privileges in the test
@@ -38,7 +38,7 @@ source code root folder, use this command:
 
 ::
 
-    $ php tests/TestOfUserDAO.php
+    $ php tests/TestOfUserMySQLDAO.php
 
 To run all the test suites, use:
 
@@ -56,7 +56,7 @@ To see all the available options, run:
 
 ::
 
-    $ php tests/all_tests -help
+    $ php tests/all_tests.php -help
 
 Writing Tests
 -------------

--- a/webapp/config.sample.inc.php
+++ b/webapp/config.sample.inc.php
@@ -48,18 +48,18 @@ $THINKUP_CFG['table_prefix']              = 'tu_';
 /************************************************/
 
 // Full server path to crawler.log.
-// $THINKUP_CFG['log_location']              = $THINKUP_CFG['datadir_path'] . '/logs/crawler.log';
+// $THINKUP_CFG['log_location']              = $THINKUP_CFG['datadir_path'] . 'logs/crawler.log';
 $THINKUP_CFG['log_location']              = false;
 
 // Verbosity of log. 0 is everything, 1 is user messages, 2 is errors only
 $THINKUP_CFG['log_verbosity']             = 0;
 
 // Full server path to stream processor log.
-// $THINKUP_CFG['stream_log_location']       = $THINKUP_CFG['datadir_path'] . '/logs/stream.log';
+// $THINKUP_CFG['stream_log_location']       = $THINKUP_CFG['datadir_path'] . 'logs/stream.log';
 $THINKUP_CFG['stream_log_location']       = false;
 
 // Full server path to sql.log. To not log queries, set to null.
-// $THINKUP_CFG['sql_log_location']          = $THINKUP_CFG['datadir_path'] . '/logs/sql.log';
+// $THINKUP_CFG['sql_log_location']          = $THINKUP_CFG['datadir_path'] . 'logs/sql.log';
 $THINKUP_CFG['sql_log_location']          = null;
 
 // How many seconds does a query take before it gets logged as a slow query?


### PR DESCRIPTION
- Removed leading '/' directory separator from log file variables
  in config.sample.in.php, to remove duplication of the same
- Test file documentation pointed to a test that doesn't exist -
  changed this to point to the closest existing Test
  (TestOfUserMySQLDAO.php)
- added trailing '.php' to 'all_tests.php -help'
- Added stream and sql log files to the setup information
