### PR TITLE
Alter Reply Spike Insight to use correct term for posts.

### DIFF
--- a/webapp/plugins/insightsgenerator/insights/replyspike.php
+++ b/webapp/plugins/insightsgenerator/insights/replyspike.php
@@ -76,8 +76,8 @@ class ReplySpikeInsight extends InsightPluginParent implements InsightPlugin {
                     if (isset($hot_posts_data)) {
                         $this->insight_dao->insertInsight('reply_high_365_day_'.$post->id, $instance->id,
                         $simplified_post_date, "New 365-day record!","<strong>".number_format($post->reply_count_cache).
-                        " people</strong> replied to $this->username's post.", $filename, Insight::EMPHASIS_HIGH,
-                        serialize(array($post, $hot_posts_data)));
+                        " people</strong> replied to $this->username's ".$this->terms->getNoun('post').".", $filename,
+                        Insight::EMPHASIS_HIGH, serialize(array($post, $hot_posts_data)));
 
                         $this->insight_dao->deleteInsight('reply_high_30_day_'.$post->id, $instance->id,
                         $simplified_post_date);
@@ -97,8 +97,8 @@ class ReplySpikeInsight extends InsightPluginParent implements InsightPlugin {
                     if (isset($hot_posts_data)) {
                         $this->insight_dao->insertInsight('reply_high_30_day_'.$post->id, $instance->id,
                         $simplified_post_date, "New 30-day record!", "<strong>".number_format($post->reply_count_cache).
-                        " people</strong> replied to $this->username's post.", $filename, Insight::EMPHASIS_HIGH,
-                        serialize(array($post, $hot_posts_data)));
+                        " people</strong> replied to $this->username's ".$this->terms->getNoun('post').".", $filename,
+                        Insight::EMPHASIS_HIGH, serialize(array($post, $hot_posts_data)));
 
                         $this->insight_dao->deleteInsight('reply_high_7_day_'.$post->id, $instance->id,
                         $simplified_post_date);
@@ -116,8 +116,8 @@ class ReplySpikeInsight extends InsightPluginParent implements InsightPlugin {
                     if (isset($hot_posts_data)) {
                         $this->insight_dao->insertInsight('reply_high_7_day_'.$post->id, $instance->id,
                         $simplified_post_date, "New 7-day record!", "<strong>".number_format($post->reply_count_cache).
-                        " people</strong> replied to $this->username's post.", $filename, Insight::EMPHASIS_HIGH,
-                        serialize(array($post, $hot_posts_data)));
+                        " people</strong> replied to $this->username's ".$this->terms->getNoun('post').".", $filename,
+                        Insight::EMPHASIS_HIGH, serialize(array($post, $hot_posts_data)));
 
                         $this->insight_dao->deleteInsight('reply_high_30_day_'.$post->id, $instance->id,
                         $simplified_post_date);
@@ -137,8 +137,8 @@ class ReplySpikeInsight extends InsightPluginParent implements InsightPlugin {
                         $this->insight_dao->insertInsight('reply_spike_30_day_'.$post->id, $instance->id,
                         $simplified_post_date, "Conversation starter:",
                         "<strong>".number_format($post->reply_count_cache).
-                        " people</strong> replied to $this->username's post, more than <strong>".$multiplier.
-                        "x</strong> $this->username's 30-day average.", $filename,
+                        " people</strong> replied to $this->username's ".$this->terms->getNoun('post'). ", more than ".
+                        "<strong>".$multiplier. "x</strong> $this->username's 30-day average.", $filename,
                         Insight::EMPHASIS_LOW, serialize(array($post, $hot_posts_data)));
 
                         $this->insight_dao->deleteInsight('reply_high_30_day_'.$post->id, $instance->id,
@@ -159,9 +159,9 @@ class ReplySpikeInsight extends InsightPluginParent implements InsightPlugin {
                         $this->insight_dao->insertInsight('reply_spike_7_day_'.$post->id, $instance->id,
                         $simplified_post_date, "Conversation starter:",
                         "<strong>".number_format($post->reply_count_cache).
-                        " people</strong> replied to $this->username's post, more than <strong>" .$multiplier.
-                        "x</strong> $this->username's 7-day average.", $filename, Insight::EMPHASIS_LOW,
-                        serialize(array($post, $hot_posts_data)));
+                        " people</strong> replied to $this->username's ".$this->terms->getNoun('post'). ", more than ".
+                        "<strong>" .$multiplier. "x</strong> $this->username's 7-day average.", $filename,
+                        Insight::EMPHASIS_LOW, serialize(array($post, $hot_posts_data)));
 
                         $this->insight_dao->deleteInsight('reply_high_30_day_'.$post->id, $instance->id,
                         $simplified_post_date);

--- a/webapp/plugins/insightsgenerator/tests/TestOfReplySpikeInsight.php
+++ b/webapp/plugins/insightsgenerator/tests/TestOfReplySpikeInsight.php
@@ -136,7 +136,7 @@ class TestOfReplySpikeInsight extends ThinkUpUnitTestCase {
         $this->assertNotNull($check);
         $this->assertEqual($check->slug, 'reply_high_365_day_28');
         $this->assertEqual($check->prefix, 'New 365-day record!');
-        $this->assertEqual($check->text, '<strong>50 people</strong> replied to @ev\'s post.');
+        $this->assertEqual($check->text, '<strong>50 people</strong> replied to @ev\'s tweet.');
         $this->assertEqual($check->emphasis, 2);
         $this->assertEqual($check->filename, 'replyspike');
     }
@@ -180,7 +180,7 @@ class TestOfReplySpikeInsight extends ThinkUpUnitTestCase {
         $this->assertNotNull($check);
         $this->assertEqual($check->slug, 'reply_high_30_day_29');
         $this->assertEqual($check->prefix, 'New 30-day record!');
-        $this->assertEqual($check->text, '<strong>40 people</strong> replied to @ev\'s post.');
+        $this->assertEqual($check->text, '<strong>40 people</strong> replied to @ev\'s tweet.');
         $this->assertEqual($check->emphasis, 2);
         $this->assertEqual($check->filename, 'replyspike');
     }
@@ -233,7 +233,7 @@ class TestOfReplySpikeInsight extends ThinkUpUnitTestCase {
         $this->assertNotNull($check);
         $this->assertEqual($check->slug, 'reply_high_7_day_30');
         $this->assertEqual($check->prefix, 'New 7-day record!');
-        $this->assertEqual($check->text, '<strong>30 people</strong> replied to @ev\'s post.');
+        $this->assertEqual($check->text, '<strong>30 people</strong> replied to @ev\'s tweet.');
         $this->assertEqual($check->emphasis, 2);
         $this->assertEqual($check->filename, 'replyspike');
     }
@@ -316,7 +316,7 @@ class TestOfReplySpikeInsight extends ThinkUpUnitTestCase {
         $this->assertEqual($check->slug, 'reply_high_30_day_33');
         $this->assertEqual($check->prefix, 'New 30-day record!');
         $this->assertEqual($check->text,
-        '<strong>26 people</strong> replied to @ev\'s post.');
+        '<strong>26 people</strong> replied to @ev\'s tweet.');
         $this->assertEqual($check->emphasis, 2);
         $this->assertEqual($check->filename, 'replyspike');
     }
@@ -390,7 +390,7 @@ class TestOfReplySpikeInsight extends ThinkUpUnitTestCase {
         $this->assertEqual($check->slug, 'reply_high_7_day_32');
         $this->assertEqual($check->prefix, 'New 7-day record!');
         $this->assertEqual($check->text,
-        '<strong>12 people</strong> replied to @ev\'s post.');
+        '<strong>12 people</strong> replied to @ev\'s tweet.');
         $this->assertEqual($check->emphasis, 2);
         $this->assertEqual($check->filename, 'replyspike');
     }


### PR DESCRIPTION
Hi,

The reply spike insight was not using the InsightTerm class to pick the correct word for post.

This fixes that.

Thanks

Aaron
