### PR TITLE
Fix register & forgot password links on login view

### DIFF
--- a/webapp/_lib/view/session.login.tpl
+++ b/webapp/_lib/view/session.login.tpl
@@ -39,8 +39,8 @@
                             <input type="submit" id="login-save" name="Submit" class="btn btn-primary" value="Log In">
                             <span class="pull-right">
                                 <div class="btn-group">
-                                    {if $is_registration_open}<a href="register.php" class="btn btn-mini hidden-phone">Register</a>{else}{/if}
-                                    <a href="forgot.php" class="btn btn-mini">Forgot password</a>
+                                    {if $is_registration_open}<a href="{$site_root_path}session/register.php" class="btn btn-mini hidden-phone">Register</a>{else}{/if}
+                                    <a href="{$site_root_path}session/forgot.php" class="btn btn-mini">Forgot password</a>
                                     {insert name="help_link" id='login'}
                                 </div>
                             </span>


### PR DESCRIPTION
The register and forgot password links did not include "{$site_root_path}session/" before them. When the login view is displayed outside of the session path (unauthenticated view to the root), the links do not work properly. This fixes that issue. 

It wasn't clear to me how to add a test for markup change, so I apologize for not including a test with this pull request. 
