### PR TITLE
Reset Password Token on password update

### DIFF
--- a/tests/TestOfPasswordResetController.php
+++ b/tests/TestOfPasswordResetController.php
@@ -207,7 +207,16 @@ SQL;
         $owner = $dao->getByEmail('zaphod@hog.com');
         $this->assertTrue($owner->is_activated);
         $this->assertEqual($owner->account_status, '');
+        $this->assertEqual($owner->password_token, '');
         $this->assertEqual($owner->failed_logins, 0);
+		
+        // Trying to use the same password reset token
+        $controller = new PasswordResetController(true);
+        $result = $controller->go();
+
+        // Error message should appear
+        $v_mgr = $controller->getViewManager();
+        $this->assertEqual($v_mgr->getTemplateDataItem('error_msg'), 'You have reached this page in error.');
     }
 
     public function testOfControllerWithRegistrationOpen() {

--- a/webapp/_lib/controller/class.PasswordResetController.php
+++ b/webapp/_lib/controller/class.PasswordResetController.php
@@ -63,6 +63,7 @@ class PasswordResetController extends ThinkUpController {
                     $owner_dao->activateOwner($user->email);
                     $owner_dao->clearAccountStatus($user->email);
                     $owner_dao->resetFailedLogins($user->email);
+                    $owner_dao->updatePasswordToken($user->email, '');
                     $login_controller->addSuccessMessage('You have changed your password.');
                 }
                 return $login_controller->go();


### PR DESCRIPTION
Restrict owner from changing password multiple times with the same
password token as security measure. Reset the token once the password
has been updated.

Updated test after successful password reset.
- test if the password token is empty
- test if a new attempt to update password with the same token prompts the error
