### PR TITLE
Plugins link on account management now always takes you to plugins.

### DIFF
--- a/tests/TestOfAccountConfigurationController.php
+++ b/tests/TestOfAccountConfigurationController.php
@@ -394,6 +394,7 @@ class TestOfAccountConfigurationController extends ThinkUpUnitTestCase {
         $this->assertEqual($owner->email, 'admin@example.com');
         $this->assertIsA($v_mgr->getTemplateDataItem('owners'), 'array');
         $this->assertEqual(sizeof($v_mgr->getTemplateDataItem('owners')), 2);
+        $this->assertTrue($v_mgr->getTemplateDataItem('installed_plugins'));
 
         //not set: owners, body, success_msg, error_msg
         $this->assertTrue(!$v_mgr->getTemplateDataItem('body'));
@@ -418,12 +419,12 @@ class TestOfAccountConfigurationController extends ThinkUpUnitTestCase {
         $this->assertEqual($owner->full_name, 'ThinkUp J. User');
         $this->assertEqual($owner->email, 'me@example.com');
         $this->assertTrue($v_mgr->getTemplateDataItem('body'));
+        $this->assertTrue($v_mgr->getTemplateDataItem('installed_plugins'));
 
-        //not set: owners, body, success_msg, error_msg
+        //not set: owners, success_msg, error_msg
         $this->assertTrue(!$v_mgr->getTemplateDataItem('owners'));
         $this->assertTrue(!$v_mgr->getTemplateDataItem('success_msg'));
         $this->assertTrue(!$v_mgr->getTemplateDataItem('error_msg'));
-        $this->assertTrue(!$v_mgr->getTemplateDataItem('installed_plugins'));
     }
 
     public function testAuthControlLoggedInSpecificPluginDoesNotExist() {

--- a/webapp/_lib/controller/class.AccountConfigurationController.php
+++ b/webapp/_lib/controller/class.AccountConfigurationController.php
@@ -293,12 +293,12 @@ class AccountConfigurationController extends ThinkUpAuthController {
             $this->addToView('body', $p->renderInstanceConfiguration($owner, $instance_username, $instance_network));
             $profiler = Profiler::getInstance();
             $profiler->clearLog();
-        }  else {
-            $plugin_dao = DAOFactory::getDAO('PluginDAO');
-            $config = Config::getInstance();
-            $installed_plugins = $plugin_dao->getInstalledPlugins();
-            $this->addToView('installed_plugins', $installed_plugins);
-        }
+        } 
+
+        $plugin_dao = DAOFactory::getDAO('PluginDAO');
+        $config = Config::getInstance();
+        $installed_plugins = $plugin_dao->getInstalledPlugins();
+        $this->addToView('installed_plugins', $installed_plugins);
         /* End plugin-specific configuration handling */
 
         if ($owner->is_admin) {

--- a/webapp/_lib/view/account.index.tpl
+++ b/webapp/_lib/view/account.index.tpl
@@ -42,14 +42,14 @@
                             </td>
                             <td>
                                 <p class="lead" style="padding-left: 0px; margin : 0px;">
-                                <a href="?p={$ip->folder_name|get_plugin_path}"><span id="spanpluginnamelink{$ip->id}">{$ip->name}</span></a>
+                                <a href="?p={$ip->folder_name|get_plugin_path}#manage_plugin" class="manage_plugin"><span id="spanpluginnamelink{$ip->id}">{$ip->name}</span></a>
                                 </p>
                                 <span class="muted">{$ip->description}</span>
                             </td>
                     {if $user_is_admin}
                       <td class="action-button">
                       <span id="spanpluginactivation{$ip->id}" style="margin-top : 4px;">
-                          <a href="{$site_root_path}account/?p={$ip->folder_name|get_plugin_path}" class="btn {if !$ip->isConfigured()}btn-primary{/if}">{if $ip->isConfigured()} <i class="icon-cog "></i> Configure{else}<i class="icon-warning-sign"></i> Set Up{/if}</a>
+                          <a href="{$site_root_path}account/?p={$ip->folder_name|get_plugin_path}#manage_plugin" class="manage_plugin btn {if !$ip->isConfigured()}btn-primary{/if}">{if $ip->isConfigured()} <i class="icon-cog "></i> Configure{else}<i class="icon-warning-sign"></i> Set Up{/if}</a>
                       </span>
                       <span style="display: none;" class='linkbutton' id="messageactive{$ip->id}"></span>
                       </td>
@@ -58,13 +58,15 @@
                   {/if}
                 {/foreach}
                     </table>
-              {else}
-                <a href="?m=manage" class="btn btn-mini"><i class="icon-chevron-left icon-muted"></i> Back to plugins</a>
               {/if}
+        </div> <!-- end #plugins -->
+
+		<div class="section" id="manage_plugin" {if $body}style="display: block"{/if}>
+            <a href="?m=manage" class="btn btn-mini"><i class="icon-chevron-left icon-muted"></i> Back to plugins</a>
             {if $body}
               {$body}
             {/if}
-        </div> <!-- end #plugins -->
+		</div>
 
         {if $user_is_admin}
         <div class="section thinkup-canvas clearfix" id="app_settings">
@@ -490,6 +492,20 @@ $(function() {
         demoteOwner($(this).attr("id"));
       }
     });
+
+    $('.manage_plugin').click(function (e) {
+      var url = $(this).attr('href');
+      var p = url.replace(/.*p=/, '').replace(/#.*/, '');;
+      if (window.location.href.indexOf("="+p) >= 0) {
+        $('.section').hide();
+        $('#manage_plugin').show();
+        e.preventDefault();
+      }
+    });
+    if (window.location.hash && window.location.hash == '#manage_plugin') {
+      $('.section').hide();
+      $('#manage_plugin').show();
+    }
 
   });
 


### PR DESCRIPTION
This addresses issue #1486.

Two things I wasn't sure of:

1) Is this a good idea?  Because the tabs work by loading the whole page and then dynamically hiding and showing divs, solving this requires loading both the current plugin and the list of plugins at once OR making the navigation/tab javascript and/or template a lot more complicated to know whether it's currently in plugin vs plugin list mode.

2) Whether including that very view-specific javascript in the template (in the existing jquery.ready(), though) is the best place for it to go.
