### PR TITLE
Liked FB pages now appear in alphabetical order in the "Add a Facebook P...

### DIFF
--- a/webapp/plugins/facebook/controller/class.FacebookPluginConfigurationController.php
+++ b/webapp/plugins/facebook/controller/class.FacebookPluginConfigurationController.php
@@ -163,6 +163,14 @@ class FacebookPluginConfigurationController extends PluginConfigurationControlle
                 $instance->auth_error = $tokens['auth_error'];
             }
         }
+
+        function cmp( $a, $b ) { 
+            if(  $a->name ==  $b->name ){ return 0 ; } 
+            return ($a->name < $b->name) ? -1 : 1;
+        } 
+        usort($user_pages[$instance->network_user_id],'cmp');
+        usort($user_admin_pages[$instance->network_user_id],'cmp');
+
         $this->addToView('user_pages', $user_pages);
         $this->addToView('user_admin_pages', $user_admin_pages);
 


### PR DESCRIPTION
...age" dropdown

I was adding Facebook pages to my local installation of ThinkUp and had a real tough time finding particular pages in the list as currently they are ordered according to the date the user 'liked' them.
