### PR TITLE
1578-search-box-fix-when-same-keyword-twice

### DIFF
--- a/webapp/_lib/dao/class.PostMySQLDAO.php
+++ b/webapp/_lib/dao/class.PostMySQLDAO.php
@@ -2367,7 +2367,7 @@ class PostMySQLDAO extends PDODAO implements PostDAO  {
         $counter = 0;
         foreach ($keywords as $keyword) {
             $q .= " post_text LIKE :keyword".$counter." ";
-            if ($keyword != end($keywords)) {
+            if (($counter + 1) != count($keywords)) {
                 $q .= "AND";
             }
             $counter++;


### PR DESCRIPTION
We're comparing the content to append the "AND" for the query which is logically wrong and is causing issue if last two keywords are same.
