### PR TITLE
1578-search-box-bug

### DIFF
--- a/tests/TestOfPostMySQLDAO.php
+++ b/tests/TestOfPostMySQLDAO.php
@@ -3871,6 +3871,10 @@ class TestOfPostMySQLDAO extends ThinkUpUnitTestCase {
 
         $results = $post_dao->searchPostsByUser('keyword', 'twitter', 'ev');
         $this->assertEqual(sizeof($results), 0);
+
+        //test with repeated keywords
+        $results = $post_dao->searchPostsByUser(array('post','post'), 'twitter', 'ev');
+        $this->assertEqual(sizeof($results), 0);
     }
     /**
      * Test getAllPostsByHashtagId

--- a/webapp/_lib/controller/class.SearchController.php
+++ b/webapp/_lib/controller/class.SearchController.php
@@ -94,16 +94,7 @@ class SearchController extends ThinkUpAuthController {
      */
     private function searchPosts() {
         $page_number = (isset($_GET['page']) && is_numeric($_GET['page']))?$_GET['page']:1;
-        $keywords = array();
-        $terms = explode(' ', $_GET['q']);
-        $unique_terms = array_unique($terms);
-        foreach ($unique_terms as $term) {
-            $keyword = $term;
-            for ($i = 1; $i < count(array_keys($terms,$term)); $i++) {
-                $keyword .= '%'.$term;
-            }
-            $keywords[] = $keyword;
-        }
+        $keywords = explode(' ', $_GET['q']);
         $this->addToView('current_page', $page_number);
 
         $post_dao = DAOFactory::getDAO('PostDAO');

--- a/webapp/_lib/dao/class.PostMySQLDAO.php
+++ b/webapp/_lib/dao/class.PostMySQLDAO.php
@@ -2365,9 +2365,16 @@ class PostMySQLDAO extends PDODAO implements PostDAO  {
         $q .= "FROM #prefix#posts p WHERE  author_username=:author_username AND network = :network ";
         $q .= "AND (";
         $counter = 0;
-        foreach ($keywords as $keyword) {
+        $search_terms = array();
+        $unique_keywords = array_unique($keywords);
+        foreach ($unique_keywords as $keyword) {
+            $term = $keyword;
+            for ($i = 1; $i < count(array_keys($keywords,$keyword)); $i++) {
+                $term .= '%'.$keyword;
+            }
+            $search_terms[] = $term;
             $q .= " post_text LIKE :keyword".$counter." ";
-            if ($keyword != end($keywords)) {
+            if ($keyword != end($unique_keywords)) {
                 $q .= "AND";
             }
             $counter++;
@@ -2384,8 +2391,8 @@ class PostMySQLDAO extends PDODAO implements PostDAO  {
             ':network'=>$network
         );
         $counter = 0;
-        foreach ($keywords as $keyword) {
-            $vars[':keyword'.$counter] = '%'.$keyword.'%';
+        foreach ($search_terms as $term) {
+            $vars[':keyword'.$counter] = '%'.$term.'%';
             $counter++;
         }
         if ($page_count > 0) {


### PR DESCRIPTION
When searching for terms with repetitive keywords, the naive condition would check if the keyword matches with the last keyword in the array and appends an 'AND' accordingly. This bug was easily fixed by reloading the array of keywords with distinct keywords only by using array_unique(). This fixes the bug as well as enhances the performance of MySQL search.
