### PR TITLE
1437 log in button mobile

### DIFF
--- a/webapp/_lib/view/session.forgot.tpl
+++ b/webapp/_lib/view/session.forgot.tpl
@@ -40,7 +40,7 @@
                             <span class="pull-right">
                                 <div class="btn-group">
                                     <a href="login.php" class="btn btn-mini">Log In</a>
-                                    {if $is_registration_open}<a href="register.php" class="btn btn-mini">Register</a>{else}{/if}
+                                    {if $is_registration_open}<a href="register.php" class="btn btn-mini hidden-phone">Register</a>{else}{/if}
                                     {insert name="help_link" id='forgot'}
                                 </div>
                             </span>

--- a/webapp/_lib/view/session.login.tpl
+++ b/webapp/_lib/view/session.login.tpl
@@ -37,7 +37,7 @@
                             <input type="submit" id="login-save" name="Submit" class="btn btn-primary" value="Log In">
                             <span class="pull-right">
                                 <div class="btn-group">
-                                    {if $is_registration_open}<a href="register.php" class="btn btn-mini">Register</a>{else}{/if}
+                                    {if $is_registration_open}<a href="register.php" class="btn btn-mini hidden-phone">Register</a>{else}{/if}
                                     <a href="forgot.php" class="btn btn-mini">Forgot password</a>
                                     {insert name="help_link" id='login'}
                                 </div>

--- a/webapp/_lib/view/session.resetpassword.tpl
+++ b/webapp/_lib/view/session.resetpassword.tpl
@@ -45,7 +45,7 @@
                             <span class="pull-right">
                                 <div class="btn-group">
                                     <a href="login.php" class="btn btn-mini">Log In</a>
-                                    {if $is_registration_open}<a href="register.php" class="btn btn-mini">Register</a>{else}{/if}
+                                    {if $is_registration_open}<a href="register.php" class="btn btn-mini hidden-phone">Register</a>{else}{/if}
                                     {insert name="help_link" id='reset'}
                                 </div>
                             </span>


### PR DESCRIPTION
Resolves https://github.com/ginatrapani/ThinkUp/issues/1437 by hiding the registration link when in a phone-sized viewport, and removes the "Registration disabled" notice universally, since disabled registration is none of anybody's business.
