### PR TITLE
Improve the styling of the weekly interactions bar chart

### DIFF
--- a/webapp/_lib/view/insights.tpl
+++ b/webapp/_lib/view/insights.tpl
@@ -55,7 +55,7 @@
 
 <div class="panel panel-default insight insight-default insight-{$i->slug|replace:'_':'-'}
   {if $i->emphasis > '1'}insight-hero{/if} insight-{$color|strip} {if
-  isset($i->related_data.hero_image) and $i->emphasis > '1'}insight-wide{/if}" id="insight-{$i->id}">
+  (isset($i->related_data.hero_image) and $i->emphasis > '1') | $i->slug eq 'weekly_graph'}insight-wide{/if}" id="insight-{$i->id}">
   <div class="panel-heading ">
     <h2 class="panel-title">{$i->headline}</h2>
     {if ($i->slug eq 'posts_on_this_day_popular_flashback')}

--- a/webapp/plugins/insightsgenerator/view/weeklygraph.tpl
+++ b/webapp/plugins/insightsgenerator/view/weeklygraph.tpl
@@ -1,5 +1,5 @@
 {if isset($i->related_data.posts[0])}
-    <div id="response_rates_{$i->id}">&nbsp;</div>
+    <div id="response_rates_{$i->id}" class="weekly_chart">&nbsp;</div>
     <script type="text/javascript">
         // Load the Visualization API and the standard charts
         google.load('visualization', '1');
@@ -17,19 +17,41 @@
               chartType: 'BarChart',
               dataTable: response_rates_data_{/literal}{$i->id}{literal},
               options: {
-                  colors: ['#3e5d9a', '#3c8ecc', '#BBCCDD'],
+                  backgroundColor: 'transparent',
+                  colors: ['#125C9C', '#2785D3', '#46BCFF'],
                   isStacked: true,
-                  width: 300,
                   height: 250,
-                  chartArea:{left:100,height:"80%"},
-                  legend: 'bottom',
+                  focusTarget: 'category',
+                  annotations: {
+                    textStyle: {
+                      fontName: 'tablet-gothic-wide, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif'
+                    },
+                  },
+                  chartArea:{
+                      height:"100%",
+                      left: 200
+                  },
+                  legend: {
+                    position: 'bottom',
+                    alignment: 'start'
+                  },
+                  tooltip: {
+                    showColorCode: true
+                  },
                   hAxis: {
-                    textStyle: { color: '#fff', fontSize: 1 }
+                    direction: 1,
+                    titleTextStyle: {
+                      left: -100
+                    }
                   },
                   vAxis: {
                     minValue: 0,
                     baselineColor: '#ccc',
-                    textStyle: { color: '#999' },
+                    textStyle: {
+                        color: '#000',
+                        fontName: 'Libre Baskerville, georgia, serif'
+                    },
+                    textPosition: 'out',
                     gridlines: { color: '#eee' }
                   },
                 }


### PR DESCRIPTION
Make it wide, bring it in line with the current ThinkUp colors, clean up hover display of data, and use serif font on post excerpts to echo styling of inline tweets.
