### PR TITLE
Fix issue with Insight URLs in mandrill emails

### DIFF
--- a/webapp/plugins/insightsgenerator/model/class.InsightsGeneratorPlugin.php
+++ b/webapp/plugins/insightsgenerator/model/class.InsightsGeneratorPlugin.php
@@ -212,6 +212,7 @@ class InsightsGeneratorPlugin extends Plugin implements CrawlerPlugin {
         // If we've got a Mandrill key and template, send HTML
         if ($config->getValue('mandrill_api_key') != null && !empty($options['mandrill_template'])) {
             $view->assign('insights', $insights);
+            $view->assign('application_url', Utils::getApplicationURL());
             $insights = $view->fetch(Utils::getPluginViewDirectory($this->folder_name).'_email.insights_html.tpl');
             $parameters = array();
             $parameters['insights'] = $insights;

--- a/webapp/plugins/insightsgenerator/tests/TestOfInsightsGeneratorPlugin.php
+++ b/webapp/plugins/insightsgenerator/tests/TestOfInsightsGeneratorPlugin.php
@@ -379,6 +379,7 @@ class TestOfInsightsGeneratorPlugin extends ThinkUpUnitTestCase {
         foreach ($decoded->global_merge_vars as $mv) {
             $merge_vars[$mv->name] = $mv->content;
         }
+        $this->assertPattern('/http:\/\/downtonabb.ey\/\?u=/', $merge_vars['insights'], 'Insights URL contains host');
         $this->assertPattern('/1234 new lists/', $merge_vars['insights']);
         $this->assertEqual($config->getValue('app_title_prefix').'ThinkUp', $merge_vars['app_title']);
         unlink(FileDataManager::getDataPath(Mailer::EMAIL));


### PR DESCRIPTION
The application_url used in the template was not being set before rendering
the insights fragment.

Also added test that the a url containing the host/?u= is in the insights
param sent to mandrill.

This is another fix for #1787 - You'd think that URLs wouldn't be so complicated. ;)
