### PR TITLE
Make Foursquare tests require statements consistent with other plugins

### DIFF
--- a/webapp/plugins/foursquare/tests/TestOfFoursquareCrawler.php
+++ b/webapp/plugins/foursquare/tests/TestOfFoursquareCrawler.php
@@ -29,7 +29,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2012-2013 Aaron Kalair
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/web_tester.php';
 require_once THINKUP_ROOT_PATH.'webapp/plugins/foursquare/model/class.FoursquareCrawler.php';

--- a/webapp/plugins/foursquare/tests/TestOfFoursquarePlugin.php
+++ b/webapp/plugins/foursquare/tests/TestOfFoursquarePlugin.php
@@ -30,7 +30,7 @@
  * @copyright 2012-2013 Aaron Kalair
  */
 
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 require_once THINKUP_ROOT_PATH.'tests/classes/class.ThinkUpBasicUnitTestCase.php';

--- a/webapp/plugins/foursquare/tests/TestOfFoursquarePluginConfigurationController.php
+++ b/webapp/plugins/foursquare/tests/TestOfFoursquarePluginConfigurationController.php
@@ -25,7 +25,7 @@
  * @license http://www.gnu.org/licenses/gpl.html
  * @copyright 2012-2013 Aaron Kalair
  */
-require_once 'tests/init.tests.php';
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
 require_once THINKUP_ROOT_PATH.'webapp/_lib/extlib/simpletest/autorun.php';
 require_once THINKUP_ROOT_PATH.'webapp/config.inc.php';
 require_once THINKUP_ROOT_PATH.'tests/classes/class.ThinkUpBasicUnitTestCase.php';


### PR DESCRIPTION
Broke this out from the Instagram plugin. The Foursquare tests require statements for init.tests.php were inconsistent with all the other plugins, this makes them consistent.
