### PR TITLE
Mandrill feature

### DIFF
--- a/tests/TestOfMailer.php
+++ b/tests/TestOfMailer.php
@@ -33,10 +33,14 @@ class TestOfMailer extends ThinkUpBasicUnitTestCase {
 
     public function setUp() {
         parent::setUp();
+        $config = Config::getInstance();
+        $config->setValue("mandrill_key", "");
     }
 
     public function tearDown(){
         parent::tearDown();
+        $config = Config::getInstance();
+        $config->setValue("mandrill_key", "");
         // delete test email file if it exists
         $test_email = FileDataManager::getDataPath(Mailer::EMAIL);
         if (file_exists($test_email)) {
@@ -44,7 +48,7 @@ class TestOfMailer extends ThinkUpBasicUnitTestCase {
         }
     }
 
-    public function testFromName() {
+    public function testFromName() {    
         $config = Config::getInstance();
         $config->setValue("app_title_prefix", "My Crazy Custom ");
         $_SERVER['HTTP_HOST'] = "my_thinkup_hostname";
@@ -61,5 +65,38 @@ class TestOfMailer extends ThinkUpBasicUnitTestCase {
         $this->debug($email_body);
         $this->assertPattern('/From: "My Other Installation of ThinkUp" <notifications@my_other_hostname>/',
         $email_body);
+    }
+
+    public function testMandrill() {
+        $config = Config::getInstance();
+        $config->setValue("app_title_prefix", "My Crazy Custom ");
+        $config->setValue("mandrill_key", "1234567890");
+        $_SERVER['HTTP_HOST'] = "my_thinkup_hostname";
+        Mailer::mail('you@example.com', 'Testing 123', 'Me worky, yo?');
+        $email_body = Mailer::getLastMail();
+        $this->debug($email_body);
+
+        // Exact JSON structure copied from Mandrill's site
+        $json = <<<json
+{
+    "key": "1234567890",
+    "message": {
+        "text": "Me worky, yo?",
+        "subject": "Testing 123",
+        "from_email": "notifications@my_thinkup_hostname",
+        "from_name": "My Crazy Custom ThinkUp",
+        "to": [
+            {
+                "email": "you@example.com",
+                "name": "you@example.com"
+            }
+        ]
+    }         
+}
+json;
+        
+        // Compare JSON string, ignoring whitespace differences
+        $this->assertTrue(json_encode(json_decode($json)) === $email_body);
+
     }
 }

--- a/webapp/_lib/class.MailerMandrill.php
+++ b/webapp/_lib/class.MailerMandrill.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ *
+ * ThinkUp/webapp/_lib/class.MailerMandrill.php
+ *
+ * Copyright (c) 2009-2013 Gina Trapani
+ *
+ * LICENSE:
+ *
+ * This file is part of ThinkUp (http://thinkup.com).
+ *
+ * ThinkUp is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * ThinkUp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with ThinkUp.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @author KJ <xiankai[at]gmail[dot]com>
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2009-2013 Gina Trapani
+ */
+class MailerMandrill {
+    /**
+     * @param str $to A valid email address
+     * @param str $subject
+     * @param str $message
+     */
+    public static function mail($to, $subject, $message) {
+        $config = Config::getInstance();
+
+        $app_title = $config->getValue('app_title_prefix') . "ThinkUp";
+        $host = Mailer::getHost();
+        $mandrill_key = $config->getValue('mandrill_key');
+        $params = array(
+                'key' => $mandrill_key,
+                'message' => array(
+                    'text' => $message,
+                    'subject' => $subject,
+                    'from_email' => "notifications@${host}",
+                    'from_name' => $app_title,
+                    'to' => array(
+                        array(
+                            'email' => $to,
+                            'name' => $to
+                        )
+                    )
+                ),
+            );
+        $params = json_encode($params);
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_USERAGENT, 'Mandrill-PHP/1.0.22');
+        curl_setopt($ch, CURLOPT_URL, 'https://mandrillapp.com/api/1.0/messages/send');
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+        curl_setopt($ch, CURLOPT_HEADER, 0);
+
+        //don't send email when running tests, just write it to the filesystem for assertions
+        if (Mailer::isTest()) {
+            Mailer::setLastMail($params);
+        } else {
+            curl_exec($ch);
+        }
+
+    }
+}

--- a/webapp/_lib/class.MailerPHP.php
+++ b/webapp/_lib/class.MailerPHP.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ *
+ * ThinkUp/webapp/_lib/class.MailerPHP.php
+ *
+ * Copyright (c) 2009-2013 Gina Trapani
+ *
+ * LICENSE:
+ *
+ * This file is part of ThinkUp (http://thinkup.com).
+ *
+ * ThinkUp is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * ThinkUp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with ThinkUp.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @author KJ <xiankai[at]gmail[dot]com>
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2009-2013 Gina Trapani
+ */
+class MailerPHP {
+    /**
+     * Send email from ThinkUp instalation. If you're running tests, just write the message headers and contents to
+     * the file system in the data directory.
+     * @param str $to A valid email address
+     * @param str $subject
+     * @param str $message
+     */
+    public static function mail($to, $subject, $message) {
+        $config = Config::getInstance();
+
+        $app_title = $config->getValue('app_title_prefix'). "ThinkUp";
+        $host = Mailer::getHost();
+
+        $mail_header = "From: \"{$app_title}\" <notifications@{$host}>\r\n";
+        $mail_header .= "X-Mailer: PHP/".phpversion();
+
+        //don't send email when running tests, just write it to the filesystem for assertions
+        if (Mailer::isTest()) {
+            Mailer::setLastMail($mail_header."\n" .
+                                "to: $to\n" .
+                                "subject: $subject\n" .
+                                "message: $message");
+        } else {
+            mail($to, $subject, $message, $mail_header);
+        }
+    }
+}

--- a/webapp/config.sample.inc.php
+++ b/webapp/config.sample.inc.php
@@ -30,6 +30,9 @@ $THINKUP_CFG['cache_lifetime']               = 600;
 // 20 minutes or more since the last crawl.
 $THINKUP_CFG['rss_crawler_refresh_rate']  = 20;
 
+// Optional Mandrill key. Set this to a valid key to send via Mandrill instead.
+$THINKUP_CFG['mandrill_key'] = '';
+
 /************************************************/
 /***  DATABASE CONFIG                         ***/
 /************************************************/


### PR DESCRIPTION
This is my first attempt at open-source contribution, and I figured that if the requirement for PHP's `mail` function could be removed, It would benefit the project greatly. Since the call to Mandrill uses cURL and sends a simple transactional email, it can serve as a simple drop-in replacement for a local mail sender. Please let me know if I can improve on it!
