### PR TITLE
Can now specify the order crawler plugins run relative to the insight generator plugin

### DIFF
--- a/tests/TestOfPluginRegistrar.php
+++ b/tests/TestOfPluginRegistrar.php
@@ -69,4 +69,26 @@ class TestOfPluginRegistrar extends ThinkUpBasicUnitTestCase {
         Exception("The TestFauxPluginOne object does not have a performAppFunction function."));
         $test_ph->performAppFunction();
     }
+
+    public function testOrderOfPlugins() {
+        $plugin_registrar = new PluginRegistrarCrawler();
+        // Register some plugins that should run before the insight generator
+        $plugin_registrar->registerCrawlerPlugin('TwitterPlugin', true);
+        $plugin_registrar->registerCrawlerPlugin('FacebookPlugin', true);
+        // Register the insight generator
+        $plugin_registrar->registerCrawlerPlugin('InsightsGeneratorPlugin', true);
+        // Register some that should run after the insight generator
+        $plugin_registrar->registerCrawlerPlugin('FoursquarePlugin', false);
+        $plugin_registrar->registerCrawlerPlugin('YouTubePlugin', false);
+        // Order the plugins and check they're in the right order
+        $plugin_registrar->orderPlugins('crawl');
+        $plugins = $plugin_registrar->getObjectFunctionCallbacks();
+        $this->assertNotNull($plugins);
+        $crawl_plugins = $plugins['crawl'];
+        $this->assertEqual($crawl_plugins[0][0], 'TwitterPlugin');
+        $this->assertEqual($crawl_plugins[1][0], 'FacebookPlugin');
+        $this->assertEqual($crawl_plugins[2][0], 'InsightsGeneratorPlugin');
+        $this->assertEqual($crawl_plugins[3][0], 'FoursquarePlugin');
+        $this->assertEqual($crawl_plugins[4][0], 'YouTubePlugin');
+    }
 }

--- a/webapp/_lib/class.PluginRegistrarCrawler.php
+++ b/webapp/_lib/class.PluginRegistrarCrawler.php
@@ -119,8 +119,17 @@ class PluginRegistrarCrawler extends PluginRegistrar {
      * Register crawler plugin.
      * @param str $object_name Name of Crawler plugin object which instantiates the Crawler interface, like
      * "TwitterPlugin"
+     * @param boolean $run_before_insight_generator true if this plugin should run before the insight generator plugin
      */
-    public function registerCrawlerPlugin($object_name) {
-        $this->registerObjectFunction('crawl', $object_name, 'crawl');
+    public function registerCrawlerPlugin($object_name, $run_before_insight_generator=true) {
+        $this->registerObjectFunction('crawl', $object_name, 'crawl', $run_before_insight_generator);
+    }
+
+    /**
+     * FOR TESTING PURPOSES ONLY
+     * -- Returns the array of function call backs
+     */
+    public function getObjectFunctionCallbacks() {
+        return $this->object_function_callbacks;
     }
 }


### PR DESCRIPTION
Hi,

As we discussed this patch allows you to specify the order crawler plugins run relative to the insight generator by setting the second parameter of the registerCrawlerPlugin() function.

Thanks

Aaron
