### PR TITLE
Google+ plugin: url encoding for redirect solved

### DIFF
--- a/webapp/plugins/googleplus/controller/class.GooglePlusPluginConfigurationController.php
+++ b/webapp/plugins/googleplus/controller/class.GooglePlusPluginConfigurationController.php
@@ -94,7 +94,7 @@ class GooglePlusPluginConfigurationController extends PluginConfigurationControl
         //prep redirect URI
         $config = Config::getInstance();
         $site_root_path = $config->getValue('site_root_path');
-        $redirect_uri = urlencode(Utils::getApplicationURL() .'account/?p=google%2B');
+        $redirect_uri = urlencode(Utils::getApplicationURL() .'account/?p=googleplus');
 
         //create OAuth link
         $oauth_link = "https://accounts.google.com/o/oauth2/auth?client_id=".$client_id.

--- a/webapp/plugins/googleplus/view/googleplus.account.index.tpl
+++ b/webapp/plugins/googleplus/view/googleplus.account.index.tpl
@@ -39,7 +39,7 @@
             <span id="divactivate{$i->id}"><input type="submit" name="submit" id="{$i->id}" class="linkbutton {if $i->is_active}btnPause{else}btnPlay{/if}" value="{if $i->is_active}pause crawling{else}start crawling{/if}" /></span>
         </div>
         <div class="grid_8 right">
-            <span id="delete{$i->id}"><form method="post" action="{$site_root_path}account/?p=google%2B"><input type="hidden" name="instance_id" value="{$i->id}">
+            <span id="delete{$i->id}"><form method="post" action="{$site_root_path}account/?p=googleplus"><input type="hidden" name="instance_id" value="{$i->id}">
             {insert name="csrf_token"}<!-- delete account csrf token -->
             <input onClick="return confirm('Do you really want to delete this Google+ account from ThinkUp?');"  type="submit" name="action" class="linkbutton" value="delete" /></form></span>
         </div>
@@ -63,7 +63,7 @@
 <li>
   Edit the settings for your new Client ID then click "Next." Make sure "Application Type" is set to "Web Application" and set the first line of Authorized Redirect URIs to<br> 
     <small>
-      <code style="font-family:Courier;" id="clippy_2988">{$thinkup_site_url}account/?p=google%2B</code>
+      <code style="font-family:Courier;" id="clippy_2988">{$thinkup_site_url}account/?p=googleplus</code>
     </small>
     <object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
               width="100"


### PR DESCRIPTION
Not sure if this is all that is needed for the fix.
Also did not pay attention to possible tests...

This fixes a redirect error while adding a new user for the GooglePlus plugin.
The plus sign in the url (%2b) gets urlencoded twice, which causes a wrong redirect from google.

The uri called is /account/?p=google%252b, because the % is url encoded.
