### PR TITLE
Fix keyword search to save old tweets and all tweets between crawls

### DIFF
--- a/webapp/_lib/dao/class.HashtagPostMySQLDAO.php
+++ b/webapp/_lib/dao/class.HashtagPostMySQLDAO.php
@@ -172,4 +172,13 @@ class HashtagPostMySQLDAO extends PDODAO implements HashtagPostDAO {
         $result = $this->getDataRowAsArray($ps);
         return $result['total'];
     }
+    
+    public function getLastPostIDByHashtag($hashtag_id) {
+        $vars = array(':hashtag_id'=>$hashtag_id);       
+        $q = "SELECT max(post_id) AS post_id FROM  #prefix#hashtags_posts ";
+        $q .= "WHERE  hashtag_id = :hashtag_id;";      
+        $ps = $this->execute($q, $vars);
+        $result = $this->getDataRowAsArray($ps);
+        return $result['post_id'];
+    }
 }

--- a/webapp/_lib/dao/interface.HashtagPostDAO.php
+++ b/webapp/_lib/dao/interface.HashtagPostDAO.php
@@ -77,4 +77,10 @@ interface HashtagPostDAO {
      * @return arr Post objects
      */
     public function getTotalPostsByHashtagAndDate($hashtag_id, $for_date=null);
+    /**
+     * Get last post ID by hashtag
+     * @param int $hashtag_id
+     * @return int post_id
+     */
+    public function getLastPostIDByHashtag($hashtag_id);
 }

--- a/webapp/plugins/twitter/model/class.TwitterCrawler.php
+++ b/webapp/plugins/twitter/model/class.TwitterCrawler.php
@@ -1154,6 +1154,9 @@ class TwitterCrawler {
             $continue_fetching = true;
             $since_id = 0;
             $max_id = 0;
+            $hashtag_count_cache = 0;
+            $capture_old_tweets = false;
+            $save_last_post_id = false;
             $instance_hashtag_dao = DAOFactory::getDAO('InstanceHashtagDAO');
             $post_dao = DAOFactory::getDAO('PostDAO');
             $user_dao = DAOFactory::getDAO('UserDAO');
@@ -1162,6 +1165,22 @@ class TwitterCrawler {
 
             //Get hashtag
             $hashtag = $hashtag_dao->getHashtagByID($instance_hashtag->hashtag_id);
+
+            //TODO: Change table column names last_post_id for since_post_id
+            //TODO: Change table column names earliest_post_id for max_post_id    
+            $hashtag_count_cache = $hashtag->count_cache;
+            
+            //if last_post_id is zero means that we still must save old tweets
+            if ($instance_hashtag->last_post_id == 0)  {
+                $max_id = $instance_hashtag->earliest_post_id; 
+                $capture_old_tweets = true;
+            } else {
+                //if earliest_post_id > last_post_id we are saving tweets between new and old ones
+                $since_id = $instance_hashtag->last_post_id;
+                if ($instance_hashtag->earliest_post_id > $instance_hashtag->last_post_id) {
+                    $max_id = $instance_hashtag->earliest_post_id;
+                }
+            }
 
             while ($continue_fetching) {
                 $endpoint = $this->api->endpoints['search_tweets'];
@@ -1172,14 +1191,10 @@ class TwitterCrawler {
                 $args["count"] = $count_arg;
                 $args["include_entities"] = "true";
 
-                if ($since_id == 0) {
-                    $since_id = $instance_hashtag->last_post_id;
-                }
-                if ($since_id > 0) {
-                    $args["since_id"] = $since_id;
-                }
-                if ($max_id > $since_id) {
-                    $args["max_id"] = $max_id;
+                if  ($capture_old_tweets) { if ($max_id > 0) { $args["max_id"] = bcsub($max_id,1); } } 
+                else{
+                    if ($since_id > 0) { $args["since_id"] = $since_id; }
+                    if (($max_id > $since_id) && ($max_id > 0)) { $args["max_id"] = bcsub($max_id,1); }                    
                 }
 
                 try {
@@ -1195,7 +1210,6 @@ class TwitterCrawler {
                     $tweets = $this->api->parseJSONTweetsFromSearch($payload);
                     foreach ($tweets as $tweet) {
                         $this->logger->logDebug('Processing '.$tweet['post_id'],__METHOD__.','.__LINE__);
-                        $this->logger->logDebug('Processing '.Utils::varDumpToString($tweet),__METHOD__.','.__LINE__);
                         $inserted_post_key = $post_dao->addPost($tweet, $this->user, $this->logger);
                         //We need to check if post exists before add relationship between post and hashtag
                         if ( $post_dao->isPostInDB($tweet['post_id'],'twitter')) {
@@ -1235,44 +1249,48 @@ class TwitterCrawler {
                                 $this->logger->logDebug('URLs have been processed',__METHOD__.','.__LINE__);
                             }
                         }
-                        if ($tweet['post_id'] > $instance_hashtag->last_post_id) {
-                            $instance_hashtag->last_post_id = $tweet['post_id'];
-                        }
-                        if ($instance_hashtag->earliest_post_id == 0
-                        || $tweet['post_id'] < $instance_hashtag->earliest_post_id) {
-                            $instance_hashtag->earliest_post_id = $tweet['post_id'];
-                        }
-                        if ($max_id == 0 || $tweet['post_id'] < $max_id) {
-                            $max_id = $tweet['post_id'];
-                        }
-                        $this->logger->logDebug('Instance hashtag markers updated',__METHOD__.','.__LINE__);
+                        //For each tweet we save max_id if lower
+                        if ($max_id == 0 || $tweet['post_id'] < $max_id) { $max_id = $tweet['post_id']; }
                     }
 
                     //Status message for tweets and users
-                    $status_message = ' ' . count($tweets)." tweet(s) found and $count saved";
-                    $this->logger->logUserSuccess($status_message, __METHOD__.','.__LINE__);
-                    $status_message = ' ' . count($tweets)." tweet(s) found and $user_count users saved";
-                    $this->logger->logUserSuccess($status_message, __METHOD__.','.__LINE__);
-
-                    //Save instance_hashtag important values
-                    if ($instance_hashtag->last_post_id > 0) {
-                        $instance_hashtag_dao->updateLastPostID($instance_hashtag->instance_id,
-                        $instance_hashtag->hashtag_id, $instance_hashtag->last_post_id);
-                    }
-                    if ($instance_hashtag->earliest_post_id > 0) {
-                        $instance_hashtag_dao->updateEarliestPostID($instance_hashtag->instance_id,
-                        $instance_hashtag->hashtag_id, $instance_hashtag->earliest_post_id);
-                    }
-
-                    //Not to continue fetching if search not return the maxim number of tweets
-                    if  (count($tweets) < $count_arg) {
+                    if (count($tweets) > 0 || $count > 0 || $user_count > 0) {
+                        $hashtag_count_cache += $count;
+                        if ($capture_old_tweets && ($hashtag_count_cache >= $this->api->archive_limit) ) {
+                            //We have saved so many old tweets
+                            $capture_old_tweets = false;
+                            $save_last_post_id = true;
+                        }
+                        $status_message = ' ' . count($tweets)." tweet(s) found and $count saved";
+                        $this->logger->logUserSuccess($status_message, __METHOD__.','.__LINE__);
+                        $status_message = ' ' . count($tweets)." tweet(s) found and $user_count users saved";
+                        $this->logger->logUserSuccess($status_message, __METHOD__.','.__LINE__);
+                    } else {       
+                        //Search don't return any tweet, so we finish searching                 
                         $continue_fetching = false;
+                        $capture_old_tweets = false;
+                        $save_last_post_id = true;
                     }
+                    
+                    if ($save_last_post_id) {
+                        //Save last_post_id for searching new tweets next time
+                        $last_post_id = $hashtagpost_dao->getLastPostIDByHashtag($instance_hashtag->hashtag_id);
+                        if ($last_post_id > 0) {
+                            $since_id = $last_post_id;
+                            $instance_hashtag_dao->updateLastPostID($instance_hashtag->instance_id,
+                                    $instance_hashtag->hashtag_id, $last_post_id);
+                        }
+                    }                                       
+                    if ($max_id > 0) {
+                        $instance_hashtag_dao->updateEarliestPostID($instance_hashtag->instance_id,
+                        $instance_hashtag->hashtag_id, $max_id);
+                    }
+
                 } else {
                     $status_message = "Stop fetching tweets. cURL_status = " . $cURL_status;
                     $this->logger->logUserSuccess($status_message, __METHOD__.','.__LINE__);
                     $continue_fetching = false;
-                }
+                }                
             }
         }
     }


### PR DESCRIPTION
# Introduction

We have made improvements:
- Crawl save old tweets when you start a saved search, not only the last **tweet_count_per_call** tweets with maximum **archive_limit** tweets
- Crawl save all tweets between consecutive calls by saving since_id and max_id in database
- If there is an API call limit problem and searching tweets is interrupted, next time it will continue and you won't lose any tweet
# Changes
- New function getLastPostIDByHashtag in HashtagPostDAO interface
- Modifications in getLastPostIDByHashtag to ensure capturing all tweets from a search

Powered by Televisió de Catalunya / Universitat Illes Balears -
SOCIALMEDIA PROJECT - CEN-20101037 - This contribution has been kindly
sponsored by the Centro para el Desarrollo Tecnológico Industrial within
the Programa de Investigación Nacional Español CENIT. -
http://www.cenitsocialmedia.es/
