### PR TITLE
Refresh Data link on Insights now pulls Developer Log setting.

### DIFF
--- a/webapp/_lib/controller/class.InsightStreamController.php
+++ b/webapp/_lib/controller/class.InsightStreamController.php
@@ -41,6 +41,7 @@ class InsightStreamController extends ThinkUpController {
         $config = Config::getInstance();
         $this->setViewTemplate('insights.tpl');
         $this->addToView('enable_bootstrap', true);
+    	$this->addToView('developer_log', $config->getValue('is_log_verbose'));
 
         if ($this->shouldRefreshCache() ) {
             if (isset($_GET['u']) && isset($_GET['n']) && isset($_GET['d']) && isset($_GET['s'])) {


### PR DESCRIPTION
The refresh data link in the status bar of the Insights view was ignoring the enable verbose/developer log setting (defaulting to not being enabled). I noticed this was a quick fix of adding this variable for the Insights controller (in addition to the Dashboard controller).
