### PR TITLE
Twitter Birthday Insight

### DIFF
--- a/tests/all_plugin_tests.php
+++ b/tests/all_plugin_tests.php
@@ -115,6 +115,7 @@ $plugin_tests->add(new TestOfFollowCountVisualizerInsight());
 $plugin_tests->add(new TestOfCongratsCountInsight());
 $plugin_tests->add(new TestOfTimeSpentInsight());
 $plugin_tests->add(new TestOfTwitterAgeInsight());
+$plugin_tests->add(new TestOfTwitterBirthdayInsight());
 // One-time or developer insight tests that don't have to run every time
 // $plugin_tests->add(new TestOfHelloThinkUpInsight());
 // $plugin_tests->add(new TestOfOlympics2014Insight());

--- a/webapp/_lib/dao/interface.FollowDAO.php
+++ b/webapp/_lib/dao/interface.FollowDAO.php
@@ -104,7 +104,15 @@ interface FollowDAO {
      */
     public function countTotalFriends($user_id, $network);
     /**
-     * Gets the number of friends that is protected.
+     * Gets the number of friends of a user that joined the network after the specified date
+     * @param int $user_id
+     * @param str $network
+     * @param str $date Fetch friends joined after this date
+     * @return int Number of friends that joined after date
+     */
+    public function countTotalFriendsJoinedAfterDate($user_id, $network, $date);
+    /**
+     * Gets the number of friends that are protected.
      * Includes inactive friendships in count.
      * @param int $user_id
      * @param str $network
@@ -261,4 +269,13 @@ interface FollowDAO {
      * @param int $page_count
      */
     public function searchFollowers(array $keywords, $network, $user_id, $page_number=1, $page_count=20);
+    /**
+     * Gets the followers that joined just before user
+     * @param str $user_id
+     * @param str $network
+     * @param str $earliest_date Earliest date a friend should have joined to be returned
+     * @param str $latest_date Latest date a friend should have joined to be returned
+     * @return array Array of User objects
+     **/
+    public function getFriendsJoinedInTimeFrame($user_id, $network, $earliest_date, $latest_date);
 }

--- a/webapp/plugins/insightsgenerator/insights/twitterbirthday.php
+++ b/webapp/plugins/insightsgenerator/insights/twitterbirthday.php
@@ -1,0 +1,131 @@
+<?php
+/*
+ Plugin Name: Twitter Birthday
+ Description: A happy birthday notice and comparison to the join dates of your friends.
+ When: Yearly, on twitter anniversary
+ */
+/**
+ *
+ * ThinkUp/webapp/plugins/insightsgenerator/insights/twitterbirthday.php
+ *
+ * Copyright (c) 2014 Chris Moyer
+ *
+ * LICENSE:
+ *
+ * This file is part of ThinkUp (http://thinkup.com).
+ *
+ * ThinkUp is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * ThinkUp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with ThinkUp.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2014 Chris Moyer
+ * @author Chris Moyer <chris [at] inarow [dot] net>
+ */
+class TwitterBirthdayInsight extends InsightPluginParent implements InsightPlugin {
+    public function generateInsight(Instance $instance, User $user, $last_week_of_posts, $number_days) {
+        parent::generateInsight($instance, $user, $last_week_of_posts, $number_days);
+        $this->logger->logInfo("Begin generating insight", __METHOD__.','.__LINE__);
+
+        $joined_ts = strtotime($user->joined, TimeHelper::getTime());
+        $joined_day = date('m-d', $joined_ts);
+        $is_twitter = $instance->network == 'twitter';
+        if ($is_twitter && date('m-d', TimeHelper::getTime()) == $joined_day) {
+            $insight = new Insight();
+            $insight->slug = "twitterbirthday";
+            $insight->instance_id = $instance->id;
+            $insight->date = $this->insight_date;
+            $insight->filename = basename(__FILE__, ".php");
+            $insight->headline = "Happy Twitter birthday!";
+
+            $follow_dao = DAOFactory::getDAO('FollowDAO');
+            $all_friends = $follow_dao->countTotalFriends($instance->network_user_id, $instance->network);
+            $late_friends = $follow_dao->countTotalFriendsJoinedAfterDate($instance->network_user_id,
+                $instance->network, $user->joined);
+            $years = date('Y', TimeHelper::getTime()) - date('Y', $joined_ts);
+
+            $insight->text = $this->username." joined Twitter $years year".($years==1?'':'s')." ago today";
+
+            if ($all_friends > 0 && $late_friends > 0) {
+                $percent_before = floor($late_friends / $all_friends * 100);
+                $insight->text .= ", " . "before ".$percent_before."% of the people ".$this->username." follows did.";
+            }
+            else {
+                $insight->text  .= ".";
+            }
+
+            $week_seconds = 60 * 60 * 24 * 7;
+            $followers = $follow_dao->getFriendsJoinedInTimeFrame($user->user_id, $instance->network,
+                date('Y-m-d', $joined_ts - $week_seconds), date('Y-m-d', $joined_ts + $week_seconds));
+
+            $just_before = null;
+            $just_after = null;
+
+            $last_user = null;
+            foreach ($followers as $follower) {
+                if (strtotime($follower->joined, TimeHelper::getTime()) > $joined_ts) {
+                    $just_after = $follower;
+                    $just_before = $last_user;
+                    break;
+                }
+                $last_user = $follower;
+            }
+            if (!$just_after && $last_user) {
+                $just_before = $last_user;
+            }
+
+            $bonus_text = array();
+            $people = array();
+            if ($just_before) {
+                $time = $this->secondsToRelativeTime(abs($joined_ts - strtotime($just_before->joined, TimeHelper::getTime())));
+                $bonus_text[] = "@".$just_before->username." just beat ".$this->username.", joining $time earlier";
+                $people[] = $just_before;
+            }
+            if ($just_after) {
+                $time = $this->secondsToRelativeTime(abs($joined_ts - strtotime($just_after->joined, TimeHelper::getTime())));
+                $bonus_text[] = "@".$just_after->username." was a little slower, getting on Twitter $time later";
+                $people[] = $just_after;
+            }
+
+            if (count($bonus_text)) {
+                $insight->text .= " ".join(', and ', $bonus_text).".";
+                $insight->setPeople($people);
+            }
+
+            $res = $this->insight_dao->insertInsight($insight);
+        }
+
+        $this->logger->logInfo("Done generating insight", __METHOD__.','.__LINE__);
+    }
+
+    public function secondsToRelativeTime($seconds) {
+        if ($seconds >= (60*60*24*7)) {
+            $weeks = floor($seconds / (60*60*24*7));
+            return $weeks." week".($weeks==1?'':'s');
+        }
+        if ($seconds >= (60*60*24)) {
+            $days = floor($seconds / (60*60*24));
+            return $days." day".($days==1?'':'s');
+        }
+        if ($seconds >= (60*60)) {
+            $hours = floor($seconds / (60*60));
+            return $hours." hour".($hours==1?'':'s');
+        }
+        if ($seconds >= 60) {
+            $minutes = floor($seconds / 60);
+            return $minutes." minute".($minutes==1?'':'s');
+        }
+
+        return $seconds." second".($seconds==1?'':'s');
+    }
+}
+
+$insights_plugin_registrar = PluginRegistrarInsights::getInstance();
+$insights_plugin_registrar->registerInsightPlugin('TwitterBirthdayInsight');

--- a/webapp/plugins/insightsgenerator/tests/TestOfInsightsGeneratorPlugin.php
+++ b/webapp/plugins/insightsgenerator/tests/TestOfInsightsGeneratorPlugin.php
@@ -746,7 +746,9 @@ class TestOfInsightsGeneratorPlugin extends ThinkUpInsightUnitTestCase {
         'email'=>'admin@example.com', 'is_activated'=>1, 'email_notification_frequency' => 'daily',
         'timezone' => 'America/New_York'));
         $builders[] = FixtureBuilder::build('instances', array('network_username'=>'cdmoyer', 'id' => 6,
-        'network'=>'twitter', 'is_activated'=>1, 'is_public'=>1));
+            'network'=>'twitter', 'is_activated'=>1, 'is_public'=>1, 'network_user_id'=>'11'));
+        $builders[] = FixtureBuilder::build('users', array('user_id' => '11', 'network' => 'twitter',
+            'joined' => date('Y-m-d', strtotime('-10 day'))));
         $builders[] = FixtureBuilder::build('owner_instances', array('owner_id'=>1, 'instance_id'=>6, 'id'=>1));
         $builders[] = FixtureBuilder::build('insights', array('id'=>2, 'instance_id'=>6,
         'slug'=>'new_group_memberships', 'headline'=>'Made the List:',
@@ -807,7 +809,9 @@ class TestOfInsightsGeneratorPlugin extends ThinkUpInsightUnitTestCase {
         'email'=>'admin@example.com', 'is_activated'=>1, 'email_notification_frequency' => 'daily',
         'timezone' => 'America/New_York'));
         $builders[] = FixtureBuilder::build('instances', array('network_username'=>'cdmoyer', 'id' => 6,
-        'network'=>'twitter', 'is_activated'=>1, 'is_public'=>1));
+            'network'=>'twitter', 'is_activated'=>1, 'is_public'=>1, 'network_user_id'=>'11'));
+        $builders[] = FixtureBuilder::build('users', array('user_id' => '11', 'network' => 'twitter',
+            'joined' => date('Y-m-d', strtotime('-10 day'))));
         $builders[] = FixtureBuilder::build('owner_instances', array('owner_id'=>1, 'instance_id'=>6, 'id'=>1));
         $builders[] = FixtureBuilder::build('options', array('namespace'=>'application_options',
         'option_name'=>'server_name', 'option_value'=>'downtonabb.ey'));

--- a/webapp/plugins/insightsgenerator/tests/TestOfTwitterBirthdayInsight.php
+++ b/webapp/plugins/insightsgenerator/tests/TestOfTwitterBirthdayInsight.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ *
+ * ThinkUp/webapp/plugins/insightsgenerator/tests/TestOfTwitterBirthdayInsight.php
+ *
+ * Copyright (c) 2014 Chris Moyer
+ *
+ * LICENSE:
+ *
+ * This file is part of ThinkUp (http://thinkup.com).
+ *
+ * ThinkUp is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * ThinkUp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with ThinkUp.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Test of TwitterBirthdayInsight
+ *
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2014 Chris Moyer
+ * @author Chris Moyer <chris[at]inarow[dot]net>
+ */
+
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
+require_once THINKUP_WEBAPP_PATH.'_lib/extlib/simpletest/autorun.php';
+require_once THINKUP_WEBAPP_PATH.'_lib/extlib/simpletest/web_tester.php';
+require_once THINKUP_ROOT_PATH. 'webapp/plugins/insightsgenerator/model/class.InsightPluginParent.php';
+require_once THINKUP_ROOT_PATH. 'webapp/plugins/insightsgenerator/insights/twitterbirthday.php';
+
+class TestOfTwitterBirthdayInsight extends ThinkUpInsightUnitTestCase {
+
+    public function setUp(){
+        parent::setUp();
+
+        $this->instance = new Instance();
+        $this->instance->id = 10;
+        $this->instance->network_user_id = 42;
+        $this->instance->network_username = 'hbtome';
+        $this->instance->network = 'twitter';
+        $this->instance->is_public = 1;
+
+        TimeHelper::setTime(1400745664);
+    }
+
+    public function tearDown() {
+        parent::tearDown();
+    }
+
+    public function testConstructor() {
+        $insight_plugin = new TwitterBirthdayInsight();
+        $this->assertIsA($insight_plugin, 'TwitterBirthdayInsight' );
+    }
+
+    public function testNoFacebookInsight() {
+        $this->instance->network = 'facebook';
+        $insight_plugin = new TwitterBirthdayInsight();
+        $user = $this->makeUser('hbtome', ('2013-05-22 04:01'));
+        $insight_plugin->generateInsight($this->instance, $user, array(), 3);
+
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('twitterbirthday', $this->instance->id, $today);
+        $this->assertNull($result);
+    }
+
+    public function testNoInsightOnNonTwitterBD() {
+        $insight_plugin = new TwitterBirthdayInsight();
+        $user = $this->makeUser('hbtome', ('2013-04-22 04:01'));
+        $insight_plugin->generateInsight($this->instance, $user, array(), 3);
+
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('twitterbirthday', $this->instance->id, $today);
+        $this->assertNull($result);
+
+        $user = $this->makeUser('hbtome', ('2011-01-02 01:01'));
+        $insight_plugin->generateInsight($this->instance, $user, array(), 3);
+
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('twitterbirthday', $this->instance->id, $today);
+        $this->assertNull($result);
+    }
+
+    public function testNormalUse() {
+        $builders = array();
+        $builders[] = FixtureBuilder::build('follows', array('user_id'=>'2', 'follower_id'=>'1',
+            'last_seen'=>'-0d', 'first_seen'=>'-0d', 'network'=>'twitter','active'=>1));
+        $builders[] = FixtureBuilder::build('users', array('user_id'=>'2', 'network' => 'twitter','is_protected'=>0,
+            'network' => 'twitter',
+            'user_name' => 'first_user', 'joined' => ('2013-05-20 01:01')));
+
+        $builders[] = FixtureBuilder::build('follows', array('user_id'=>'3', 'follower_id'=>'1',
+            'last_seen'=>'-0d', 'first_seen'=>'-0d', 'network'=>'twitter','active'=>1));
+        $builders[] = FixtureBuilder::build('users', array('user_id'=>'3', 'network' => 'twitter','is_protected'=>0,
+            'network' => 'twitter',
+            'user_name' => 'second_user', 'joined' => ('2013-05-20 18:01')));
+
+        $builders[] = FixtureBuilder::build('follows', array('user_id'=>'4', 'follower_id'=>'1',
+            'last_seen'=>'-0d', 'first_seen'=>'-0d', 'network'=>'twitter','active'=>1));
+        $builders[] = FixtureBuilder::build('users', array('user_id'=>'4', 'network' => 'twitter','is_protected'=>0,
+            'network' => 'twitter',
+            'user_name' => 'third_user', 'joined' => ('2013-05-23 04:01')));
+
+        $builders[] = FixtureBuilder::build('follows', array('user_id'=>'5', 'follower_id'=>'1',
+            'last_seen'=>'-0d', 'first_seen'=>'-0d', 'network'=>'twitter','active'=>1));
+        $builders[] = FixtureBuilder::build('users', array('user_id'=>'5', 'network' => 'twitter','is_protected'=>0,
+            'network' => 'twitter',
+            'user_name' => 'fourth_user', 'joined' => ('2013-05-25 03:12')));
+
+        $insight_plugin = new TwitterBirthdayInsight();
+        $user = $this->makeUser('hbtome', ('2013-05-22 04:01'), 1);
+        $insight_plugin->generateInsight($this->instance, $user, array(), 3);
+
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('twitterbirthday', $this->instance->id, $today);
+        $this->assertEqual('Happy Twitter birthday!', $result->headline);
+        $this->assertEqual('@hbtome joined Twitter 1 year ago today. @second_user just beat @hbtome, joining '
+           .'1 day earlier, and @third_user was a little slower, getting on Twitter 1 day later.', $result->text);
+
+        $data = unserialize($result->related_data);
+        $this->assertEqual(count($data['people']), 2);
+        $this->assertEqual($data['people'][0]->username, 'second_user');
+        $this->assertEqual($data['people'][1]->username, 'third_user');
+
+        $this->debug($this->getRenderedInsightInHTML($result));
+        $this->debug($this->getRenderedInsightInEmail($result));
+    }
+
+    public function testNoFollowers() {
+        $insight_plugin = new TwitterBirthdayInsight();
+        $user = $this->makeUser('hbtome', ('2013-05-22 04:01'));
+        $insight_plugin->generateInsight($this->instance, $user, array(), 3);
+
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('twitterbirthday', 10, $today);
+        $this->assertEqual('Happy Twitter birthday!', $result->headline);
+        $this->assertEqual('@hbtome joined Twitter 1 year ago today.', $result->text);
+        $data = unserialize($result->related_data);
+        $this->assertEqual(count($data['people']), 0);
+
+        $this->debug($this->getRenderedInsightInHTML($result));
+        $this->debug($this->getRenderedInsightInEmail($result));
+    }
+
+    public function testNoFollowersAfter() {
+        $builders = array();
+        $builders[] = FixtureBuilder::build('follows', array('user_id'=>'2', 'follower_id'=>'1',
+            'last_seen'=>'-0d', 'first_seen'=>'-0d', 'network'=>'twitter','active'=>1));
+        $builders[] = FixtureBuilder::build('users', array('user_id'=>'2', 'network' => 'twitter','is_protected'=>0,
+            'network' => 'twitter',
+            'user_name' => 'first_user', 'joined' => ('2013-05-20 12:19')));
+
+        $builders[] = FixtureBuilder::build('follows', array('user_id'=>'3', 'follower_id'=>'1',
+            'last_seen'=>'-0d', 'first_seen'=>'-0d', 'network'=>'twitter','active'=>1));
+        $builders[] = FixtureBuilder::build('users', array('user_id'=>'3', 'network' => 'twitter','is_protected'=>0,
+            'network' => 'twitter',
+            'user_name' => 'second_user', 'joined' => ('2013-05-20 18:01')));
+
+        $insight_plugin = new TwitterBirthdayInsight();
+        $user = $this->makeUser('hbtome', ('2013-05-22 04:01'), 1);
+        $insight_plugin->generateInsight($this->instance, $user, array(), 3);
+
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('twitterbirthday', $this->instance->id, $today);
+        $this->assertEqual('Happy Twitter birthday!', $result->headline);
+        $this->assertEqual('@hbtome joined Twitter 1 year ago today. @second_user just beat @hbtome, joining '
+           .'1 day earlier.', $result->text);
+
+        $data = unserialize($result->related_data);
+        $this->assertEqual(count($data['people']), 1);
+        $this->assertEqual($data['people'][0]->username, 'second_user');
+
+        $this->debug($this->getRenderedInsightInHTML($result));
+        $this->debug($this->getRenderedInsightInEmail($result));
+    }
+
+    public function testSecondsToRelativeTime() {
+        $insight_plugin = new TwitterBirthdayInsight();
+        $minute = 60;
+        $hour = 60 * $minute;
+        $day = $hour * 24;
+        $week = $day * 7;
+
+        $this->assertEqual('1 second', $insight_plugin->secondsToRelativeTime(1));
+        $this->assertEqual('0 seconds', $insight_plugin->secondsToRelativeTime(0));
+        $this->assertEqual('11 seconds', $insight_plugin->secondsToRelativeTime(11));
+        $this->assertEqual('1 minute', $insight_plugin->secondsToRelativeTime($minute));
+        $this->assertEqual('6 minutes', $insight_plugin->secondsToRelativeTime($minute*6));
+        $this->assertEqual('1 hour', $insight_plugin->secondsToRelativeTime($hour));
+        $this->assertEqual('23 hours', $insight_plugin->secondsToRelativeTime($hour*23));
+        $this->assertEqual('1 day', $insight_plugin->secondsToRelativeTime($hour*26));
+        $this->assertEqual('3 days', $insight_plugin->secondsToRelativeTime($day*3));
+        $this->assertEqual('1 week', $insight_plugin->secondsToRelativeTime($week));
+        $this->assertEqual('1 week', $insight_plugin->secondsToRelativeTime($day * 8));
+        $this->assertEqual('3 weeks', $insight_plugin->secondsToRelativeTime($day * 23));
+        $this->assertEqual('2 weeks', $insight_plugin->secondsToRelativeTime($week*2));
+    }
+
+    /**
+     * Create a test user.
+     * @param username $username The user's username
+     * @param str $joined Joined date for the user
+     * @return User
+     */
+    private function makeUser($username, $joined, $user_id = 999) {
+        $user = new User();
+        $user->username = $username;
+        $user->joined = $joined;
+        $user->user_id = $user_id;
+        $user->network = "twitter";
+        return $user;
+    }
+}

--- a/webapp/plugins/insightsgenerator/view/twitterbirthday.tpl
+++ b/webapp/plugins/insightsgenerator/view/twitterbirthday.tpl
@@ -1,0 +1,2 @@
+
+{include file=$tpl_path|cat:"_users.tpl" users=$i->related_data.people}


### PR DESCRIPTION
Each year on your anniversary of joining twitter, gives you an insight.
Shows people you follow that joined just before and after you.
Added getFollowersJoinedInTimeFrame and countTotalFriendsJoinedAfterDate to FollowDAO

References #1514
