### PR TITLE
New insight: Outreach Punchcard Insight

### DIFF
--- a/tests/all_plugin_tests.php
+++ b/tests/all_plugin_tests.php
@@ -87,6 +87,7 @@ $plugin_tests->add(new TestOfReplySpikeInsight());
 $plugin_tests->add(new TestOfResponseTimeInsight());
 $plugin_tests->add(new TestOfFavoritedLinksInsight());
 $plugin_tests->add(new TestOfLongLostContactsInsight());
+$plugin_tests->add(new TestOfOutreachPunchcardInsight());
 $version = explode('.', PHP_VERSION); //dont run redis test for php less than 5.3
 if ($version[0] >= 5 && $version[1] >= 3) { //only run Redis tests if PHP 5.3
     $plugin_tests->add(new TestOfStreamMessageQueueRedis());

--- a/webapp/plugins/insightsgenerator/insights/outreachpunchcard.php
+++ b/webapp/plugins/insightsgenerator/insights/outreachpunchcard.php
@@ -1,0 +1,145 @@
+<?php
+/*
+ Plugin Name: Outreach Punchcard
+ Description: How best can you time your posts to get best outreach.
+ When: Mondays
+ */
+
+/**
+ *
+ * ThinkUp/webapp/plugins/insightsgenerator/insights/outreachpunchcard.php
+ *
+ * Copyright (c) 2013 Nilaksh Das, Gina Trapani
+ *
+ * LICENSE:
+ *
+ * This file is part of ThinkUp (http://thinkup.com).
+ *
+ * ThinkUp is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * ThinkUp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with ThinkUp.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2013 Nilaksh Das, Gina Trapani
+ * @author Nilaksh Das <nilakshdas [at] gmail [dot] com>
+ */
+
+class OutreachPunchcardInsight extends InsightPluginParent implements InsightPlugin {
+    public function generateInsight(Instance $instance, $last_week_of_posts, $number_days) {
+        parent::generateInsight($instance, $last_week_of_posts, $number_days);
+        $this->logger->logInfo("Begin generating insight", __METHOD__.','.__LINE__);
+
+        if (parent::shouldGenerateInsight('outreach_punchcard', $instance, $insight_date='today',
+        $regenerate_existing_insight=false, $day_of_week=1, count($last_week_of_posts))) {
+            require THINKUP_WEBAPP_PATH.'config.inc.php';
+
+            $local_timezone = new DateTimeZone($THINKUP_CFG['timezone']);
+
+            $post_dao = DAOFactory::getDAO('PostDAO');
+            $punchcard = array();
+            $responses_chron = array();
+            $response_avg_timediffs = array();
+            for ($hotd = 0; $hotd < 24; $hotd++) {
+                for ($dotw = 1; $dotw <= 7; $dotw++) {
+                    $punchcard['posts'][$dotw][$hotd] = 0;
+                    $punchcard['responses'][$dotw][$hotd] = 0;
+                }
+                $responses_chron[$hotd] = 0;
+            }
+
+            foreach ($last_week_of_posts as $post) {
+                $responses = array();
+                $responses = array_merge(
+                    (array)$post_dao->getRepliesToPost($post->post_id, $post->network),
+                    (array)$post_dao->getRetweetsOfPost($post->post_id, $post->network)
+                );
+
+                foreach ($responses as $response) {
+                    $response_pub_date = new DateTime($response->pub_date);
+                    $response_dotw = date('N',
+                        (date('U',
+                            strtotime($response->pub_date)) + timezone_offset_get($local_timezone, $response_pub_date)
+                        )
+                    ); // Day of the week
+                    $response_hotd = date('G',
+                        (date('U',
+                            strtotime($response->pub_date)) + timezone_offset_get($local_timezone, $response_pub_date)
+                        )
+                    ); // Hour of the day
+                    $punchcard['responses'][$response_dotw][$response_hotd]++;
+
+                    $responses_chron[$response_hotd]++;
+                }
+
+                $post_pub_date = new DateTime($post->pub_date, $gmt);
+                $post_dotw = date('N',
+                    (date('U',
+                        strtotime($post->pub_date)) + timezone_offset_get($local_timezone, $post_pub_date)
+                    )
+                ); // Day of the week
+                $post_hotd = date('G',
+                    (date('U',
+                        strtotime($post->pub_date)) + timezone_offset_get($local_timezone, $post_pub_date)
+                    )
+                ); // Hour of the day
+                $punchcard['posts'][$post_dotw][$post_hotd]++;
+            }
+
+            arsort($responses_chron);
+            $most_responses = each($responses_chron);
+
+            $insight_text = '';
+
+            if ($most_responses['value'] > 0) {
+                $time1_low_hotd = $most_responses['key'];
+                $time1_high_hotd = $time1_low_hotd + 1;
+
+                $time1_low = (($time1_low_hotd % 12) ? ($time1_low_hotd % 12) : 12)
+                .((floor($time1_low_hotd / 12) == 1) ? 'pm' : 'am');
+                $time1_high = (($time1_high_hotd % 12) ? ($time1_high_hotd % 12) : 12)
+                .((floor($time1_high_hotd / 12) == 1) ? 'pm' : 'am');
+
+                $insight_text = $this->username."'s ".$this->terms->getNoun('post', InsightTerms::PLURAL)
+                ." from last week got <strong>".$most_responses['value']." "
+                .($most_responses['value'] > 1 ? 'responses' : 'response')."</strong>"
+                ." between <strong>".$time1_low." and ".$time1_high."</strong>";
+
+                $insight_comparison_text = '';
+                foreach ($responses_chron as $key => $value) {
+                    if ($value > 0 && $value < $most_responses['value']) {
+                        $time2_low_hotd = $key;
+                        $time2_high_hotd = $time2_low_hotd + 1;
+
+                        $time2_low = (($time2_low_hotd % 12) ? ($time2_low_hotd % 12) : 12)
+                        .((floor($time2_low_hotd / 12) == 1) ? 'pm' : 'am');
+                        $time2_high = (($time2_high_hotd % 12) ? ($time2_high_hotd % 12) : 12)
+                        .((floor($time2_high_hotd / 12) == 1) ? 'pm' : 'am');
+
+                        $insight_comparison_text = ", as compared to <strong>".$value." "
+                        .($value > 1 ? 'responses' : 'response')."</strong>"
+                        ." between <strong>".$time2_low." and ".$time2_high."</strong>";
+                    }
+                }
+
+                $insight_text .= $insight_comparison_text.".";
+
+                $this->insight_dao->insertInsight("outreach_punchcard", $instance->id, $this->insight_date,
+                "Outreach:", $insight_text, basename(__FILE__, ".php"), Insight::EMPHASIS_LOW,
+                serialize($punchcard));
+            }
+        }
+
+
+        $this->logger->logInfo("Done generating insight", __METHOD__.','.__LINE__);
+    }
+}
+
+$insights_plugin_registrar = PluginRegistrarInsights::getInstance();
+$insights_plugin_registrar->registerInsightPlugin('OutreachPunchcardInsight');

--- a/webapp/plugins/insightsgenerator/tests/TestOfOutreachPunchcardInsight.php
+++ b/webapp/plugins/insightsgenerator/tests/TestOfOutreachPunchcardInsight.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ *
+ * ThinkUp/webapp/plugins/insightsgenerator/tests/TestOfOutreachPunchcardInsight.php
+ *
+ * Copyright (c) 2013 Nilaksh Das, Gina Trapani
+ *
+ * LICENSE:
+ *
+ * This file is part of ThinkUp (http://thinkup.com).
+ *
+ * ThinkUp is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * ThinkUp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with ThinkUp.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Test of Outreach Punchcard Insight
+ *
+ * Test for OutreachPunchcardInsight class.
+ *
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2013 Nilaksh Das, Gina Trapani
+ * @author Nilaksh Das <nilakshdas [at] gmail [dot] com>
+ */
+
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
+require_once THINKUP_WEBAPP_PATH.'_lib/extlib/simpletest/autorun.php';
+require_once THINKUP_WEBAPP_PATH.'_lib/extlib/simpletest/web_tester.php';
+require_once THINKUP_WEBAPP_PATH.'config.inc.php';
+require_once THINKUP_ROOT_PATH. 'webapp/plugins/insightsgenerator/model/class.InsightPluginParent.php';
+require_once THINKUP_ROOT_PATH. 'webapp/plugins/insightsgenerator/insights/outreachpunchcard.php';
+
+class TestOfOutreachPunchcardInsight extends ThinkUpUnitTestCase {
+
+    public function setUp(){
+        parent::setUp();
+    }
+
+    public function tearDown() {
+        parent::tearDown();
+    }
+
+    public function testOutreachPunchcardInsight() {
+        require THINKUP_WEBAPP_PATH.'config.inc.php';
+
+        $local_timezone = new DateTimeZone($THINKUP_CFG['timezone']);
+
+        // Get data ready that insight requires
+        $posts = self::getTestPostObjects();
+
+        $post_pub_date = new DateTime($posts[0]->pub_date, $gmt);
+        $post_dotw = date('N',
+            (date('U',
+                strtotime($posts[0]->pub_date)) + timezone_offset_get($local_timezone, $post_pub_date)
+            )
+        ); // Day of the week
+        $post_hotd = date('G',
+            (date('U',
+                strtotime($posts[0]->pub_date)) + timezone_offset_get($local_timezone, $post_pub_date)
+            )
+        ); // Hour of the day
+
+        $builders = array();
+
+        $builders[] = FixtureBuilder::build('users', array('user_id'=>'7654321', 'user_name'=>'twitteruser',
+        'full_name'=>'Twitter User', 'avatar'=>'avatar.jpg', 'follower_count'=>36000, 'is_protected'=>0,
+        'network'=>'twitter', 'description'=>'A test Twitter User'));
+
+        $date_r = date("Y-m-d",strtotime('-1 day'));
+
+        // Response between 1pm and 2pm
+        $builders[] = FixtureBuilder::build('posts', array('id'=>136, 'post_id'=>136, 'author_user_id'=>7654321,
+        'author_username'=>'twitteruser', 'author_fullname'=>'Twitter User', 'author_avatar'=>'avatar.jpg',
+        'network'=>'twitter', 'post_text'=>'This is a reply.', 'source'=>'web',
+        'pub_date'=>$date_r.' 13:11:09', 'in_reply_to_post_id'=>133, 'reply_count_cache'=>0, 'is_protected'=>0));
+
+        // Response between 1pm and 2pm
+        $builders[] = FixtureBuilder::build('posts', array('id'=>137, 'post_id'=>137, 'author_user_id'=>7654321,
+        'author_username'=>'twitteruser', 'author_fullname'=>'Twitter User', 'author_avatar'=>'avatar.jpg',
+        'network'=>'twitter', 'post_text'=>'This is a reply.', 'source'=>'web',
+        'pub_date'=>$date_r.' 13:01:13', 'in_reply_to_post_id'=>133, 'reply_count_cache'=>0, 'is_protected'=>0));
+
+        // Response between 1pm and 2pm
+        $builders[] = FixtureBuilder::build('posts', array('id'=>138, 'post_id'=>138, 'author_user_id'=>7654321,
+        'author_username'=>'twitteruser', 'author_fullname'=>'Twitter User', 'author_avatar'=>'avatar.jpg',
+        'network'=>'twitter', 'post_text'=>'This is a reply.', 'source'=>'web',
+        'pub_date'=>$date_r.' 13:13:56', 'in_reply_to_post_id'=>135, 'reply_count_cache'=>0, 'is_protected'=>0));
+
+        // Response between 11am and 12pm
+        $builders[] = FixtureBuilder::build('posts', array('id'=>139, 'post_id'=>139, 'author_user_id'=>7654321,
+        'author_username'=>'twitteruser', 'author_fullname'=>'Twitter User', 'author_avatar'=>'avatar.jpg',
+        'network'=>'twitter', 'source'=>'web',
+        'post_text'=>'RT @testeriffic: New Year\'s Eve! Feeling very gay today, but not very homosexual.',
+        'pub_date'=>$date_r.' 11:07:42', 'in_retweet_of_post_id'=>134, 'reply_count_cache'=>0, 'is_protected'=>0));
+
+        $time1_low = new DateTime($date_r.' 13:00:00');
+        $time1_high = new DateTime($date_r.' 14:00:00');
+        $time1str_low = date('ga',
+            (date('U',
+                strtotime($date_r.' 13:00:00')) + timezone_offset_get($local_timezone, $time1_low)
+            )
+        );
+        $time1str_high = date('ga',
+            (date('U',
+                strtotime($date_r.' 14:00:00')) + timezone_offset_get($local_timezone, $time1_high)
+            )
+        );
+        $time1str = $time1str_low." and ".$time1str_high;
+
+        $time2_low = new DateTime($date_r.' 13:00:00');
+        $time2_high = new DateTime($date_r.' 14:00:00');
+        $time2str_low = date('ga',
+            (date('U',
+                strtotime($date_r.' 11:00:00')) + timezone_offset_get($local_timezone, $time2_low)
+            )
+        );
+        $time2str_high = date('ga',
+            (date('U',
+                strtotime($date_r.' 12:00:00')) + timezone_offset_get($local_timezone, $time2_high)
+            )
+        );
+        $time2str = $time2str_low." and ".$time2str_high;
+
+        $instance = new Instance();
+        $instance->id = 10;
+        $instance->network_username = 'testeriffic';
+        $instance->network = 'twitter';
+        $insight_plugin = new OutreachPunchcardInsight();
+        $insight_plugin->generateInsight($instance, $posts, 3);
+
+        // Assert that insight got inserted with correct punchcard information
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('outreach_punchcard', 10, $today);
+        $punchcard = unserialize($result->related_data);
+        $this->debug(Utils::varDumpToString($result));
+        $this->assertNotNull($result);
+        $this->assertIsA($result, "Insight");
+        $this->assertEqual($punchcard['posts'][$post_dotw][$post_hotd], 3);
+        $this->assertPattern('/\@testeriffic\'s tweets from last week got/', $result->text);
+        $this->assertPattern('/<strong>3 responses<\/strong> between <strong>'.$time1str.'<\/strong>/', $result->text);
+        $this->assertPattern('/as compared to <strong>1 response<\/strong>/', $result->text);
+        $this->assertPattern('/<strong>1 response<\/strong> between <strong>'.$time2str.'<\/strong>/', $result->text);
+    }
+
+    public function testOutreachPunchcardInsightNoResponse() {
+        // Get data ready that insight requires
+        $posts = self::getTestPostObjects();
+        $instance = new Instance();
+        $instance->id = 10;
+        $instance->network_username = 'testeriffic';
+        $instance->network = 'twitter';
+        $insight_plugin = new OutreachPunchcardInsight();
+        $insight_plugin->generateInsight($instance, $posts, 3);
+
+        // Assert that insight did not got inserted for no responses
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('outreach_punchcard', 10, $today);
+        $this->debug(Utils::varDumpToString($result));
+        $this->assertNull($result);
+    }
+
+    /**
+     * Get test post objects
+     * @return array of post objects for use in testing
+     */
+    private function getTestPostObjects() {
+        $post_text_arr = array();
+        $post_text_arr[] = "Now that I'm back on Android, realizing just how under sung Google Now is. ".
+        "I want it everywhere.";
+        $post_text_arr[] = "New Year's Eve! Feeling very gay today, but not very homosexual.";
+        $post_text_arr[] = "When @anildash told me he was writing this I was ".
+        "like 'yah whatever cool' then I read it and it knocked my socks off http://bit.ly/W9ASnj ";
+
+        $posts = array();
+        $counter = 133;
+        foreach ($post_text_arr as $test_text) {
+            $p = new Post();
+            $p->post_id = $counter++;
+            $p->network = 'twitter';
+            $p->post_text = $test_text;
+            $p->pub_date = date("Y-m-d H:i:s", strtotime('-2 days'));
+            $posts[] = $p;
+        }
+        return $posts;
+    }
+}

--- a/webapp/plugins/insightsgenerator/view/outreachpunchcard.tpl
+++ b/webapp/plugins/insightsgenerator/view/outreachpunchcard.tpl
@@ -1,0 +1,130 @@
+{include file=$tpl_path|cat:'_header.tpl'}
+
+{if  !$expand}
+<div class="pull-right detail-btn"><button class="btn btn-info btn-mini" data-toggle="collapse" data-target="#chart-{$i->id}"><i class="icon-signal icon-white"></i></button></div>
+{/if}
+
+<span class="label label-{if $i->emphasis eq '1'}info{elseif $i->emphasis eq '2'}success{elseif $i->emphasis eq '3'}error{else}info{/if}"><i class="icon-white icon-time"></i> <a href="?u={$i->instance->network_username}&n={$i->instance->network}&d={$i->date|date_format:'%Y-%m-%d'}&s={$i->slug}">{$i->prefix}</a></span>
+
+<i class="icon-{$i->instance->network}{if $i->instance->network eq 'google+'} icon-google-plus{/if} icon-muted"></i>
+{$i->text|link_usernames_to_twitter}
+
+{if !$expand}
+<div class="collapse in" id="chart-{$i->id}">
+{/if}
+
+    <div id="outreach_punchcard_{$i->id}">&nbsp;</div>
+    <div id="outreach_punchcard_legend_{$i->id}" style="padding: 5px; display: block; float: right; font-family: sans-serif; font-size: 12px;">
+      <div style="margin-right: 4px; padding: 2px; color: #0072bc; float: left;">posts</div>
+      <div style="margin-right: 4px; padding: 2px; color: #7dd3f0; float: left;">responses</div>
+    </div>
+    <script type="text/javascript">
+        {literal}
+        (function(d3) {
+          var OutreachPunchcard = function(placeholder_id, graph_size, outreach_data) {
+            var vis = d3.select('#'+placeholder_id)
+            .append("svg")
+            .attr("width", graph_size)
+            .attr("height", (graph_size / 3))
+            .style("display", "block")
+            .style("margin", "0 auto");
+
+            var x = d3.scale.linear().domain([0, 23]).range([(graph_size / 9), (graph_size - 20)]);
+            var y = d3.scale.linear().domain([1, 7]).range([20, ((graph_size / 3) - 40)]);
+
+            var xAxis = d3.svg.axis().scale(x).orient("bottom")
+            .ticks(24)
+            .tickFormat(function (d, i) {
+              var m = (d < 12) ? 'a' : 'p';
+              return (d % 12 == 0) ? 12+m :  (d % 12)+m;
+            });
+            var yAxis = d3.svg.axis().scale(y).orient("left")
+            .ticks(7)
+            .tickFormat(function (d, i) {
+              return ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][d - 1];
+            });
+
+            vis.append("g")
+            .attr("class", "axis")
+            .attr("transform", "translate(0, "+((graph_size / 3) - 20)+")")
+            .call(xAxis);
+
+            vis.append("g")
+            .attr("class", "axis")
+            .attr("transform", "translate("+((graph_size / 9) - 20)+", 0)")
+            .call(yAxis);
+
+            d3.selectAll('.axis path')
+            .style("fill", "none")
+            .style("stroke", "#eee")
+            .style("shape-rendering", "crispEdges");
+
+            d3.selectAll('.axis line')
+            .style("fill", "none")
+            .style("stroke", "#eee")
+            .style("shape-rendering", "crispEdges");
+
+            d3.selectAll('.axis text')
+            .style("font-family", "sans-serif")
+            .style("font-size", "11px");
+
+            var punches = {posts: [], responses: []};
+            var max_val = 0;
+            for (var i = 1; i <= 7; i++) {
+              for (var j = 0; j < 24; j++) {
+                max_val = Math.max(outreach_data.posts[i][j],max_val);
+                max_val = Math.max(outreach_data.responses[i][j],max_val);
+
+                punches.posts.push([i, j, outreach_data.posts[i][j]]);
+                punches.responses.push([i, j, outreach_data.responses[i][j]]);
+              }
+            }
+            var rad = d3.scale.linear()
+            .domain([0, 1, max_val])
+            .range([0, (max_val < 6 ? Math.round(12 / max_val) : 2), 12]);
+
+            var post_punch = vis.selectAll('g.post-punch')
+            .data(punches.posts)
+            .enter()
+            .append("g")
+            .attr("class", "post-punch");
+
+            post_punch.append("title")
+            .text(function(d) { return d[2]+" post"+(d[2] > 1 ? 's' : ''); });
+
+            post_punch.append("circle")
+            .attr("cx", function(d) { return x(d[1]); })
+            .attr("cy", function(d) { return y(d[0]); })
+            .attr("r", function(d) { return Math.round(rad(d[2])); })
+            .style("fill", "#0072bc")
+            .style("opacity", "1.0");
+
+            var response_punch = vis.selectAll('g.response-punch')
+            .data(punches.responses)
+            .enter()
+            .append("g")
+            .attr("class", "response-punch");
+
+            response_punch.append("title")
+            .text(function(d) { return d[2]+" response"+(d[2] > 1 ? 's' : ''); });
+
+            response_punch.append("circle")
+            .attr("cx", function(d) { return x(d[1]); })
+            .attr("cy", function(d) { return y(d[0]); })
+            .attr("r", function(d) { return Math.round(rad(d[2])); })
+            .style("fill", "#7dd3f0")
+            .style("opacity", "0.5");
+          };
+          {/literal}
+          var dataset = {$i->related_data|@json_encode};
+          new OutreachPunchcard("outreach_punchcard_{$i->id}", 800, dataset);
+          {literal}
+        })(d3);
+        {/literal}
+    </script>
+
+{if  !$expand}
+</div>
+{/if}
+
+{include file=$tpl_path|cat:'_footer.tpl'}


### PR DESCRIPTION
This insight helps users determine the time when their followers are online by plotting a punchcard of their posts with a punchcard of when their posts started getting responses. This would help users time their updates properly so as to get the optimum outreach and make sure that their updates don't get lost in their followers' timelines.

As discussed in #1669.
