### PR TITLE
Add manage_pages to the Facebook permissions

### DIFF
--- a/webapp/plugins/facebook/controller/class.FacebookPluginConfigurationController.php
+++ b/webapp/plugins/facebook/controller/class.FacebookPluginConfigurationController.php
@@ -122,7 +122,7 @@ class FacebookPluginConfigurationController extends PluginConfigurationControlle
         }
 
         $params = array('scope'=>'read_stream,user_likes,user_location,user_website,'.
-        'read_friendlists,friends_location,manage_pages,read_insights',
+        'read_friendlists,friends_location,manage_pages,read_insights,manage_pages',
         'state'=>SessionCache::get('facebook_auth_csrf'));
 
         $fbconnect_link = $facebook->getLoginUrl($params);


### PR DESCRIPTION
It appears that adding the manage_pages permissions results in Facebook issuing tokens which don't appear to expire after 60 days.
