### PR TITLE
Check for links from 2 days ago midnight untl an hour ago in LinkPrompt Insight

### DIFF
--- a/webapp/plugins/insightsgenerator/insights/linkprompt.php
+++ b/webapp/plugins/insightsgenerator/insights/linkprompt.php
@@ -43,8 +43,10 @@ class LinkPromptInsight extends InsightPluginParent implements InsightPlugin {
             $post_dao = DAOFactory::getDAO('PostDAO');
             $link_dao = DAOFactory::getDAO('LinkDAO');
 
+            // Check from midnight two days ago until an hour from now
+            // (to avoid clock-sync issues)
             $recent_posts = $post_dao->getPostsByUserInRange($instance->network_user_id, $instance->network,
-            date('Y-m-d H:i:s', strtotime('-2 days midnight')), date('Y-m-d H:i:s', strtotime('today midnight')));
+            date('Y-m-d H:i:s', strtotime('-2 days midnight')), date('Y-m-d H:i:s', strtotime('+1 hour')));
 
             $posts_with_links = array();
 

--- a/webapp/plugins/insightsgenerator/tests/TestOfLinkPromptInsight.php
+++ b/webapp/plugins/insightsgenerator/tests/TestOfLinkPromptInsight.php
@@ -66,6 +66,32 @@ class TestOfLinkPromptInsight extends ThinkUpUnitTestCase {
         $this->assertPattern('/\@testeriffic hasn\'t tweeted a link in the last 2 days/', $result->text);
     }
 
+    public function testLinkPromptInsighPromptWithRecentTweet() {
+        // Get data ready that insight requires
+        $builders = self::buildData();
+
+        $days_ago_1 = date('Y-m-d H:i:s', strtotime('1 hour ago'));
+        $builders[] = FixtureBuilder::build('posts', array('id'=>241, 'post_id'=>241, 'author_user_id'=>7612345,
+        'author_username'=>'testeriffic', 'author_fullname'=>'Twitter User', 'author_avatar'=>'avatar.jpg',
+        'network'=>'twitter', 'post_text'=>"I don't always tweet holiday gift guides, but when I do, it's from @overthinkingit: http://t.co/jZTI9PGm9b\nIdeas for the geek on your list.", 'source'=>'web',
+        'pub_date'=>$days_ago_1, 'reply_count_cache'=>0, 'is_protected'=>0));
+
+        $instance = new Instance();
+        $instance->id = 10;
+        $instance->network_user_id = 7612345;
+        $instance->network_username = 'testeriffic';
+        $instance->network = 'twitter';
+        $insight_plugin = new LinkPromptInsight();
+        $insight_plugin->generateInsight($instance, $last_week_of_posts, 3);
+
+        // Assert that no insight got inserted
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('link_prompt', 10, $today);
+        $this->debug(Utils::varDumpToString($result));
+        $this->assertNull($result);
+    }
+
     public function testLinkPromptInsightNoPrompt() {
         // Get data ready that insight requires
         $builders = self::buildData();


### PR DESCRIPTION
strtotime('midnight today') was generating a time at 00:00:00 on the
current day which would exclude many recent tweets and cause a confusing
insight to be generated.

In regards to #1620
