### PR TITLE
Added check for writable session save path during installation

### DIFF
--- a/tests/TestOfInstaller.php
+++ b/tests/TestOfInstaller.php
@@ -95,6 +95,15 @@ class TestOfInstaller extends ThinkUpUnitTestCase {
         $this->assertTrue($perms['data_dir']);
         $this->assertTrue($perms['cache']);
     }
+    
+    public function testInstallerCheckSessionPermission() {
+        $installer = Installer::getInstance();
+        $perms = $installer->checkSessionPermission();
+        $this->assertTrue($perms['session_save_dir']);
+        
+        $permsFail = $installer->checkSessionPermission(array('session_save_dir' => false));
+        $this->assertFalse($permsFail['session_save_dir']);
+    }
 
     public function testInstallerCheckPath() {
         $installer = Installer::getInstance();

--- a/webapp/_lib/class.FileDataManager.php
+++ b/webapp/_lib/class.FileDataManager.php
@@ -73,4 +73,17 @@ class FileDataManager {
         }
         return $path;
     }
+    
+    /**
+     * Get the path to the php session save path
+     * @param str $file File or directory to get the path of
+     * @return str Absolute path to file
+     */
+    public static function getSessionSavePath($str = null) {
+        $path = ini_get('session.save_path');
+        if ($str) {
+            $path = $path . $str;
+        }        
+        return $path;
+    }    
 }

--- a/webapp/_lib/class.Installer.php
+++ b/webapp/_lib/class.Installer.php
@@ -254,6 +254,26 @@ class Installer {
         return $ret;
     }
 
+        /**
+     * Check if session directories are writeable
+     *
+     * @param array $perms can be used for testing for failing
+     * @return array 
+     */
+    public function checkSessionPermission($perms = array()) {
+        $session_save_dir = FileDataManager::getSessionSavePath();
+        $ret = array('session_save_dir' => false);
+        if ( is_writable($session_save_dir) ) {
+            $ret['session_save_dir'] = true;
+        }
+
+        // when testing
+        if ( defined('TESTS_RUNNING') && TESTS_RUNNING && !empty($perms) ) {
+            $ret = $perms;
+        }
+        return $ret;
+    }
+    
     /**
      * Check if Thinkup's paths exists.
      *
@@ -291,11 +311,17 @@ class Installer {
         foreach ($writeable_permission as $permission) {
             $writeable_permission_ret = $writeable_permission_ret && $permission;
         }
+        
+        $writeable_session_permission = $this->checkSessionPermission();
+        $writeable_session_permission_ret = true;
+        foreach ($writeable_session_permission as $session_permission) {
+            $writeable_session_permission_ret = $writeable_session_permission_ret && $session_permission;
+        }
         // when testing
         if ( defined('TESTS_RUNNING') && TESTS_RUNNING && !empty($pass) ) {
             $ret = $pass;
         } else {
-            $ret = ($version_compat && $lib_depends_ret && $writeable_permission_ret);
+            $ret = ($version_compat && $lib_depends_ret && $writeable_permission_ret && $writeable_session_permission);
         }
         return $ret;
     }

--- a/webapp/_lib/controller/class.InstallerController.php
+++ b/webapp/_lib/controller/class.InstallerController.php
@@ -155,9 +155,22 @@ class InstallerController extends ThinkUpController {
         }
         $this->addToView('permissions_compat', $permissions_compat);
         $this->addToView('writeable_data_directory', FileDataManager::getDataPath());
-
+        
+        // session save path permissions check
+        $session_permissions = $this->installer->checkSessionPermission();
+        $this->addToView('session_permission', $session_permissions);
+        $session_permissions_compat = true;
+        foreach ($session_permissions as $session_perm) {
+            if (!$session_perm) {
+                $session_permissions_compat = false;
+            }
+        }
+        
+        $this->addToView('session_permissions_compat', $session_permissions_compat);
+        $this->addToView('writeable_session_save_directory', FileDataManager::getSessionSavePath());
+        
         // other vars set to view
-        $requirements_met = ($php_compat && $libs_compat && $permissions_compat);
+        $requirements_met = ($php_compat && $libs_compat && $permissions_compat && $session_permissions_compat);
         $this->addToView('requirements_met', $requirements_met);
         $this->addToView('subtitle', 'Check System Requirements');
 

--- a/webapp/_lib/view/install.step1.tpl
+++ b/webapp/_lib/view/install.step1.tpl
@@ -200,6 +200,28 @@
               <p>ThinkUp's <code>data</code> directory, located at <code>{$writeable_data_directory}</code>, must be writable for installation to complete. <a href="http://thinkupapp.com/docs/install/perms.html">Here's how to set that folder's permissions.</a></p>
             </div>
             {/if}
+            
+            <div class="clearfix append_20">
+              <div class="grid_6 prefix_5 right">
+                {if $session_permissions_compat}
+                <span class="label">Session directory writeable</span>
+                {else}
+                <span class="label no">Session directory writeable?</span>
+                {/if}
+              </div>
+              <div class="grid_8 prefix_1 left">
+                {if $session_permissions_compat}
+                <span class="value yes">Yes</span>
+                {else}
+                <span class="value no">No</span>
+                {/if}
+              </div>
+            </div>
+            {if !$session_permissions_compat}
+            <div class="clearfix append_20 info_message">
+              <p>The PHP <code>session.save_path</code> directory, located at <code>{$writeable_session_save_directory}</code>, must be writable for installation to complete. <a href="http://php.net/manual/en/session.configuration.php#ini.session.save-path">Here's how to set that folder's permissions.</a></p>
+            </div>
+            {/if}
         {/if}
         
       </div>


### PR DESCRIPTION
Fix for Issue #1195. Added checks to make sure php session save directory is writable during installation process.
