### PR TITLE
Adding Vagrant capability

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,54 @@
+#
+# Vagrantfile for Thinkup
+# Builds a precise64 box, installs ThinkUp SQL, and creates a default user.
+# @author woganmay
+#
+# Default user:
+#     email: vagrant@vagrant.local
+#  password: thinkup00
+#
+
+VAGRANTFILE_API_VERSION = "2"
+
+# Setup!
+$script = <<SCRIPT
+
+# Install stuff in noninteractive mode
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y sudo apache2 php5 mysql-server php5-mysql php5-curl
+export DEBIAN_FRONTEND=
+
+# Will be used as the mysql root password
+export ADMINPASS="$(date | md5sum | head -c 16)"
+echo $ADMINPASS > /etc/mysql_root_password
+
+# Set MySQL root
+mysqladmin -u root password "$ADMINPASS"
+mysqladmin -u root -h localhost password "$ADMINPASS"
+service mysql restart
+
+# Create database, set access and import the sql build
+mysql -uroot -p$ADMINPASS -e 'CREATE DATABASE thinkup;'
+mysql -uroot -p$ADMINPASS -e "GRANT ALL ON thinkup.* TO 'thinkup_sql'@'localhost' IDENTIFIED BY 'thinkup_password';"
+mysql -uroot -p$ADMINPASS thinkup < /vagrant/webapp/install/sql/build-db_mysql.sql
+
+# Create the default admin user (Email: vagrant@vagrant.local, Pass: thinkup00)
+mysql -uroot -p$ADMINPASS -e 'INSERT INTO thinkup.tu_owners (`email`, `pwd`, `pwd_salt`, `joined`, `activation_code`, `full_name`, `timezone`, `api_key`, `is_admin`, `is_activated`) VALUES ("vagrant@vagrant.local", "7876ece7604da1df99ca2adce144c2cfeeee5679a987365fbf759203775e5c27", "b51838bc616ac039e36899426be4b5973b906a6277433c3ab1ed9076efe4b53b", NOW(), 1234, "Vagrant User", "UTC", "e46b19a0b38007b684efefe3aedb82aa", 1, 1)'
+
+# Configure apache to serve /vagrant/ as a default site
+a2dissite default
+cp /vagrant/vagrant-vhost.conf /etc/apache2/sites-available/vagrant
+a2ensite vagrant
+a2enmod rewrite
+service apache2 restart
+
+SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "base"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.provision "shell", inline: $script
+  config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.synced_folder "webapp/data/", "/thinkup-data", owner: "www-data", group: "www-data"
+end

--- a/vagrant-config.php
+++ b/vagrant-config.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Will be deployed at /vagrant/config.inc.php after the database is created
+ * and user access configured. This file is a copy of config.sample.inc.php
+ * with the TESTS overrides removed
+ */
+$THINKUP_CFG['app_title_prefix']            = "";
+$THINKUP_CFG['site_root_path']              = '/';
+$THINKUP_CFG['source_root_path']            = dirname( __FILE__ ) . '/';
+$THINKUP_CFG['datadir_path']                = '/thinkup-data/'; // Writeable folder shared from the host
+$THINKUP_CFG['timezone']                    = 'UTC';
+$THINKUP_CFG['cache_pages']                 = true;
+$THINKUP_CFG['cache_lifetime']              = 600;
+$THINKUP_CFG['rss_crawler_refresh_rate']    = 20;
+$THINKUP_CFG['mandrill_api_key']            = '';
+
+$THINKUP_CFG['db_host']         = 'localhost';
+$THINKUP_CFG['db_type']         = 'mysql';
+$THINKUP_CFG['db_user']         = 'thinkup_sql';
+$THINKUP_CFG['db_password']     = 'thinkup_password';
+$THINKUP_CFG['db_name']         = 'thinkup';
+$THINKUP_CFG['db_socket']       = '';
+$THINKUP_CFG['db_port']         = '';
+$THINKUP_CFG['table_prefix']    = 'tu_';
+
+$THINKUP_CFG['log_location']              = false;
+$THINKUP_CFG['log_verbosity']             = 0;
+$THINKUP_CFG['stream_log_location']       = false;
+$THINKUP_CFG['sql_log_location']          = null;
+$THINKUP_CFG['slow_query_log_threshold']  = 2.0;
+$THINKUP_CFG['debug']                     = false;
+$THINKUP_CFG['enable_profiler']           = false;
+$THINKUP_CFG['set_pdo_charset']           = false;
+
+// Set aggressive time limit for long crawls
+set_time_limit(500);

--- a/vagrant-vhost.conf
+++ b/vagrant-vhost.conf
@@ -1,0 +1,16 @@
+#
+# Deployed to Vagrant VM
+#
+<VirtualHost *:80>
+	ServerAdmin webmaster@localhost
+	DocumentRoot /vagrant/webapp/
+	<Directory /vagrant/webapp/>
+		Options Indexes FollowSymLinks MultiViews
+		AllowOverride All
+		Order allow,deny
+		allow from all
+	</Directory>
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	LogLevel warn
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>


### PR DESCRIPTION
Assuming you have vagrantup.com installed, this lets you run "vagrant up" which basically gives you a functioning ThinkUp install running at http://localhost:8080 ready for logging in and configuring.
- Username: vagrant@vagrant.local
- Password: thinkup00

Vagrant steps:
- Builds precise64 box
- Install apache2, MySQL, PHP and extensions
- Create a root mysql user, saves the password in /etc/mysql_root_password
- Runs the build-db_mysql.sql script into the thinkup database it creates
- Adds the default admin user

Developed / tested on:
- OSX 10.7.5
- VirtualBox 4.3.6 r91406
- Vagrant 1.4.3
