### PR TITLE
Fix broken link in the registration email

### DIFF
--- a/webapp/_lib/view/_email.registration.tpl
+++ b/webapp/_lib/view/_email.registration.tpl
@@ -1,5 +1,5 @@
 Click on the link below to activate your new account on {$app_title|filter_xss}:
 
-{$application_url}session/activate.php?usr={$email}&code={$activ_code}
+{$application_url}/session/activate.php?usr={$email}&code={$activ_code}
 
 Thanks for registering!


### PR DESCRIPTION
The link generated to activate an account is incorrect (there is a missing slash) so unless the user can recognise the issue they will be unable to activate their account.
