### PR TITLE
Center header bar on mobile views, and minimize margins/spacing on mobil...

### DIFF
--- a/webapp/_lib/view/insights.tpl
+++ b/webapp/_lib/view/insights.tpl
@@ -44,7 +44,7 @@
 
         {else}
 
-    <div class="span3">&nbsp;</div>
+    <div class="span3"></div>
         {/if}
 
     <div class="span9">

--- a/webapp/assets/css/insights.css
+++ b/webapp/assets/css/insights.css
@@ -23,6 +23,7 @@ p {
 
 .navbar-static-top {
   margin-bottom: 20px;
+  margin-left : 0px;
 }
 
 .navbar-static-top ul.nav.pull-right {
@@ -379,4 +380,14 @@ footer {
     height: 60px;
     padding: 20px 0;
     background: #fff;
+}
+
+@media (max-width: 767px) {
+body {
+	padding-left: 6px;
+	padding-right: 6px;
+}
+.alert, .alert.insight-item, .white-card, .row {
+  margin-bottom: 6px;
+}
 }


### PR DESCRIPTION
...e devices.

Resolves https://github.com/ginatrapani/ThinkUp/issues/1436 to fix the weird left-aligned header part on mobile webkit browsers. Also greatly reduces spacing around insight items to increase info density on mobile devices.
