### PR TITLE
Handle Facebook business accounts.

### DIFF
--- a/webapp/plugins/facebook/controller/class.FacebookPluginConfigurationController.php
+++ b/webapp/plugins/facebook/controller/class.FacebookPluginConfigurationController.php
@@ -219,8 +219,15 @@ class FacebookPluginConfigurationController extends PluginConfigurationControlle
                     $fb_user_profile = $facebook->api('/me');
                     $fb_username = $fb_user_profile['name'];
                     $fb_user_id = $fb_user_profile['id'];
-                    $this->addSuccessMessage($this->saveAccessToken($fb_user_id, $access_token, $fb_username),
-                    'authorization');
+
+                    if (empty($fb_username)) {
+                        $error = 'This type of account (which appears to be a Business account) is not supported.';
+                        $this->addErrorMessage($error, 'authorization');
+                    }
+                    else {
+                        $this->addSuccessMessage($this->saveAccessToken($fb_user_id, $access_token, $fb_username),
+                            'authorization');
+                    }
                 } else {
                     $error_msg = "Problem authorizing your Facebook account! Please correct your plugin settings.";
                     $error_object = json_decode($access_token_response);

--- a/webapp/plugins/facebook/tests/TestOfFacebookPluginConfigurationController.php
+++ b/webapp/plugins/facebook/tests/TestOfFacebookPluginConfigurationController.php
@@ -411,6 +411,46 @@ class TestOfFacebookPluginConfigurationController extends ThinkUpUnitTestCase {
         $this->assertEqual($owner_instance->oauth_access_token, 'swappedinlonglivetoken104567');
     }
 
+    public function testConnectBusinessAccountUnsuccessful()  {
+        Facebook::$user_type = 'business';
+        $owner_instance_dao = new OwnerInstanceMySQLDAO();
+        $instance_dao = new InstanceMySQLDAO();
+        $owner_dao = new OwnerMySQLDAO();
+
+        $config = Config::getInstance();
+        $config->setValue('site_root_path', '/');
+
+        $_SERVER['SERVER_NAME'] = "srvr";
+        SessionCache::put('facebook_auth_csrf', '123');
+        $_GET['p'] = 'facebook';
+        $_GET['code'] = '456';
+        $_GET['state'] = '123';
+
+        $options_array = $this->buildPluginOptions();
+        $this->simulateLogin('me@example.com', true);
+
+        $instance = $instance_dao->getByUserIdOnNetwork('606837591', 'facebook');
+        $this->assertNull($instance); //Instance doesn't exist
+
+        $owner = $owner_dao->getByEmail(Session::getLoggedInUser());
+        $controller = new FacebookPluginConfigurationController($owner, 'facebook');
+        $output = $controller->go();
+
+        $v_mgr = $controller->getViewManager();
+
+        $msgs = $v_mgr->getTemplateDataItem('success_msgs');
+        $this->assertEqual(count($msgs['user_add']), 0);
+        $this->debug(Utils::varDumpToString($msgs));
+
+        $msgs = $v_mgr->getTemplateDataItem('error_msgs');
+        $this->debug(Utils::varDumpToString($msgs));
+        $this->assertEqual($msgs['authorization'], 'This type of account (which appears to be a Business account) is not supported.');
+
+        $instance = $instance_dao->getByUserIdOnNetwork('606837591', 'facebook');
+        $this->assertNull($instance); //Instance not created
+        Facebook::$user_type = 'user';
+    }
+
     public function testConnectAccountSuccessfulNoServerName()  {
         $owner_instance_dao = new OwnerInstanceMySQLDAO();
         $instance_dao = new InstanceMySQLDAO();

--- a/webapp/plugins/facebook/tests/classes/mock.facebook.php
+++ b/webapp/plugins/facebook/tests/classes/mock.facebook.php
@@ -32,6 +32,11 @@
  */
 class Facebook {
 
+    /**
+     * @var str type of user we want to mock
+     */
+    public static $user_type = "user";
+
     public function __construct($config) {
     }
 
@@ -61,7 +66,11 @@ class Facebook {
 
     public function api($str) {
         if ($str = '/me') {
-            return array('name'=>'Gina Trapani', 'id'=>'606837591');
+            if (Facebook::$user_type == 'business') {
+                return array('username'=>'businessaccount', 'id'=>'606837591');
+            } else {
+                return array('name'=>'Gina Trapani', 'id'=>'606837591');
+            }
         }
     }
 


### PR DESCRIPTION
In the past, facebook allowed business owners to sign up for an account with
no wall, profile, etc, that was just for managing pages and ads.

They no longer do so.  The /me api for these accounts does not return
a name field, which is sad, because we use that as the key in the instances
table.

For reference, I found these stack overflow on this topic and the suggestions
all come down to "check for a name field":
http://stackoverflow.com/questions/14719211/how-can-i-know-if-a-facebook-account-is-personal-account-or-a-company-type-accou
http://stackoverflow.com/questions/10857138/how-to-obtain-username-name-for-a-company-facebook-account

This simply checks for a name parameter and then shows the user an error.
