### PR TITLE
Added missing #prefix# markers to getUsersWhoFavoritedMostOfYourPosts()

### DIFF
--- a/webapp/_lib/dao/class.FavoritePostMySQLDAO.php
+++ b/webapp/_lib/dao/class.FavoritePostMySQLDAO.php
@@ -375,9 +375,9 @@ class FavoritePostMySQLDAO extends PostMySQLDAO implements FavoritePostDAO  {
     public function getUsersWhoFavoritedMostOfYourPosts($author_user_id, $network, $last_x_days) {
         //$q = "SELECT u.user_name, fav_of_user_id, count(f.post_id) AS total_likes from tu_favorites f ";
         $q = "SELECT * FROM ( ";
-        $q .= "SELECT u.*, count(f.post_id) AS total_likes from tu_favorites f ";
-        $q .= "INNER JOIN tu_users u ON u.user_id = f.fav_of_user_id ";
-        $q .= "INNER JOIN tu_posts p ON f.post_id = p.post_id ";
+        $q .= "SELECT u.*, count(f.post_id) AS total_likes from #prefix#favorites f ";
+        $q .= "INNER JOIN #prefix#users u ON u.user_id = f.fav_of_user_id ";
+        $q .= "INNER JOIN #prefix#posts p ON f.post_id = p.post_id ";
         $q .= "WHERE f.author_user_id = :author_user_id and f.network=:network ";
         $q .= "AND p.pub_date >= date_sub(current_date, INTERVAL :last_x_days day) ";
         $q .= "GROUP BY f.fav_of_user_id ORDER BY total_likes DESC";


### PR DESCRIPTION
This fixes database query error:

> Database error! ThinkUp could not execute the following query: SELECT \* FROM ( SELECT u.*, count(f.post_id) AS total_likes from tu_favorites f INNER JOIN tu_users u ON u.user_id = f.fav_of_user_id INNER JOIN tu_posts p ON f.post_id = p.post_id WHERE f.author_user_id = :author_user_id and f.network=:network AND p.pub_date >= date_sub(current_date, INTERVAL :last_x_days day) GROUP BY f.fav_of_user_id ORDER BY total_likes DESC) favs WHERE favs.total_likes > 1 LIMIT 3 PDOException: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'ivuorinen.tu_favorites' doesn't exist

Triggered by `BiggestFansInsight::generateInsight`
