### PR TITLE
Can now specify the order crawler plugins run relative to the insight generator plugin

### DIFF
--- a/tests/TestOfPluginRegistrar.php
+++ b/tests/TestOfPluginRegistrar.php
@@ -69,4 +69,43 @@ class TestOfPluginRegistrar extends ThinkUpBasicUnitTestCase {
         Exception("The TestFauxPluginOne object does not have a performAppFunction function."));
         $test_ph->performAppFunction();
     }
+
+    public function testOrderOfPlugins() {
+        $plugin_registrar = new PluginRegistrarCrawler();
+        // Register some plugins that should run before the insight generator
+        $plugin_registrar->registerCrawlerPlugin('TwitterPlugin', true);
+        $plugin_registrar->registerCrawlerPlugin('FacebookPlugin', true);
+        // Register the insight generator
+        $plugin_registrar->registerCrawlerPlugin('InsightsGeneratorPlugin', true);
+        // Register some that should run after the insight generator
+        $plugin_registrar->registerCrawlerPlugin('FoursquarePlugin', false);
+        $plugin_registrar->registerCrawlerPlugin('YouTubePlugin', false);
+        // Order the plugins and check they're in the right order
+        $plugin_registrar->orderPlugins('crawl');
+        $plugins = $plugin_registrar->getObjectFunctionCallbacks();
+        $this->assertNotNull($plugins);
+        $crawl_plugins = $plugins['crawl'];
+        $this->assertEqual($crawl_plugins[0][0], 'TwitterPlugin');
+        $this->assertEqual($crawl_plugins[1][0], 'FacebookPlugin');
+        $this->assertEqual($crawl_plugins[2][0], 'InsightsGeneratorPlugin');
+        $this->assertEqual($crawl_plugins[3][0], 'FoursquarePlugin');
+        $this->assertEqual($crawl_plugins[4][0], 'YouTubePlugin');
+    }
+
+    public function testOrderOfPluginsWithoutInsightGenerator() {
+        $plugin_registrar = new PluginRegistrarCrawler();
+        $plugin_registrar->registerCrawlerPlugin('TwitterPlugin', true);
+        $plugin_registrar->registerCrawlerPlugin('FacebookPlugin', true);
+        $plugin_registrar->registerCrawlerPlugin('FoursquarePlugin', false);
+        $plugin_registrar->registerCrawlerPlugin('YouTubePlugin', false);
+        // Order the plugins and check they're in the right order
+        $plugin_registrar->orderPlugins('crawl');
+        $plugins = $plugin_registrar->getObjectFunctionCallbacks();
+        $this->assertNotNull($plugins);
+        $crawl_plugins = $plugins['crawl'];
+        $this->assertEqual($crawl_plugins[0][0], 'TwitterPlugin');
+        $this->assertEqual($crawl_plugins[1][0], 'FacebookPlugin');
+        $this->assertEqual($crawl_plugins[2][0], 'FoursquarePlugin');
+        $this->assertEqual($crawl_plugins[3][0], 'YouTubePlugin');
+    }
 }

--- a/webapp/_lib/class.PluginRegistrar.php
+++ b/webapp/_lib/class.PluginRegistrar.php
@@ -40,16 +40,41 @@ abstract class PluginRegistrar {
      * All the registered callbacks, an array of arrays where the index is the action name
      * @var arr $object_function_callbacks['trigger_name'][] = array('object_name', 'function_name');
      */
-    private $object_function_callbacks = array();
+    protected $object_function_callbacks = array();
+    /**
+     * All registered callbacks that need to be run before insight generation
+     */
+    private $before_insight_generation = array();
+    /**
+     * All registered callbacks that need to be run after insight generation
+     */
+    private $after_insight_generation = array();
+    /**
+     * The insight generator plugin
+     */
+    private $insight_generator = array();
+
     /**
      * Register an object function call
      * Note: This will cause a PHP fatal error if the object name does not exist
      * @param str $trigger Trigger keyword
      * @param str $object_name Object name
      * @param str $function_name Function name
+     * @param boolean $before_insights_generate=true true if this plugin should run before the insight generator plugin
      */
-    protected function registerObjectFunction($trigger, $object_name, $function_name) {
-        $this->object_function_callbacks[$trigger][] = array($object_name, $function_name);
+    protected function registerObjectFunction($trigger, $object_name, $function_name, $before_insights_generate=true) {
+        // If the trigger type is crawl then we have to store them in the correct array for ordering later
+        if($trigger == 'crawl') {
+            if($object_name == 'InsightsGeneratorPlugin') {
+                $this->insight_generator[$trigger][] = array($object_name, $function_name);
+            } elseif($before_insights_generate == true) {
+                $this->before_insight_generation[$trigger][] = array($object_name, $function_name);
+            } elseif($before_insights_generate == false) {
+                $this->after_insight_generation[$trigger][] = array($object_name, $function_name);
+            }
+        } else { // Any other type such as generateInsight don't need ordering
+            $this->object_function_callbacks[$trigger][] = array($object_name, $function_name);
+        }
     }
     /**
      * Run all object functions registered as callbacks.
@@ -58,6 +83,9 @@ abstract class PluginRegistrar {
      * @throws Exception When registered object doesn't have function
      */
     protected function emitObjectFunction($trigger, $params = array()) {
+        // Order the call back arrays for crawler plugins relative to the insight generator
+        self::orderPlugins($trigger);
+
         if (isset($this->object_function_callbacks[$trigger])) {
             foreach ($this->object_function_callbacks[$trigger] as $callback) {
                 if (method_exists($callback[0], $callback[1] )) {
@@ -90,5 +118,35 @@ abstract class PluginRegistrar {
             throw new PluginNotFoundException($shortname);
         }
         return $this->plugins[$shortname];
+    }
+    /**
+     * Orders the object_function_callback array relative to the insight generator plugin
+     * @param  string $trigger the type of plugins you want to order currently only supports crawl
+     */
+    public function orderPlugins($trigger='crawl') {
+        if($trigger == 'crawl') {
+            // Handle case where the insight generator plugin does not exist (only known case is during testing)
+            if(sizeof($this->insight_generator['crawl']) != 1) {
+                if(sizeof($this->before_insight_generation) > 0 && sizeof($this->after_insight_generation) > 0) {
+                    $this->object_function_callbacks['crawl'] = array_merge($this->before_insight_generation['crawl'],
+                    $this->after_insight_generation['crawl']);
+                } elseif(sizeof($this->before_insight_generation) > 0) {
+                    $this->object_function_callbacks['crawl'] = $this->before_insight_generation['crawl'];
+                } elseif(sizeof($this->after_insight_generation) > 0) {
+                    $this->object_function_callbacks['crawl'] = $this->after_insight_generation['crawl'];
+                }
+            } else {
+                if(sizeof($this->before_insight_generation) > 0 && sizeof($this->after_insight_generation) > 0) {
+                    $this->object_function_callbacks['crawl'] = array_merge($this->before_insight_generation['crawl'],
+                    $this->insight_generator['crawl'], $this->after_insight_generation['crawl']);
+                } elseif(sizeof($this->before_insight_generation) > 0) {
+                    $this->object_function_callbacks['crawl'] = array_merge($this->before_insight_generation['crawl'],
+                    $this->insight_generator['crawl']);
+                } elseif(sizeof($this->after_insight_generation) > 0) {
+                    $this->object_function_callbacks['crawl'] = array_merge($this->insight_generator['crawl'],
+                    $this->after_insight_generation['crawl']);
+                }
+            }
+        }
     }
 }

--- a/webapp/_lib/class.PluginRegistrarCrawler.php
+++ b/webapp/_lib/class.PluginRegistrarCrawler.php
@@ -119,8 +119,17 @@ class PluginRegistrarCrawler extends PluginRegistrar {
      * Register crawler plugin.
      * @param str $object_name Name of Crawler plugin object which instantiates the Crawler interface, like
      * "TwitterPlugin"
+     * @param boolean $run_before_insight_generator true if this plugin should run before the insight generator plugin
      */
-    public function registerCrawlerPlugin($object_name) {
-        $this->registerObjectFunction('crawl', $object_name, 'crawl');
+    public function registerCrawlerPlugin($object_name, $run_before_insight_generator=true) {
+        $this->registerObjectFunction('crawl', $object_name, 'crawl', $run_before_insight_generator);
+    }
+
+    /**
+     * FOR TESTING PURPOSES ONLY
+     * -- Returns the array of function call backs
+     */
+    public function getObjectFunctionCallbacks() {
+        return $this->object_function_callbacks;
     }
 }


### PR DESCRIPTION
Hi,

I've fixed the test failures.

As we discussed this patch allows you to specify the order crawler plugins run relative to the insight generator by setting the second parameter of the registerCrawlerPlugin() function.

Thanks

Aaron
