### PR TITLE
Fix 1542 - Docs templates of nesting, pagination, version header

### DIFF
--- a/docs/source/_templates/bootstrap/globaltoc.html
+++ b/docs/source/_templates/bootstrap/globaltoc.html
@@ -1,5 +1,5 @@
-<ul class="">
-    <li><a href="https://thinkup.com/docs/">ThinkUp {{ version }} Docs</a></li>
+<ul>
+    <li><a href="https://thinkup.com/docs/" class="version">ThinkUp {{ version }} Docs</a></li>
 </ul>
 
 

--- a/docs/source/_templates/bootstrap/layout.html
+++ b/docs/source/_templates/bootstrap/layout.html
@@ -18,7 +18,7 @@
                     <li><a href="http://twitter.com/thinkup"><i class="icon-twitter"></i></a></li>
                     <li>
                         <form action="http://thinkupapp.com/docs/search.html" method="get" class="form-search"><input type="text" name="q" placeholder="Search Docs" class="search-query" id="docs-search"><input type="hidden" name="check_keywords" value="yes"><input type="hidden" name="area" value="default"></form>
-                    
+
                     </li>
 
               </ul>
@@ -51,6 +51,7 @@
     <link href="//netdna.bootstrapcdn.com/font-awesome/3.0.2/css/font-awesome.css" rel="stylesheet">
     <link rel="stylesheet" href="https://thinkup.com/css/insights.css" type="text/css">
     <link rel="stylesheet" href="https://thinkup.com/css/strip.css" type="text/css">
+    <link rel="stylesheet" href="{{ pathto('_static/style.css', 1) }}" type="text/css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 {% endblock %}
@@ -70,7 +71,7 @@
 {%- endblock %}
 
 {%- block footer %}
-        
+
         </div><!-- end alert -->
 
             <div class="container">
@@ -78,7 +79,7 @@
                     {% include "relations.html" %}
                 {% endblock %}
             </div>
-    
+
     </div>
 </div>
 </div><!-- end container -->
@@ -93,10 +94,10 @@
         <a href="http://thinkup.com/tos">Terms</a>
         -->
         <a href="http://twitter.com/thinkup"><i class="icon-twitter"></i></a>
-        <a href="http://facebook.com/thinkupapp"><i class="icon-facebook"></i></a>   
-        <a href="http://gplus.to/thinkup"><i class="icon-google-plus"></i></a>      
-    </nav>                 
-    <p>&copy; 2013 ThinkUp LLC. It is nice to be nice.</p>           
+        <a href="http://facebook.com/thinkupapp"><i class="icon-facebook"></i></a>
+        <a href="http://gplus.to/thinkup"><i class="icon-google-plus"></i></a>
+    </nav>
+    <p>&copy; 2013 ThinkUp LLC. It is nice to be nice.</p>
 </footer>
 
 

--- a/docs/source/_templates/bootstrap/relations.html
+++ b/docs/source/_templates/bootstrap/relations.html
@@ -1,8 +1,8 @@
 {%- if prev %}
 <a href="{{ prev.link|e }}"
-         title="{{ _('previous chapter') }}" class="btn">{{ "&laquo;"|safe }} Previous: {{ prev.title }}</a> &nbsp;
+         title="{{ _('previous chapter') }}" class="btn pagination_prev">{{ "&laquo;"|safe }} Previous: {{ prev.title }}</a> &nbsp;
 {%- endif %}
 {%- if next %}
   &nbsp;<a href="{{ next.link|e }}"
-       title="{{ _('next chapter ') }}" class="btn">Next: {{ next.title }} {{ "&raquo;"|safe }}</a>
+       title="{{ _('next chapter ') }}" class="btn pagination_next">Next: {{ next.title }} {{ "&raquo;"|safe }}</a>
 {%- endif %}

--- a/docs/source/_templates/bootstrap/static/style.css_t
+++ b/docs/source/_templates/bootstrap/static/style.css_t
@@ -1,0 +1,22 @@
+h2 {
+  font-size: 1.5em;
+  margin: 0 0 0.5em 0;
+}
+
+li {
+  color: #000;
+}
+
+.pagination_prev,
+.pagination_next {
+  margin-top: 1em;
+}
+
+.section {
+  margin: 0;  
+}
+
+.version {
+  display: block;
+  text-align: left;
+}


### PR DESCRIPTION
- Subsections no longer indented (caused by nesting .section DIVs
  when sections created per subheading).
- Text in bullet points now black, not blue.
- Next/previous paging buttons now include spacing when page titles
  are too long and they sit on top of each other.
- Version header now aligned with nav menu on sidebar.

Original first line of commit was supposed to be "Fix docs templates of nesting, pagination, version header"
