### PR TITLE
Improvements to Instagram Plugin.

### DIFF
--- a/webapp/plugins/instagram/model/PHP5.3/class.InstagramCrawler.php
+++ b/webapp/plugins/instagram/model/PHP5.3/class.InstagramCrawler.php
@@ -107,7 +107,6 @@ class InstagramCrawler {
 
                 $user_vals["post_count"] = $details->getMediaCount();
                 $user_vals["follower_count"] = $details->getFollowersCount();
-
                 $user_vals["user_name"] = $details->getUserName();
                 $user_vals["full_name"] = $details->getFullName();
                 $user_vals["user_id"] = $details->getId();
@@ -133,15 +132,34 @@ class InstagramCrawler {
      */
     public function fetchPostsAndReplies() {
         $id = $this->instance->network_user_id;
+        $option_dao = DAOFactory::getDAO('OptionDAO');
         $network = $this->instance->network;
-        // fetch user's friends
-        $this->storeFriends();
-
+        //Checks if last friends update is over 2 days ago and runs storeFriends if it is.
+        $friends_last_updated = $option_dao->getOptionByName('instagram_option_friends','last_crawled_friends') ;
+        $friends_last_updated_check = microtime(true) - 172800;
+        if($friends_last_updated == NULL) {
+            $this->storeFriends();
+            $option_dao->insertOption('instagram_option_friends','last_crawled_friends', microtime(true));
+        } elseif($friends_last_updated->option_value < $friends_last_updated_check) {
+            $this->storeFriends();
+            $option_dao->updateOptionByName('instagram_option_friends','last_crawled_friends', microtime(true));
+        }
+        
         $fetch_next_page = true;
         $current_page_number = 1;
+        $api_param = array();
+        if($this->instance->total_posts_in_system !=0) {
+            $last_crawl = $this->instance->crawler_last_run;
+            $crawl_less_week = date($last_crawl, strtotime("-1 week"));
+            $unix_less_week = strtotime($crawl_less_week);
+            $api_param = array('min_timestamp' => $unix_less_week ,'count' => 20);
+
+        } else {
+            $api_param = array('count' => 20);
+        }
 
         $this->logger->logUserInfo("About to request media",__METHOD__.','.__LINE__);
-        $posts = InstagramAPIAccessor::apiRequest('media', $id, $this->access_token, array('count' => 20));
+        $posts = InstagramAPIAccessor::apiRequest('media', $id, $this->access_token, $api_param);
         $this->logger->logUserInfo("Media requested",__METHOD__.','.__LINE__);
 
         //Cap crawl time for very busy pages with thousands of likes/comments
@@ -166,8 +184,8 @@ class InstagramCrawler {
                 $this->processPosts($posts, $network, $current_page_number);
 
                 if ($posts->getNext() != null) {
-                    $posts = InstagramAPIaccessor::apiRequest('media', $id, $this->access_token, array('count' => 20,
-                    'max_id' => $posts->getNext()));
+                    $api_param['max_id'] = $posts->getNext();
+                    $posts = InstagramAPIaccessor::apiRequest('media', $id, $this->access_token,$api_param);
                     $current_page_number++;
                 } else {
                     $fetch_next_page = false;

--- a/webapp/plugins/instagram/tests/TestOfInstagramCrawler.php
+++ b/webapp/plugins/instagram/tests/TestOfInstagramCrawler.php
@@ -80,6 +80,18 @@ class TestOfInstagramCrawler extends ThinkUpUnitTestCase {
         'earliest_post_in_system'=>'2009-01-01 13:48:05', 'favorites_profile' => '0'
         );
         $this->profile2_instance = new Instance($r);
+
+        $r = array('id'=>5, 'network_username'=>'ni_ato', 'network_user_id'=>'502993749',
+        'network_viewer_id'=>'502993749', 'last_post_id'=>'0', 'last_page_fetched_replies'=>0,
+        'last_page_fetched_tweets'=>'0', 'total_posts_in_system'=>'7', 'total_replies_in_system'=>'0',
+        'total_follows_in_system'=>'0', 'is_archive_loaded_replies'=>'0',
+        'is_archive_loaded_follows'=>'0', 'crawler_last_run'=>'2014-01-01 13:48:05', 'earliest_reply_in_system'=>'',
+        'avg_replies_per_day'=>'2', 'is_public'=>'0', 'is_active'=>'0', 'network'=>'instagram',
+        'last_favorite_id' => '0', 'owner_favs_in_system' => '0', 'total_posts_by_owner'=>0,
+        'posts_per_day'=>1, 'posts_per_week'=>1, 'percentage_replies'=>50, 'percentage_links'=>50,
+        'earliest_post_in_system'=>'2009-01-01 13:48:05', 'favorites_profile' => '0'
+        );
+        $this->profile3_instance = new Instance($r);
     }
 
     public function tearDown() {
@@ -178,7 +190,6 @@ class TestOfInstagramCrawler extends ThinkUpUnitTestCase {
         $this->assertEqual($user->avatar, 'http://images.ak.instagram.com/profiles/anonymousUser.jpg');
         $this->assertFalse($user->is_protected);
         $this->assertEqual($user->network, 'instagram');
-
         // Check the second photo was added, it has no comments and two likes
         $post = $photo_dao->getPhoto('519642461157682352_494785218', 'instagram');
         $this->assertEqual($post->post_id, '519642461157682352_494785218' );
@@ -232,4 +243,54 @@ class TestOfInstagramCrawler extends ThinkUpUnitTestCase {
         $this->expectException('Instagram\Core\ApiAuthException', 'The "access_token" provided is invalid.');
         $ic->fetchPostsAndReplies();
     }
+
+    public function testFetchNewestPosts() {
+        $user_dao = new UserMySQLDAO();
+        $photo_dao = new PhotoMySQLDAO();
+        $count_history_dao = new CountHistoryMySQLDAO();
+        $favorite_dao = new FavoritePostMySQLDAO();
+        $follow_dao = new FollowMySQLDAO();
+        $ic = new InstagramCrawler($this->profile3_instance, 'fauxaccesstoken', 120);
+
+        $config = Config::getInstance();
+        $instagram_crawler_log = $config->getValue('log_location');
+        // prepare log for reading after fetchPostsAndReplies
+        $log_reader_handle = fopen($instagram_crawler_log, 'r');
+        fseek($log_reader_handle, 0, SEEK_END);
+        //Check if newest posts are returned.
+        $ic->fetchPostsAndReplies();
+
+        $post = $photo_dao->getPhoto('519671854563291086', 'instagram');
+        $this->assertEqual($post->post_id, '519671854563291086' );
+        $this->assertEqual($post->author_user_id, '502993749' );
+        $this->assertEqual($post->author_username, 'ni_ato' );
+        $this->assertEqual($post->author_fullname, 'niki' );
+        $avatar = 'http://images.ak.instagram.com/profiles/anonymousUser.jpg';
+        $this->assertEqual($post->author_avatar, $avatar);
+        $this->assertEqual($post->post_text, 'Epikinduna paixnidia');
+        $this->assertFalse($post->is_protected);
+        $this->assertEqual($post->pub_date, '2013-08-10 20:28:00');
+        $this->assertEqual($post->network, 'instagram');
+        $this->assertEqual($post->in_reply_to_user_id, '494785218');
+        $this->assertEqual($post->in_reply_to_post_id, '519644594447805677_494785218');
+    }
+
+    public function testFetchFriendsAfterTwoDays() {
+        $option_dao = new OptionMySQLDAO();
+        $ic = new InstagramCrawler($this->profile3_instance, 'fauxaccesstoken', 120);
+        $ic->fetchPostsAndReplies();
+        //Checks to see if date value has been inserted into table after first crawl.
+        $select_insert = $option_dao->getOptionByName('instagram_option_friends','last_crawled_friends');
+        $this->assertNotNull($select_insert->option_value);
+        //Checks to see if date value hasn't changed after a crawl within two days of the last.
+        $ic->fetchPostsAndReplies();
+        $select_under_two_days = $option_dao->getOptionByName('instagram_option_friends','last_crawled_friends');
+        $this->assertEqual($select_insert->option_value, $select_under_two_days->option_value);
+        //Checks to see if date value has changed after a crawl 3 days after last crawl.
+        $option_dao->updateOptionByName('instagram_option_friends','last_crawled_friends', '1396566000');
+        $ic->fetchPostsAndReplies();
+        $select_over_two_days = $option_dao->getOptionByName('instagram_option_friends','last_crawled_friends');
+        $this->assertNotEqual($select_insert->option_value, $select_over_two_days->option_value);
+    }
 }
+

--- a/webapp/plugins/instagram/tests/testdata/get_users_502993749_media_recent_1388584085_20
+++ b/webapp/plugins/instagram/tests/testdata/get_users_502993749_media_recent_1388584085_20
@@ -1,0 +1,145 @@
+{
+  "pagination": {},
+  "meta": {
+    "code": 200
+  },
+  "data": [
+    {
+      "attribution": null,
+      "tags": [],
+      "type": "image",
+      "location": null,
+      "comments": {
+        "count": 1,
+        "data": [
+          {
+            "created_time": "1376169734",
+            "text": "Epikinduna paixnidia",
+            "from": {
+              "username": "ni_ato",
+              "profile_picture": "http://images.ak.instagram.com/profiles/anonymousUser.jpg",
+              "id": "502993749",
+              "full_name": "niki"
+            },
+            "id": "519671854563291086"
+          }
+        ]
+      },
+      "filter": "Valencia",
+      "created_time": "1376166484",
+      "link": "http://instagram.com/p/c2JgFlg2zt/",
+      "likes": {
+        "count": 0,
+        "data": []
+      },
+      "images": {
+        "low_resolution": {
+          "url": "http://distilleryimage5.s3.amazonaws.com/5c3132b801fb11e38a2722000a9f1925_6.jpg",
+          "width": 306,
+          "height": 306
+        },
+        "thumbnail": {
+          "url": "http://distilleryimage5.s3.amazonaws.com/5c3132b801fb11e38a2722000a9f1925_5.jpg",
+          "width": 150,
+          "height": 150
+        },
+        "standard_resolution": {
+          "url": "http://distilleryimage5.s3.amazonaws.com/5c3132b801fb11e38a2722000a9f1925_7.jpg",
+          "width": 612,
+          "height": 612
+        }
+      },
+      "users_in_photo": [],
+      "caption": {
+        "created_time": "1376166514",
+        "text": "Pwpw katapiesh...",
+        "from": {
+          "username": "afokou",
+          "profile_picture": "http://images.ak.instagram.com/profiles/anonymousUser.jpg",
+          "id": "494785218",
+          "full_name": "Aggeliki Fokou"
+        },
+        "id": "519644847053958719"
+      },
+      "user_has_liked": false,
+      "id": "519644594447805677_494785218",
+      "user": {
+        "username": "afokou",
+        "website": "",
+        "profile_picture": "http://images.ak.instagram.com/profiles/anonymousUser.jpg",
+        "full_name": "Aggeliki Fokou",
+        "bio": "",
+        "id": "494785218"
+      }
+    },
+    {
+      "attribution": null,
+      "tags": [],
+      "type": "image",
+      "location": null,
+      "comments": {
+        "count": 0,
+        "data": []
+      },
+      "filter": "X-Pro II",
+      "created_time": "1376166230",
+      "link": "http://instagram.com/p/c2JBCzg2yw/",
+      "likes": {
+        "count": 2,
+        "data": [
+          {
+            "username": "louk_as",
+            "profile_picture": "http://images.ak.instagram.com/profiles/profile_20065178_75sq_1335521050.jpg",
+            "id": "20065178",
+            "full_name": "lucas asimo"
+          },
+          {
+            "username": "ni_ato",
+            "profile_picture": "http://images.ak.instagram.com/profiles/anonymousUser.jpg",
+            "id": "502993749",
+            "full_name": "niki"
+          }
+        ]
+      },
+      "images": {
+        "low_resolution": {
+          "url": "http://distilleryimage8.s3.amazonaws.com/c49be7f401fa11e3bcc122000a1fa49d_6.jpg",
+          "width": 306,
+          "height": 306
+        },
+        "thumbnail": {
+          "url": "http://distilleryimage8.s3.amazonaws.com/c49be7f401fa11e3bcc122000a1fa49d_5.jpg",
+          "width": 150,
+          "height": 150
+        },
+        "standard_resolution": {
+          "url": "http://distilleryimage8.s3.amazonaws.com/c49be7f401fa11e3bcc122000a1fa49d_7.jpg",
+          "width": 612,
+          "height": 612
+        }
+      },
+      "users_in_photo": [],
+      "caption": {
+        "created_time": "1376166355",
+        "text": "H diaskedastiki mou arxi ;(",
+        "from": {
+          "username": "afokou",
+          "profile_picture": "http://images.ak.instagram.com/profiles/anonymousUser.jpg",
+          "id": "494785218",
+          "full_name": "Aggeliki Fokou"
+        },
+        "id": "519643515018505730"
+      },
+      "user_has_liked": false,
+      "id": "519642461157682352_494785218",
+      "user": {
+        "username": "afokou",
+        "website": "",
+        "profile_picture": "http://images.ak.instagram.com/profiles/anonymousUser.jpg",
+        "full_name": "Aggeliki Fokou",
+        "bio": "",
+        "id": "494785218"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Only get newest posts and only get friends every two days.

Hey Gina,
                 I finished working on the Instagram plugin, I implemented the pulling of the latest posts by checking if any post are stored in the database, if there aren't any the crawler will pull all posts, otherwise it will pull the posts from the last crawl date minus a week (I used minus one week to catch the comments on the more recent posts).

I implemented pulling new friends every 2 days by checking if friends have been pulled previously, if they haven't the crawler pulls all the friends and inserts the current time and date of the crawl into the options table. If friends have been pulled previously the crawler will check if the date of the last friends update was within 2 days, if it was over 2 days the crawler stores the user's friends and updates the time of the crawl with the current time and date.
Thanks,
Gareth.
