### PR TITLE
Remove DateTimeZone from DateTime which is in GMT

### DIFF
--- a/webapp/plugins/insightsgenerator/insights/outreachpunchcard.php
+++ b/webapp/plugins/insightsgenerator/insights/outreachpunchcard.php
@@ -77,7 +77,7 @@ class OutreachPunchcardInsight extends InsightPluginParent implements InsightPlu
                     $responses_chron[$response_hotd]++;
                 }
 
-                $post_pub_date = new DateTime($post->pub_date, $local_timezone);
+                $post_pub_date = new DateTime($post->pub_date);
                 $post_dotw = date('N',
                 (date('U',
                 strtotime($post->pub_date)) + timezone_offset_get($local_timezone, $post_pub_date)

--- a/webapp/plugins/insightsgenerator/tests/TestOfOutreachPunchcardInsight.php
+++ b/webapp/plugins/insightsgenerator/tests/TestOfOutreachPunchcardInsight.php
@@ -47,22 +47,21 @@ class TestOfOutreachPunchcardInsight extends ThinkUpUnitTestCase {
     }
 
     public function testOutreachPunchcardInsight() {
-        require THINKUP_WEBAPP_PATH.'config.inc.php';
-
-        $local_timezone = new DateTimeZone($THINKUP_CFG['timezone']);
+        $cfg = Config::getInstance();
+        $local_timezone = new DateTimeZone($cfg->getValue('timezone'));
 
         // Get data ready that insight requires
         $posts = self::getTestPostObjects();
 
-        $post_pub_date = new DateTime($posts[0]->pub_date, $gmt);
+        $post_pub_date = new DateTime($posts[0]->pub_date);
         $post_dotw = date('N',
             (date('U',
-                strtotime($posts[0]->pub_date)) + timezone_offset_get($local_timezone, $post_pub_date)
+            strtotime($posts[0]->pub_date)) + timezone_offset_get($local_timezone, $post_pub_date)
             )
         ); // Day of the week
         $post_hotd = date('G',
             (date('U',
-                strtotime($posts[0]->pub_date)) + timezone_offset_get($local_timezone, $post_pub_date)
+            strtotime($posts[0]->pub_date)) + timezone_offset_get($local_timezone, $post_pub_date)
             )
         ); // Hour of the day
 


### PR DESCRIPTION
Setting DateTimeZone in DateTime is redundant for our use-case. This also fixes the [failing build in PHP 5.2](https://travis-ci.org/ginatrapani/ThinkUp/jobs/11375334).
