### PR TITLE
Fixes warning about index not being found

### DIFF
--- a/webapp/plugins/twitter/model/class.CrawlerTwitterAPIAccessorOAuth.php
+++ b/webapp/plugins/twitter/model/class.CrawlerTwitterAPIAccessorOAuth.php
@@ -77,9 +77,11 @@ class CrawlerTwitterAPIAccessorOAuth extends TwitterAPIAccessorOAuth {
             }
         }
         foreach ($this->endpoints as $endpoint) {
-            $endpoint->setRemaining($limits[$endpoint->getShortPath()]['remaining']);
-            $endpoint->setLimit($limits[$endpoint->getShortPath()]['limit']);
-            $endpoint->setReset($limits[$endpoint->getShortPath()]['reset']);
+            if(isset($limits[$endpoint->getShortPath()])) {
+                $endpoint->setRemaining($limits[$endpoint->getShortPath()]['remaining']);
+                $endpoint->setLimit($limits[$endpoint->getShortPath()]['limit']);
+                $endpoint->setReset($limits[$endpoint->getShortPath()]['reset']);
+            }
         }
     }
     /**


### PR DESCRIPTION
Another bug fix broken out of the Instagram plugin commit. Fixes an issue where warning were shown about the index not being found.
