### PR TITLE
Minor spelling corrections to CLI upgrade.php

### DIFF
--- a/webapp/install/cli/upgrade.php
+++ b/webapp/install/cli/upgrade.php
@@ -57,14 +57,14 @@ try {
         exit;
     } else {
         if (!$no_version) {
-            print "\nThinkup needs to be upgraded to version $thinkup_db_version, proceed => [y|n] ";
+            print "\nThinkup needs to be upgraded to version $thinkup_db_version, proceed? => [y|n] ";
             $handle = fopen ("php://stdin","r");
             $line = fgets($handle);
             if (trim($line) != 'y'){
                 exit;
             }
         }
-        print "\nWould you like to backup your data first? => [y|n] ";
+        print "\nWould you like to back up your data first? => [y|n] ";
         $handle = fopen ("php://stdin","r");
         $line = fgets($handle);
         if (trim($line) == 'y'){
@@ -73,7 +73,7 @@ try {
                 print "\n    Error: ThinkUp backups require Zip support\n\n";
                 exit(1);
             }
-            print "\nEnter a .zip filename (/path/tp/backup.zip) => ";
+            print "\nEnter a .zip filename (/path/to/backup.zip) => ";
             $handle = fopen ("php://stdin","r");
             $line = fgets($handle);
             $filename = trim($line);


### PR DESCRIPTION
I finally got around to upgrading my ThinkUp database today and noticed a few minor spelling errors in `upgrade.php`. 
- The question mark at the end of "ThinkUp needs to be upgraded..." brings it in line with the rest of the questions
- "backup" is [not a verb](http://notaverb.com/backup)
- Corrected "tp" to "to"
