### PR TITLE
Added section on configuring app armor to test documentation

### DIFF
--- a/docs/source/contribute/developers/tests.rst
+++ b/docs/source/contribute/developers/tests.rst
@@ -13,7 +13,7 @@ config variable to that name. You will also need a local installation of ThinkUp
 config variable equal to its URL--for example, ``http://localhost``.
 
 In ``webapp/config.inc.php``, in the DEVELOPER CONFIG section, set the name of your tests database, and the username
-and password to access it. This database name should match the one you just set in ``tests/config.tests.inc.php``. 
+and password to access it. This database name should match the one you just set in ``tests/config.tests.inc.php``.
 Finally, set ``$THINKUP_CFG['source_root_path']`` to the full path of the thinkup source files.
 
 Test Assumptions
@@ -158,8 +158,8 @@ There are a few ways to speed up the test runs:
     ``sudo sh ./extras/dev/ramdisk/osx_make_ramdisk_db create -v``
 
     Run the tests with ``RD_MODE`` set to 1:
-    
-    ``RD_MODE=1 php tests/all_tests.php`` 
+
+    ``RD_MODE=1 php tests/all_tests.php``
 
     When you are done testing you can remove the RAM disk with this command:
 
@@ -177,6 +177,14 @@ Possible reasons for getting a high number of test failures include:
 -  An incorrect value for any of the test database values. Please make
    sure that both config.inc.php and config.tests.inc.php point to an
    existing, empty database.
+-  AppArmor which is installed on Ubuntu by default can prevent the ThinkUp test suite backup tests from writing to the
+   files it needs to. To fix this add the following to your ``/etc/apparmor.d/usr.sbin.mysqld`` file:
+
+   ``path_to_thinkup/webapp/data/backup/* rw,``
+
+   and then restart AppArmor with:
+
+   ``sudo /etc/init.d/apparmor reload``
 
 If you have double-checked these and everything appears to be intact,
 send an email to the mailing list or pop into the IRC channel and we'll


### PR DESCRIPTION
Hi,

I've added a bullet point about how to configure app armor to avoid test failures to the test documentation.
