### PR TITLE
Show only error output on cli crawling

### DIFF
--- a/webapp/_lib/controller/class.AccountConfigurationController.php
+++ b/webapp/_lib/controller/class.AccountConfigurationController.php
@@ -324,7 +324,7 @@ class AccountConfigurationController extends ThinkUpAuthController {
         $this->addToView('rss_crawl_url', $rss_crawl_url);
         //cli_crawl_command
         $cli_crawl_command = 'cd '.THINKUP_WEBAPP_PATH.'crawler/;export THINKUP_PASSWORD=yourpassword; '.$php_path.
-        ' crawl.php '.$email;
+        ' -d error_reporting=3 crawl.php '.$email.' > /dev/null';
         $this->addToView('cli_crawl_command', $cli_crawl_command);
         //help link
         $this->view_mgr->addHelp('rss', 'userguide/datacapture');


### PR DESCRIPTION
Cron sends out emails everytime an output is generated. The ThinkUp Crawler generates lots of output. That's pretty annoying.
I redirected the stdout to /dev/null, but that still showed PHP notices. That's still pretty annoying, but luckily, you can set the error reporting level on the command line. I set it to E_ERROR and E_WARNING, which evaluates to 3. That should do it.
