### PR TITLE
Updated linkify javascript to skip email username for logged in user

### DIFF
--- a/tests/TestOfDashboardController.php
+++ b/tests/TestOfDashboardController.php
@@ -362,6 +362,20 @@ class TestOfDashboardController extends ThinkUpUnitTestCase {
         $this->assertNoPattern("/This is post <script>alert\('wa'\);<\/script>\d+/", $results);
         $this->assertPattern("/This is post &#60;script&#62;alert\(&#39;wa&#39;\);&#60;\/script&#62;\d+/", $results);
     }
+    
+    public function testLoggedInUserNoAutoLinkEmail() {
+        $builders = $this->buildData();
+        $this->simulateLogin('me@example.com');
+        //required params
+        $_GET['u'] ='ev';
+        $_GET['n'] = 'twitter';
+        $_GET['v'] = '';
+        $controller = new DashboardController(true);
+        $results = $controller->go();
+
+        $config = Config::getInstance();
+        $this->assertPattern('/<script>var logged_in_user = \'me@example.com\';<\/script>/', $results);
+    }
 
     private function buildData($with_xss = false) {
         //Add owner

--- a/webapp/_lib/view/_statusbar.tpl
+++ b/webapp/_lib/view/_statusbar.tpl
@@ -52,6 +52,7 @@
     <ul> 
       {if $logged_in_user}
         <li>Logged in as{if $user_is_admin} admin{/if}: {$logged_in_user} {if $user_is_admin}<script src="{$site_root_path}install/checkversion.php"></script>{/if}<a href="{$site_root_path}account/?m=manage" class="linkbutton">Settings</a> <a href="{$site_root_path}session/logout.php" class="linkbutton">Log Out</a></li>
+        <script>var logged_in_user = '{$logged_in_user}';</script>
       {else}
       
         <li><a href="http://thinkupapp.com/" class="linkbutton">Get ThinkUp</a> <a href="{$site_root_path}session/login.php" class="linkbutton"    >Log In</a></li>

--- a/webapp/assets/js/linkify.js
+++ b/webapp/assets/js/linkify.js
@@ -14,9 +14,16 @@ for (i=0; el=res.snapshotItem(i); i++) {
 			//create a span to hold the new text with links in it
 			span=document.createElement('span');
 		}
-
+                
 		//get the link without trailing dots
 		l=m[0].replace(/\.*$/, '');
+                
+                // if it's the logged in user
+                if ( typeof(logged_in_user) != 'undefined' && l == logged_in_user ) {
+                    // skip
+                    continue;
+                }
+                
 		//put in text up to the link
 		span.appendChild(document.createTextNode(txt.substring(p, m.index)));
 		//create a link and put it in the span


### PR DESCRIPTION
Fix for Issue #1318. Added javascript variable for logged in user's email address and a check in linkify javascript to skip that value.
