### PR TITLE
Handle return URLs to plugins with no hash

### DIFF
--- a/tests/TestOfAccountConfigurationController.php
+++ b/tests/TestOfAccountConfigurationController.php
@@ -1412,6 +1412,21 @@ class TestOfAccountConfigurationController extends ThinkUpUnitTestCase {
         $this->assertNull($v_mgr->getTemplateDataItem('error_msg'));
     }
 
+    public function testPluginShownWhenPSet() {
+        $this->simulateLogin('admin@example.com', true, true);
+        $_GET['p'] = "twitter";
+        $controller = new AccountConfigurationController(true);
+        $controller->go();
+        $v_mgr = $controller->getViewManager();
+        $this->assertTrue($v_mgr->getTemplateDataItem('force_plugin'));
+
+        $_GET = array();
+        $controller = new AccountConfigurationController(true);
+        $controller->go();
+        $v_mgr = $controller->getViewManager();
+        $this->assertNull($v_mgr->getTemplateDataItem('force_plugin'));
+    }
+
     private function buildHashtagData($instance) {
         $builders = array();
 

--- a/webapp/_lib/controller/class.AccountConfigurationController.php
+++ b/webapp/_lib/controller/class.AccountConfigurationController.php
@@ -301,6 +301,7 @@ class AccountConfigurationController extends ThinkUpAuthController {
             $pobj = $webapp_plugin_registrar->getPluginObject($active_plugin);
             $p = new $pobj;
             $this->addToView('body', $p->renderConfiguration($owner));
+            $this->addToView('force_plugin', true);
             $profiler = Profiler::getInstance();
             $profiler->clearLog();
         } elseif (isset($_GET['p']) && isset($_GET['u']) && isset($_GET['n'])) {
@@ -314,6 +315,7 @@ class AccountConfigurationController extends ThinkUpAuthController {
             $pobj = $webapp_plugin_registrar->getPluginObject($active_plugin);
             $p = new $pobj;
             $this->addToView('body', $p->renderInstanceConfiguration($owner, $instance_username, $instance_network));
+            $this->addToView('force_plugin', true);
             $profiler = Profiler::getInstance();
             $profiler->clearLog();
         }

--- a/webapp/_lib/view/account.index.tpl
+++ b/webapp/_lib/view/account.index.tpl
@@ -305,6 +305,7 @@
 </div>
 
 <script type="text/javascript">
+  var show_plugin = {if $force_plugin}true{else}false{/if};
   {literal}
 $(function() {
     $(".btnPub").click(function() {
@@ -523,7 +524,8 @@ $(function() {
         e.preventDefault();
       }
     });
-    if (window.location.hash && window.location.hash == '#manage_plugin') {
+    if ((show_plugin && (!window.location.hash || window.location.hash == '')
+    || (window.location.hash && window.location.hash == '#manage_plugin')) {
       $('.section').hide();
       $('#manage_plugin').show();
     }


### PR DESCRIPTION
If a plugin is activated, the javascript will select that div
unless a hash is provided (such as #instances or #ttusers)

In reference to #1780
