### PR TITLE
Reset Password Token on password update

### DIFF
--- a/webapp/_lib/controller/class.PasswordResetController.php
+++ b/webapp/_lib/controller/class.PasswordResetController.php
@@ -63,6 +63,7 @@ class PasswordResetController extends ThinkUpController {
                     $owner_dao->activateOwner($user->email);
                     $owner_dao->clearAccountStatus($user->email);
                     $owner_dao->resetFailedLogins($user->email);
+                    $owner_dao->updatePasswordToken($user->email, '');
                     $login_controller->addSuccessMessage('You have changed your password.');
                 }
                 return $login_controller->go();


### PR DESCRIPTION
Restrict owner from changing password multiple times with the same
password token as security measure. Reset the token once the password has been updated.
