### PR TITLE
Don't merge in plugin post details menu when it doesn't exist.

### DIFF
--- a/tests/TestOfPostController.php
+++ b/tests/TestOfPostController.php
@@ -387,6 +387,34 @@ class TestOfPostController extends ThinkUpUnitTestCase {
         $this->assertEqual(0, $data['is_active']);
     }
 
+    public function testPluginMenuGeneration() {
+        $instance_builder = FixtureBuilder::build('instances', array('network_user_id'=>'10', 'network_username'=>'ev',
+            'is_public'=>1, 'network'=>'facebook'));
+        $post_builder = FixtureBuilder::build('posts', array('id'=>1, 'post_id'=>'1001', 'author_user_id'=>'10',
+            'author_username'=>'ev', 'post_text'=>'This is a test post', 'retweet_count_cache'=>'5', 'network'=>'facebook',
+            'is_protected'=>0, 'location' => 'Clarence, NY 14031, USA'));
+        $user_builder = FixtureBuilder::build('users', array('user_id'=>'10', 'username'=>'ev', 'is_protected'=>'0',
+            'network'=>'facebook'));
+
+        $data[] = FixtureBuilder::build('plugins', array('name'=>"Facebook", 'folder_name'=>'facebook', 'is_active' => 1));
+        $data[] = FixtureBuilder::build('plugins', array('name'=>"YouTube", 'folder_name'=>'youtube', 'is_active' => 1));
+
+        // Disable debug (because then the controller sets reporting to E_STRICT) and enable warnings
+        $this->config->setValue('debug', 0);
+        $old_level = error_reporting();
+        error_reporting(E_WARNING);
+
+        $_GET['t'] = '1001';
+        $_GET['n'] = 'facebook';
+        $_GET['v'] = 'likes';
+        $controller = new PostController(true);
+        $results = $controller->go();
+        $this->assertNoPattern( "/PHP error/", $results);
+        $this->assertPattern( "/n=facebook.*Replies/", $results);
+        error_reporting($old_level);
+    }
+
+
     private function buildPublicPostWithMixedAccessResponses($with_xss = false) {
         $post_text = 'This is a test post';
         if ($with_xss) {

--- a/webapp/_lib/class.PluginRegistrarWebapp.php
+++ b/webapp/_lib/class.PluginRegistrarWebapp.php
@@ -121,7 +121,9 @@ class PluginRegistrarWebapp extends PluginRegistrar {
                 $p = new $plugin_class_name;
                 if ($p instanceof PostDetailPlugin) {
                     $menus = $p->getPostDetailMenuItems($post);
-                    $this->post_detail_menus = array_merge($this->post_detail_menus, $menus);
+                    if (is_array($menus)) {
+                        $this->post_detail_menus = array_merge($this->post_detail_menus, $menus);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Prevents warnings from being occassionally being generated when merging post
detail menu array details together.
The test turns off debug and turns on E_WARNING to prevent the message from
being hidden.  (Which in actual running, it is not on occasion.)
Test also verifies that plugins are added to the menu.

references issue #1756
