### PR TITLE
New insight: Outreach Punchcard Insight

### DIFF
--- a/tests/all_plugin_tests.php
+++ b/tests/all_plugin_tests.php
@@ -83,6 +83,7 @@ $plugin_tests->add(new TestOfWeeklyBestsInsight());
 $plugin_tests->add(new TestOfReplySpikeInsight());
 $plugin_tests->add(new TestOfResponseTimeInsight());
 $plugin_tests->add(new TestOfFavoritedLinksInsight());
+$plugin_tests->add(new TestOfOutreachPunchcardInsight());
 $version = explode('.', PHP_VERSION); //dont run redis test for php less than 5.3
 if ($version[0] >= 5 && $version[1] >= 3) { //only run Redis tests if PHP 5.3
     $plugin_tests->add(new TestOfStreamMessageQueueRedis());

--- a/webapp/assets/js/d3-visualizations.js
+++ b/webapp/assets/js/d3-visualizations.js
@@ -133,3 +133,78 @@ var InteractionGraph = function(placeholder_id, graph_size, interaction_data) {
 		node.attr("transform", function(d) { return "translate("+d.x+","+d.y+")"; });
 	});
 };
+
+var OutreachPunchcard = function(placeholder_id, graph_size, outreach_data) {
+	var vis = d3.select('#'+placeholder_id)
+	.append("svg")
+	.attr("width", graph_size)
+	.attr("height", (graph_size / 3))
+	.style("display", "block")
+	.style("margin", "0 auto");
+
+	var x = d3.scale.linear().domain([0, 23]).range([(graph_size / 9), (graph_size - 20)]);
+	var y = d3.scale.linear().domain([1, 7]).range([20, ((graph_size / 3) - 40)]);
+	var xAxis = d3.svg.axis().scale(x).orient("bottom")
+	.ticks(24)
+	.tickFormat(function (d, i) {
+		var m = (d < 12) ? 'a' : 'p';
+		return (d % 12 == 0) ? 12+m :  (d % 12)+m;
+	});
+	var yAxis = d3.svg.axis().scale(y).orient("left")
+	.ticks(7)
+	.tickFormat(function (d, i) {
+        return ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][d - 1];
+    });
+    vis.append("g")
+    .attr("class", "axis")
+    .attr("transform", "translate(0, "+((graph_size / 3) - 20)+")")
+    .call(xAxis);
+    vis.append("g")
+    .attr("class", "axis")
+    .attr("transform", "translate("+((graph_size / 9) - 20)+", 0)")
+    .call(yAxis);
+    d3.selectAll('.axis path')
+    .style("fill", "none")
+    .style("stroke", "#eee")
+    .style("shape-rendering", "crispEdges");
+    d3.selectAll('.axis line')
+    .style("fill", "none")
+    .style("stroke", "#eee")
+    .style("shape-rendering", "crispEdges");
+    d3.selectAll('.axis text')
+    .style("font-family", "sans-serif")
+    .style("font-size", "11px");
+
+    var punches = {posts: [], responses: []};
+    var max_val = 0;
+    for (var i = 1; i <= 7; i++) {
+    	for (var j = 0; j < 24; j++) {
+    		max_val = Math.max(outreach_data.posts[i][j],max_val);
+    		max_val = Math.max(outreach_data.responses[i][j],max_val);
+
+    		punches.posts.push([i, j, outreach_data.posts[i][j]]);
+    		punches.responses.push([i, j, outreach_data.responses[i][j]]);
+    	}
+    }
+    var rad = d3.scale.linear().domain([0, max_val]).range([0, 12]);
+
+    vis.selectAll('.post-punch')
+    .data(punches.posts)
+    .enter()
+    .append("circle")
+    .attr("cx", function(d) { return x(d[1]); })
+    .attr("cy", function(d) { return y(d[0]); })
+    .attr("r", function(d) { return rad(d[2]); })
+    .style("fill", "#f00")
+    .style("opacity", "0.8");
+
+    vis.selectAll('.response-punch')
+    .data(punches.responses)
+    .enter()
+    .append("circle")
+    .attr("cx", function(d) { return x(d[1]); })
+    .attr("cy", function(d) { return y(d[0]); })
+    .attr("r", function(d) { return rad(d[2]); })
+    .style("fill", "#0f0")
+    .style("opacity", "0.5");
+};

--- a/webapp/plugins/insightsgenerator/insights/outreachpunchcard.php
+++ b/webapp/plugins/insightsgenerator/insights/outreachpunchcard.php
@@ -1,0 +1,168 @@
+<?php
+/*
+ Plugin Name: Outreach Punchcard
+ Description: How best can you time your posts to get best outreach.
+ When: Mondays
+ */
+
+/**
+ *
+ * ThinkUp/webapp/plugins/insightsgenerator/insights/outreachpunchcard.php
+ *
+ * Copyright (c) 2012-2013 Nilaksh Das, Gina Trapani
+ *
+ * LICENSE:
+ *
+ * This file is part of ThinkUp (http://thinkup.com).
+ *
+ * ThinkUp is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * ThinkUp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with ThinkUp.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2012-2013 Nilaksh Das, Gina Trapani
+ * @author Nilaksh Das <nilakshdas [at] gmail [dot] com>
+ */
+
+class OutreachPunchcardInsight extends InsightPluginParent implements InsightPlugin {
+    public function generateInsight(Instance $instance, $last_week_of_posts, $number_days) {
+        parent::generateInsight($instance, $last_week_of_posts, $number_days);
+        $this->logger->logInfo("Begin generating insight", __METHOD__.','.__LINE__);
+
+        $in_test_mode =  ((isset($_SESSION["MODE"]) && $_SESSION["MODE"] == "TESTS") || getenv("MODE")=="TESTS");
+        //Only insert this insight if it's Monday or if we're testing
+        if ((date('w') == 1 || $in_test_mode) && count($last_week_of_posts)) {
+            $post_dao = DAOFactory::getDAO('PostDAO');
+            $quickest_response_timediffs = array();
+            $punchcard = array();
+            for ($i = 1; $i <= 7; $i++) {
+                for ($j = 0; $j < 24; $j++) {
+                    $punchcard['posts'][$i][$j] = 0;
+                    $punchcard['responses'][$i][$j] = 0;
+                }
+            }
+
+            foreach ($last_week_of_posts as $post) {
+                $responses = array();
+                $responses = array_merge(
+                    (array)$post_dao->getRepliesToPost($post->post_id, $post->network),
+                    (array)$post_dao->getRetweetsOfPost($post->post_id, $post->network)
+                );
+
+                if (count($responses)) {
+                    $quickest_response_timediff = strtotime($responses[0]->pub_date) - strtotime($post->pub_date);
+
+                    foreach ($responses as $response) {
+                        $response_dotw = date('N', strtotime($response->pub_date)); // Day of the week
+                        $response_hotd = date('G', strtotime($response->pub_date)); // Hour of the day
+                        $punchcard['responses'][$response_dotw][$response_hotd]++;
+
+                        $response_timediff = strtotime($response->pub_date) - strtotime($post->pub_date);
+                        $quickest_response_timediff = min($response_timediff, $quickest_response_timediff);
+                    }
+
+                    $quickest_response_timediffs[] = $quickest_response_timediff;
+                }
+
+                $post_dotw = date('N', strtotime($post->pub_date)); // Day of the week
+                $post_hotd = date('G', strtotime($post->pub_date)); // Hour of the day
+                $punchcard['posts'][$post_dotw][$post_hotd]++;
+            }
+
+            $insight_text = '';
+            switch ($instance->network) {
+                case 'twitter':
+                    $post_type = 'tweets';
+                    $connections = 'followers';
+                    break;
+
+                case 'facebook':
+                    $post_type = 'status updates';
+                    $connections = 'friends';
+                    break;
+
+                case 'google+':
+                    $post_type = 'posts';
+                    $connections = 'circles';
+                    break;
+
+                case 'foursquare':
+                    $post_type = 'checkins';
+                    $connections = 'friends';
+                    break;
+                
+                default:
+                    $post_type = 'posts';
+                    $connections = 'friends';
+                    break;
+            }            
+            if (count($quickest_response_timediffs)) {
+                // We have responses
+                $avg_timediff = floor(array_sum($quickest_response_timediffs) / count($quickest_response_timediffs));
+                $syntactic_avg_timediff = self::getSyntacticTimeDifference($avg_timediff);
+
+                if ($avg_timediff < (60 * 60)) {
+                    // Got responses within 1 hour
+                    $insight_text = $this->username."'s ".$post_type." from last week started getting responses "
+                    ."in as little as ".$syntactic_avg_timediff." of being posted. "
+                    ."This is a brilliant way to space updates and achieve the maximum outreach!";
+                } else if ($avg_timediff < (6 * 60 * 60)) {
+                    // Got responses within 6 hours
+                    $insight_text = $this->username."'s ".$connections." started responding "
+                    ."to their last week's ".$post_type." only after ".$syntactic_avg_timediff.". "
+                    ."The time of posting updates can be adjusted a little bit to get a better outreach.";
+                } else {
+                    $insight_text = $this->username."'s ".$post_type." from last week didn't get any responses "
+                    ."for as long as ".$syntactic_avg_timediff." of being posted. "
+                    ."Changing the time of posting updates may help in getting more outreach.";
+                }
+            } else {
+                // No post got any responses
+                $insight_text = $this->username."'s ".$post_type." from last week didn't get any responses at all! "
+                ."It maybe so that ".$connections." check in at a different time and the "
+                .$post_type." get lost in their newsfeeds.";
+            }
+
+            $this->insight_dao->insertInsight("outreach_punchcard", $instance->id, $this->insight_date,
+            "Outreach:", $insight_text, basename(__FILE__, ".php"), Insight::EMPHASIS_LOW,
+            serialize($punchcard));
+        }
+
+
+        $this->logger->logInfo("Done generating insight", __METHOD__.','.__LINE__);
+    }
+
+    /**
+     * Get the human comprehensible, syntactic time difference .
+     * @param Time difference in seconds $delta
+     * @return str Syntactic time difference
+     */
+    public static function getSyntacticTimeDifference($delta) {
+        $tokens = array();
+        $tokens['second'] = 1;
+        $tokens['minute'] = 60 * $tokens['second'];
+        $tokens['hour'] = 60 * $tokens['minute'];
+        $tokens['day'] = 24 * $tokens['hour'];
+
+        arsort($tokens);
+
+        foreach ($tokens as $unit => $value) {
+            if ($delta < $value) {
+                continue;
+            } else {
+                $number_of_units = floor($delta / $value);
+                return $number_of_units.' '.$unit.(($number_of_units > 1) ? 's' : '');
+            }
+        }
+    }
+}
+
+$insights_plugin_registrar = PluginRegistrarInsights::getInstance();
+$insights_plugin_registrar->registerInsightPlugin('OutreachPunchcardInsight');

--- a/webapp/plugins/insightsgenerator/tests/TestOfOutreachPunchcardInsight.php
+++ b/webapp/plugins/insightsgenerator/tests/TestOfOutreachPunchcardInsight.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ *
+ * ThinkUp/webapp/plugins/insightsgenerator/tests/TestOfOutreachPunchcardInsight.php
+ *
+ * Copyright (c) 2012-2013 Nilaksh Das, Gina Trapani
+ *
+ * LICENSE:
+ *
+ * This file is part of ThinkUp (http://thinkup.com).
+ *
+ * ThinkUp is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * ThinkUp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with ThinkUp.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Test of Outreach Punchcard Insight
+ *
+ * Test for OutreachPunchcardInsight class.
+ *
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2012-2013 Nilaksh Das, Gina Trapani
+ * @author Nilaksh Das <nilakshdas [at] gmail [dot] com>
+ */
+
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
+require_once THINKUP_WEBAPP_PATH.'_lib/extlib/simpletest/autorun.php';
+require_once THINKUP_WEBAPP_PATH.'_lib/extlib/simpletest/web_tester.php';
+require_once THINKUP_ROOT_PATH. 'webapp/plugins/insightsgenerator/model/class.InsightPluginParent.php';
+require_once THINKUP_ROOT_PATH. 'webapp/plugins/insightsgenerator/insights/outreachpunchcard.php';
+
+class TestOfOutreachPunchcardInsight extends ThinkUpUnitTestCase {
+
+    public function setUp(){
+        parent::setUp();
+    }
+
+    public function tearDown() {
+        parent::tearDown();
+    }
+
+    public function testGetSyntacticTimeDifference() {
+        $delta_1 = 60 * 60 * 3; // 3 hours
+        $delta_2 = 60 * 6; // 6 minutes
+        $delta_3 = 60 * 60 * 24 * 4; // 4 days
+        $delta_4 = 60 * 60 * 24; // 1 day
+
+        $result_1 = OutreachPunchcardInsight::getSyntacticTimeDifference($delta_1);
+        $result_2 = OutreachPunchcardInsight::getSyntacticTimeDifference($delta_2);
+        $result_3 = OutreachPunchcardInsight::getSyntacticTimeDifference($delta_3);
+        $result_4 = OutreachPunchcardInsight::getSyntacticTimeDifference($delta_4);
+
+        $this->assertEqual($result_1, '3 hours');
+        $this->assertEqual($result_2, '6 minutes');
+        $this->assertEqual($result_3, '4 days');
+        $this->assertEqual($result_4, '1 day');
+    }
+
+    public function testOutreachPunchcardInsight() {
+        // Get data ready that insight requires
+        $posts = self::getTestPostObjects();
+
+        $builders = array();
+
+        $builders[] = FixtureBuilder::build('users', array('user_id'=>'7654321', 'user_name'=>'twitteruser',
+        'full_name'=>'Twitter User', 'avatar'=>'avatar.jpg', 'follower_count'=>36000, 'is_protected'=>0,
+        'network'=>'twitter', 'description'=>'A test Twitter User'));
+
+        $time_1 = date("Y-m-d H:i:s", (strtotime('-2 days') + (60 * 6))); // 6 minutes later
+        $builders[] = FixtureBuilder::build('posts', array('id'=>136, 'post_id'=>136, 'author_user_id'=>7654321,
+        'author_username'=>'twitteruser', 'author_fullname'=>'Twitter User', 'author_avatar'=>'avatar.jpg',
+        'network'=>'twitter', 'post_text'=>'This is a reply.', 'source'=>'web',
+        'pub_date'=>$time_1, 'in_reply_to_post_id'=>133, 'reply_count_cache'=>0, 'is_protected'=>0));
+
+        $time_2 = date("Y-m-d H:i:s", (strtotime('-2 days') + (60 * 60 * 2))); // 2 hours later
+        $builders[] = FixtureBuilder::build('posts', array('id'=>137, 'post_id'=>137, 'author_user_id'=>7654321,
+        'author_username'=>'twitteruser', 'author_fullname'=>'Twitter User', 'author_avatar'=>'avatar.jpg',
+        'network'=>'twitter', 'post_text'=>'This is a reply.', 'source'=>'web',
+        'pub_date'=>$time_2, 'in_reply_to_post_id'=>133, 'reply_count_cache'=>0, 'is_protected'=>0));
+
+        $time_3 = date("Y-m-d H:i:s", (strtotime('-2 days') + (60 * 4))); // 4 minutes later
+        $builders[] = FixtureBuilder::build('posts', array('id'=>138, 'post_id'=>138, 'author_user_id'=>7654321,
+        'author_username'=>'twitteruser', 'author_fullname'=>'Twitter User', 'author_avatar'=>'avatar.jpg',
+        'network'=>'twitter', 'post_text'=>'This is a reply.', 'source'=>'web',
+        'pub_date'=>$time_3, 'in_reply_to_post_id'=>135, 'reply_count_cache'=>0, 'is_protected'=>0));
+
+        $time_4 = date("Y-m-d H:i:s", (strtotime('-2 days') + (60 * 14))); // 14 minutes later
+        $builders[] = FixtureBuilder::build('posts', array('id'=>139, 'post_id'=>139, 'author_user_id'=>7654321,
+        'author_username'=>'twitteruser', 'author_fullname'=>'Twitter User', 'author_avatar'=>'avatar.jpg',
+        'network'=>'twitter', 'source'=>'web',
+        'post_text'=>'RT @testeriffic: New Year\'s Eve! Feeling very gay today, but not very homosexual.',
+        'pub_date'=>$time_4, 'in_retweet_of_post_id'=>134, 'reply_count_cache'=>0, 'is_protected'=>0));
+
+        $instance = new Instance();
+        $instance->id = 10;
+        $instance->network_username = 'testeriffic';
+        $instance->network = 'twitter';
+        $insight_plugin = new OutreachPunchcardInsight();
+        $insight_plugin->generateInsight($instance, $posts, 3);
+
+        // Assert that insight got inserted with average 8 minutes
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('outreach_punchcard', 10, $today);
+        $this->debug(Utils::varDumpToString($result));
+        $this->assertNotNull($result);
+        $this->assertIsA($result, "Insight");
+        $this->assertPattern('/\@testeriffic\'s tweets from last week started getting responses/', $result->text);
+        $this->assertPattern('/in as little as 8 minutes of being posted/', $result->text);
+    }
+
+    public function testOutreachPunchcardInsightNoResponse() {
+        // Get data ready that insight requires
+        $posts = self::getTestPostObjects();
+        $instance = new Instance();
+        $instance->id = 10;
+        $instance->network_username = 'testeriffic';
+        $instance->network = 'twitter';
+        $insight_plugin = new OutreachPunchcardInsight();
+        $insight_plugin->generateInsight($instance, $posts, 3);
+
+        // Assert that insight got inserted for no responses
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('outreach_punchcard', 10, $today);
+        $this->debug(Utils::varDumpToString($result));
+        $this->assertNotNull($result);
+        $this->assertIsA($result, "Insight");
+        $this->assertPattern('/\@testeriffic\'s tweets from last week didn\'t get any responses/', $result->text);
+    }
+
+    public function testOutreachPunchcardInsightPunchcardDataset() {
+        // Get data ready that insight requires
+        $posts = self::getTestPostObjects();
+        $posts_dotw = date('N', strtotime($posts[0]->pub_date)); // Day of the week
+        $posts_hotd = date('G', strtotime($posts[0]->pub_date)); // Hour of the day
+
+        $instance = new Instance();
+        $instance->id = 10;
+        $instance->network_username = 'testeriffic';
+        $instance->network = 'twitter';
+        $insight_plugin = new OutreachPunchcardInsight();
+        $insight_plugin->generateInsight($instance, $posts, 3);
+
+        // Assert that insight got inserted and punchcard data is correct
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('outreach_punchcard', 10, $today);
+        $punchcard = unserialize($result->related_data);
+        $this->debug(Utils::varDumpToString($result));
+        $this->assertNotNull($result);
+        $this->assertIsA($result, "Insight");
+        $this->assertEqual($punchcard['posts'][$posts_dotw][$posts_hotd], 3);
+    }
+
+    /**
+     * Get test post objects
+     * @return array of post objects for use in testing
+     */
+    private function getTestPostObjects() {
+        $post_text_arr = array();
+        $post_text_arr[] = "Now that I'm back on Android, realizing just how under sung Google Now is. ".
+        "I want it everywhere.";
+        $post_text_arr[] = "New Year's Eve! Feeling very gay today, but not very homosexual.";
+        $post_text_arr[] = "When @anildash told me he was writing this I was ".
+        "like 'yah whatever cool' then I read it and it knocked my socks off http://bit.ly/W9ASnj ";
+
+        $posts = array();
+        $counter = 133;
+        foreach ($post_text_arr as $test_text) {
+            $p = new Post();
+            $p->post_id = $counter++;
+            $p->network = 'twitter';
+            $p->post_text = $test_text;
+            $p->pub_date = date("Y-m-d H:i:s",strtotime('-2 days'));
+            $posts[] = $p;
+        }
+        return $posts;
+    }
+}

--- a/webapp/plugins/insightsgenerator/view/outreachpunchcard.tpl
+++ b/webapp/plugins/insightsgenerator/view/outreachpunchcard.tpl
@@ -1,0 +1,37 @@
+{include file=$tpl_path|cat:'_header.tpl'}
+
+{if  !$expand}
+<div class="pull-right detail-btn"><button class="btn btn-info btn-mini" data-toggle="collapse" data-target="#chart-{$i->id}"><i class="icon-signal icon-white"></i></button></div>
+{/if}
+
+<span class="label label-{if $i->emphasis eq '1'}info{elseif $i->emphasis eq '2'}success{elseif $i->emphasis eq '3'}error{else}info{/if}"><i class="icon-white icon-time"></i> <a href="?u={$i->instance->network_username}&n={$i->instance->network}&d={$i->date|date_format:'%Y-%m-%d'}&s={$i->slug}">{$i->prefix}</a></span> 
+
+<i class="icon-{$i->instance->network}{if $i->instance->network eq 'google+'} icon-google-plus{/if} icon-muted"></i>
+{$i->text|link_usernames_to_twitter}
+
+{if !$expand}
+<div class="collapse in" id="chart-{$i->id}">
+{/if}
+
+    <div id="outreach_punchcard_{$i->id}">&nbsp;</div>
+    <div id="outreach_punchcard_legend_{$i->id}" style="padding: 5px; display: block; float: right; font-family: sans-serif; font-size: 12px;">
+      <div style="margin-right: 4px; padding: 2px; color: #f00; opacity: 0.8; float: left;">posts</div>
+      <div style="margin-right: 4px; padding: 2px; color: #0f0; opacity: 0.5; float: left;">responses</div>
+    </div>
+    <script type="text/javascript">
+        {literal}
+        (function(d3) {
+          {/literal}
+          var dataset = {$i->related_data|@json_encode};
+          new OutreachPunchcard("outreach_punchcard_{$i->id}",800,dataset);
+          console.log(dataset);
+          {literal}
+        })(d3);
+        {/literal}
+    </script>
+
+{if  !$expand}
+</div>
+{/if}
+
+{include file=$tpl_path|cat:'_footer.tpl'}


### PR DESCRIPTION
This insight helps users determine the time when their followers are online by plotting a punchcard of their posts with a punchcard of when their posts started getting responses. This would help users time their updates properly so as to get the optimum outreach and make sure that their updates don't get lost in their followers' timelines.

![screenshot from 2013-08-09 05 55 08](https://f.cloud.github.com/assets/1882688/935639/bf84845e-008a-11e3-9c74-62877070baea.png)

Maybe, fixes #1621.
