### PR TITLE
A link to a separate part of the documentation that tells developers how...

### DIFF
--- a/docs/source/contribute/developers/devfromsource.rst
+++ b/docs/source/contribute/developers/devfromsource.rst
@@ -121,7 +121,9 @@ your development server. If you have problems, check the permissions on
 the newly created thinkup directory on your server.
 
 Install a running instance of ThinkUp on your development server using
-any of a number of installation guides.
+any of a number of installation guides. Running nightly code from ThinkUp’s 
+git repository might require you to `catch up on necessary database 
+migrations <https://www.thinkup.com/docs/install/upgrade.html#running-beta-versions-or-code-from-github>`_.
 
 Create an Issue-Specific Development Branch
 -------------------------------------------


### PR DESCRIPTION
... to run nightly code

This page is presented in a way that fully explains how to get up an running as a ThinkUp developer. A problem I ran into was attempting to run code from HEAD in master where I could not figure out why my install was not working. It wasn't working because I missed the database migration step for nightly code.

Currently the page just says "Now Install ThinkUp" without any mention that a developer might have separate issues from a normal installer. Also the guide for what developers should do is currently on a page about upgrading while developers might hit the database migration issue on the initial install, not just on an upgrade.

I think adding this link will at least attempt to direct developers in the correct direction.

An additional step might be highlighting Developers and Beta testers in the second level navigation under the Install menu option.
