### PR TITLE
Made the Twitter post type graph look less dramatically

### DIFF
--- a/webapp/_lib/view/_dashboard.posttypes.tpl
+++ b/webapp/_lib/view/_dashboard.posttypes.tpl
@@ -45,6 +45,8 @@
                     textStyle: { color: '#000' },
                 },
                 vAxis: {
+                    minValue: 0,
+                    maxValue: 1,
                     textStyle: { color: '#666' },
                     gridlines: { color: '#ccc' },
                     format:'#,###%',


### PR DESCRIPTION
Hi,

I recently wondered about the Post Types Graph from Twitter plugin. 

![thinkup](https://f.cloud.github.com/assets/203902/36625/cfbdd488-5356-11e2-82a8-622868334a81.png)

This made me feel like I'm an incredible broadcaster at Twitter. I think the graph should show some more relationship to what you really tweeted about. Just added 2 lines more for the Google graph.

Tested on my machine and looks pretty much more what I was looking for:

![thinkup-posttypes2](https://f.cloud.github.com/assets/203902/36629/4cf6f84e-5357-11e2-9c95-ff78b2fb306a.png)

Greetings!
