### PR TITLE
Refactored init.php to remove global path initialization

### DIFF
--- a/webapp/_lib/class.Loader.php
+++ b/webapp/_lib/class.Loader.php
@@ -112,7 +112,7 @@ class Loader {
             if (file_exists(THINKUP_ROOT_PATH . 'webapp')) {
                 define('THINKUP_WEBAPP_PATH', THINKUP_ROOT_PATH . 'webapp/');
             } else {
-                define('THINKUP_WEBAPP_PATH', THINKUP_ROOT_PATH . 'thinkup/');
+                define('THINKUP_WEBAPP_PATH', THINKUP_ROOT_PATH);
             }
         }
     }

--- a/webapp/init.php
+++ b/webapp/init.php
@@ -30,15 +30,6 @@ if ( version_compare(PHP_VERSION, '5.2', '<') ) {
     exit("ERROR: ThinkUp requires PHP 5.2 or greater. The current version of PHP is ".PHP_VERSION.".");
 }
 
-//Define path globals
-if (!file_exists('README.md')) { // source repo
-    define('THINKUP_ROOT_PATH', str_replace("\\",'/', dirname(dirname(__FILE__))) .'/');
-    define('THINKUP_WEBAPP_PATH', THINKUP_ROOT_PATH . 'webapp/');
-} else { // distro package
-    define('THINKUP_ROOT_PATH', str_replace("\\",'/', dirname(__FILE__)) .'/');
-    define('THINKUP_WEBAPP_PATH', THINKUP_ROOT_PATH);
-}
-
 //Register our lazy class loader
 require_once '_lib/class.Loader.php';
 


### PR DESCRIPTION
Since initialization is already being done in Loader class, we should not set THINKUP_ROOT_PATH and THINKUP_WEBAPP_PATH in any other place.

I also found that setting THINKUP_WEBAPP_PATH to THINKUP_ROOT_PATH . 'thinkup/' is incorrect since there is no such directory. This bug might not have been exposed till now because init.php sets the path and hence the Loader class code never executes.
