### PR TITLE
Updated facebook settings view to reflect current facebook new app form.

### DIFF
--- a/webapp/plugins/facebook/view/facebook.account.index.tpl
+++ b/webapp/plugins/facebook/view/facebook.account.index.tpl
@@ -131,7 +131,7 @@
     Fill in the following settings.<br />
     <strong>App Display Name:</strong> <span style="font-family:Courier;">{$logged_in_user} ThinkUp</span><br />
     <strong>App Namespace:</strong> [leave blank]<br />
-    <strong>Web Hosting:</strong> [Do not check box]<br />
+    <strong>App Category:</strong> [Leave as default: Other - Choose a sub-category]<br />
     Click "Continue", enter in the security word, and click "Continue" again
 </li>
 <li>


### PR DESCRIPTION
Just noticed this was out-of-date when setting up my instance.

Removed instrutions about a Web Hosting checkbox, which is gone on the facebook Create App form.
Added info about the App Category dropdown, which can be left alone.
