### PR TITLE
Allow non-duplicate key errors to bubble out of CookieMysqlDAO

### DIFF
--- a/tests/TestOfCookieMySQLDAO.php
+++ b/tests/TestOfCookieMySQLDAO.php
@@ -100,6 +100,20 @@ class TestOfCookieMySQLDAO extends ThinkUpUnitTestCase {
         $this->assertNull($email);
     }
 
+    public function testThatNonDuplicateExceptionsAreThrown() {
+
+        $config = Config::getInstance();
+        $prefix = $config->getValue('table_prefix');
+        PDODAO::$PDO->exec('RENAME TABLE '.$prefix.'cookies to '.$prefix.'cookies2');
+        try {
+            $cookie = $this->DAO->generateForEmail($em = 'testy@testy.com');
+        } catch (Exception $e) {
+            $this->assertNotNull($e);
+            $this->assertPattern('/Base table or view not found/', $e->getMessage());
+        }
+        PDODAO::$PDO->exec('RENAME TABLE '.$prefix.'cookies2 to '.$prefix.'cookies');
+    }
+
     public function tearDown() {
         $this->builders = null;
         parent::tearDown();

--- a/webapp/_lib/dao/class.CookieMySQLDAO.php
+++ b/webapp/_lib/dao/class.CookieMySQLDAO.php
@@ -50,6 +50,9 @@ class CookieMySQLDAO extends PDODAO implements CookieDAO {
                     break;
                 }
             } catch (PDOException $e) {
+                if (!preg_match("/Duplicate entry .* for key 'cookie'/", $e->getMessage())) {
+                    throw $e;
+                }
                 $try = null;
                 //do nothing, loop will come back around
             }


### PR DESCRIPTION
This'll help people better troubleshoot a missing migration, for example.

References #1867
