### PR TITLE
Handle twitter photos better

### DIFF
--- a/tests/TestOfPostMySQLDAO.php
+++ b/tests/TestOfPostMySQLDAO.php
@@ -3088,6 +3088,170 @@ class TestOfPostMySQLDAO extends ThinkUpUnitTestCase {
             return array($post, $entities, $user_array);
     }
 
+    private function buildStreamPostArray4() {
+        $post = json_decode('{
+           "post_id":"462955667167662080",
+           "author_user_id":"12145232",
+           "user_id":"12145232",
+           "pub_date":"2014-05-04 14:03:27",
+           "post_text":"RT @pourmecoffee: Twenty-eight men answered Shackleton\'s Antarctic expedition ad http:\/\/t.co\/uGLsKU8Qkc http:\/\/t.co\/wpdAD4iQzB",
+           "author_username":"CDMoyer",
+           "user_name":"CDMoyer",
+           "in_reply_to_user_id":"",
+           "author_avatar":"http:\/\/pbs.twimg.com\/profile_images\/421641487051272192\/IfEg0PgG_normal.jpeg",
+           "avatar":"http:\/\/pbs.twimg.com\/profile_images\/421641487051272192\/IfEg0PgG_normal.jpeg",
+           "in_reply_to_post_id":"",
+           "author_fullname":"Chris Moyer",
+           "full_name":"Chris Moyer",
+           "source":"<a href=\"http:\/\/twitter.com\/download\/iphone\" rel=\"nofollow\">Twitter for iPhone<\/a>",
+           "location":"Buffalo, NY",
+           "url":"http:\/\/t.co\/8NCBQ5WBQU",
+           "description":"I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+           "is_verified":0,
+           "is_protected":0,
+           "follower_count":443,
+           "post_count":937,
+           "geo":"",
+           "place":"",
+           "friend_count":245,
+           "joined":"2008-01-12 05:50:44",
+           "favorites_count":169,
+           "favlike_count_cache":0,
+           "network":"twitter",
+           "retweeted_post":{
+              "content":{
+                 "post_id":"462748167357091840",
+                 "author_user_id":"16906137",
+                 "user_id":"16906137",
+                 "pub_date":"2014-05-04 00:18:55",
+                 "post_text":"Twenty-eight men answered Shackleton\'s Antarctic expedition ad http:\/\/t.co\/uGLsKU8Qkc http:\/\/t.co\/wpdAD4iQzB",
+                 "author_username":"pourmecoffee",
+                 "user_name":"pourmecoffee",
+                 "in_reply_to_user_id":"",
+                 "author_avatar":"http:\/\/pbs.twimg.com\/profile_images\/421566216\/coffee1242220886_normal.jpg",
+                 "avatar":"http:\/\/pbs.twimg.com\/profile_images\/421566216\/coffee1242220886_normal.jpg",
+                 "in_reply_to_post_id":"",
+                 "author_fullname":"pourmecoffee",
+                 "full_name":"pourmecoffee",
+                 "source":"<a href=\"https:\/\/about.twitter.com\/products\/tweetdeck\" rel=\"nofollow\">TweetDeck<\/a>",
+                 "location":"USA",
+                 "url":"http:\/\/t.co\/FzcppA8OBt",
+                 "description":"Muttering sarcasm to power http:\/\/t.co\/CD3GxwBQD8",
+                 "is_verified":1,
+                 "is_protected":0,
+                 "follower_count":161508,
+                 "post_count":32683,
+                 "geo":"",
+                 "place":"",
+                 "friend_count":1176,
+                 "joined":"2008-10-22 14:33:38",
+                 "favorites_count":0,
+                 "favlike_count_cache":431,
+                 "network":"twitter",
+                 "retweet_count_api":556,
+                 "photos":[
+                    {
+                       "id":462748165783822340,
+                       "id_str":"462748165783822336",
+                       "indices":[
+                          86,
+                          108
+                       ],
+                       "media_url":"http:\/\/pbs.twimg.com\/media\/BmwDAUoCIAAM_H4.jpg",
+                       "media_url_https":"https:\/\/pbs.twimg.com\/media\/BmwDAUoCIAAM_H4.jpg",
+                       "url":"http:\/\/t.co\/wpdAD4iQzB",
+                       "display_url":"pic.twitter.com\/wpdAD4iQzB",
+                       "expanded_url":"http:\/\/twitter.com\/pourmecoffee\/status\/462748167357091840\/photo\/1",
+                       "type":"photo",
+                       "sizes":{
+                          "large":{
+                             "w":464,
+                             "h":269,
+                             "resize":"fit"
+                          },
+                          "thumb":{
+                             "w":150,
+                             "h":150,
+                             "resize":"crop"
+                          },
+                          "medium":{
+                             "w":464,
+                             "h":269,
+                             "resize":"fit"
+                          },
+                          "small":{
+                             "w":340,
+                             "h":197,
+                             "resize":"fit"
+                          }
+                       }
+                    }
+                 ]
+              }
+           },
+           "in_retweet_of_post_id":"462748167357091840",
+           "in_rt_of_user_id":"16906137",
+           "photos":[
+              {
+                 "id":462748165783822340,
+                 "id_str":"462748165783822336",
+                 "indices":[
+                    104,
+                    126
+                 ],
+                 "media_url":"http:\/\/pbs.twimg.com\/media\/BmwDAUoCIAAM_H4.jpg",
+                 "media_url_https":"https:\/\/pbs.twimg.com\/media\/BmwDAUoCIAAM_H4.jpg",
+                 "url":"http:\/\/t.co\/wpdAD4iQzB",
+                 "display_url":"pic.twitter.com\/wpdAD4iQzB",
+                 "expanded_url":"http:\/\/twitter.com\/pourmecoffee\/status\/462748167357091840\/photo\/1",
+                 "type":"photo",
+                 "sizes":{
+                    "large":{
+                       "w":464,
+                       "h":269,
+                       "resize":"fit"
+                    },
+                    "thumb":{
+                       "w":150,
+                       "h":150,
+                       "resize":"crop"
+                    },
+                    "medium":{
+                       "w":464,
+                       "h":269,
+                       "resize":"fit"
+                    },
+                    "small":{
+                       "w":340,
+                       "h":197,
+                       "resize":"fit"
+                    }
+                 },
+                 "source_status_id":462748167357091840,
+                 "source_status_id_str":"462748167357091840"
+              }
+           ]
+        }', true);
+        return $post;
+    }
+
+    public function testOfLinksInRetweet() {
+        $post = self::buildStreamPostArray4();
+        $dao = DAOFactory::getDAO('PostDAO');
+        $id = $dao->addPost($post);
+
+        $result = $dao->getPost($post['post_id'], 'twitter');
+        $this->assertEqual(0, count($result->links));
+        $this->assertEqual('462748167357091840', $result->in_retweet_of_post_id);
+
+        $result = $dao->getPost('462748167357091840', 'twitter');
+        $this->assertEqual(2, count($result->links));
+        $this->assertEqual('http://t.co/uGLsKU8Qkc', $result->links[0]->url);
+        $this->assertEqual('', $result->links[0]->image_src);
+        $this->assertEqual('http://t.co/wpdAD4iQzB', $result->links[1]->url);
+        $this->assertEqual('http://pbs.twimg.com/media/BmwDAUoCIAAM_H4.jpg', $result->links[1]->image_src);
+    }
+
     public function testUpdateFavLikeCount() {
         $dao = new PostMySQLDAO();
         $post = $dao->getPost(10, 'twitter');

--- a/webapp/_lib/class.URLProcessor.php
+++ b/webapp/_lib/class.URLProcessor.php
@@ -67,6 +67,7 @@ class URLProcessor {
                 }
             }
         }
+        return $urls;
     }
 
     /**

--- a/webapp/_lib/dao/class.PostMySQLDAO.php
+++ b/webapp/_lib/dao/class.PostMySQLDAO.php
@@ -634,7 +634,14 @@ class PostMySQLDAO extends PDODAO implements PostDAO  {
             if ($entities && isset($entities['urls'])) {
                 $urls = $entities['urls'];
             }
-            URLProcessor::processPostURLs($vals['post_text'], $vals['post_id'], 'twitter', $this->logger, $urls);
+            $urls = URLProcessor::processPostURLs($vals['post_text'], $vals['post_id'], 'twitter', $this->logger,$urls);
+            if ($vals['photos']) {
+                $link_dao = DAOFactory::getDAO('LinkDAO');
+                foreach ($vals['photos'] as $photo) {
+                    $photo = (object) $photo;
+                    $link_dao->saveExpandedURL($photo->url, $photo->expanded_url, null, $photo->media_url, null);
+                }
+            }
 
             if (isset($entities)) {
                 if (isset($entities['mentions'])) {
@@ -689,7 +696,7 @@ class PostMySQLDAO extends PDODAO implements PostDAO  {
                 $retweeted_post_user_array = null;
             }
             $this->addPostAndAssociatedInfo($retweeted_post_data, $retweeted_post_entities,
-            $retweeted_post_user_array);
+                $retweeted_post_user_array);
         }
 
         if ($this->hasAllRequiredFields($vals)) {

--- a/webapp/plugins/twitter/model/class.TwitterAPIAccessorOAuth.php
+++ b/webapp/plugins/twitter/model/class.TwitterAPIAccessorOAuth.php
@@ -324,6 +324,17 @@ class TwitterAPIAccessorOAuth {
                 $result['in_retweet_of_post_id'] = $json_tweet->retweeted_status->id_str;
                 $result['in_rt_of_user_id'] = $json_tweet->retweeted_status->user->id_str;
             }
+            if (!empty($json_tweet->entities->media)) {
+                $photos = array();
+                foreach ($json_tweet->entities->media as $media) {
+                    if ($media->type == 'photo') {
+                        $photos[] = $media;
+                    }
+                }
+                if (count($photos) > 0) {
+                    $result['photos'] = $photos;
+                }
+            }
             return $result;
     }
     /**

--- a/webapp/plugins/twitter/tests/TestOfTwitterAPIAccessorOAuth.php
+++ b/webapp/plugins/twitter/tests/TestOfTwitterAPIAccessorOAuth.php
@@ -92,9 +92,23 @@ class TestOfTwitterAPIAccessorOAuth extends ThinkUpBasicUnitTestCase {
         $this->assertNull($result);
     }
 
+    public function testParseJSONTweetWithPhotos() {
+        $api = new TwitterAPIAccessorOAuth($oauth_access_token='111', $oauth_access_token_secret='222',
+            $oauth_consumer_key=1234, $oauth_consumer_secret=1234, $num_twitter_errors=5, $log=true);
+        $data = file_get_contents(THINKUP_ROOT_PATH . $this->test_data_path.'json/phototweet.json');
+        $results = $api->parseJSONTweet($data);
+        $this->assertNotNull($results['photos']);
+        $this->assertEqual(count($results['photos']), 1);
+        $this->assertEqual("http://pbs.twimg.com/media/Bopuw9BIEAAAYVN.jpg", $results['photos'][0]->media_url);
+        $this->assertEqual("http://twitter.com/CDMoyer/status/471310898695794688/photo/1",
+            $results['photos'][0]->expanded_url);
+        $this->assertEqual("http://t.co/1z8GGl5Zrv",
+            $results['photos'][0]->url);
+    }
+
     public function testParseJSONTweet() {
         $api = new TwitterAPIAccessorOAuth($oauth_access_token='111', $oauth_access_token_secret='222',
-        $oauth_consumer_key=1234, $oauth_consumer_secret=1234, $num_twitter_errors=5, $log=true);
+            $oauth_consumer_key=1234, $oauth_consumer_secret=1234, $num_twitter_errors=5, $log=true);
 
         $data = file_get_contents(THINKUP_ROOT_PATH . $this->test_data_path.'json/tweet.json');
 

--- a/webapp/plugins/twitter/tests/data/testoftwittercrawler/cdmoyer/statuses_user_timeline.json-count=100-include_rts=true-screen_name=CDMoyer
+++ b/webapp/plugins/twitter/tests/data/testoftwittercrawler/cdmoyer/statuses_user_timeline.json-count=100-include_rts=true-screen_name=CDMoyer
@@ -1,0 +1,12666 @@
+[
+  {
+    "created_at": "Wed May 28 15:24:30 +0000 2014",
+    "id": 471673373765156860,
+    "id_str": "471673373765156864",
+    "text": "Ever found yourself googling \"add commas to a number in javascript?\"  You have?  Me too.  This is a better solution: http://t.co/HpQrJ0u6j6",
+    "source": "<a href=\"http://bufferapp.com\" rel=\"nofollow\">Buffer</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/HpQrJ0u6j6",
+          "expanded_url": "http://bit.ly/1gxe53m",
+          "display_url": "bit.ly/1gxe53m",
+          "indices": [
+            117,
+            139
+          ]
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Wed May 28 12:45:10 +0000 2014",
+    "id": 471633278198640640,
+    "id_str": "471633278198640640",
+    "text": "i.e. vs e.g. (i.e. quick latin refresher.) http://t.co/MKMx2uKs0d",
+    "source": "<a href=\"http://bufferapp.com\" rel=\"nofollow\">Buffer</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/MKMx2uKs0d",
+          "expanded_url": "http://bit.ly/1jnzWVM",
+          "display_url": "bit.ly/1jnzWVM",
+          "indices": [
+            43,
+            65
+          ]
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Wed May 28 03:03:12 +0000 2014",
+    "id": 471486818610069500,
+    "id_str": "471486818610069504",
+    "text": "Why are people picking on this car. So cute. It's gonna be like Herbie. http://t.co/C1kwgjnSf4",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/C1kwgjnSf4",
+          "expanded_url": "http://recode.net/2014/05/27/googles-new-self-driving-car-ditches-the-steering-wheel/",
+          "display_url": "recode.net/2014/05/27/goo…",
+          "indices": [
+            72,
+            94
+          ]
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Tue May 27 21:36:42 +0000 2014",
+    "id": 471404652156964860,
+    "id_str": "471404652156964865",
+    "text": "@anildash Rich kids with their working tape drives.  I typed a game into my TI99/4A and then didn't turn if off for days.",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 471402181477019650,
+    "in_reply_to_status_id_str": "471402181477019648",
+    "in_reply_to_user_id": 36823,
+    "in_reply_to_user_id_str": "36823",
+    "in_reply_to_screen_name": "anildash",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "anildash",
+          "name": "Anil Dash",
+          "id": 36823,
+          "id_str": "36823",
+          "indices": [
+            0,
+            9
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Tue May 27 21:06:36 +0000 2014",
+    "id": 471397077642387460,
+    "id_str": "471397077642387458",
+    "text": "RT @anildash: Do young people know that we used to read print magazines that had pages &amp; pages of source code, which we'd then re-type into…",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Tue May 27 21:04:03 +0000 2014",
+      "id": 471396438958944260,
+      "id_str": "471396438958944259",
+      "text": "Do young people know that we used to read print magazines that had pages &amp; pages of source code, which we'd then re-type into our computers?",
+      "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 36823,
+        "id_str": "36823",
+        "name": "Anil Dash",
+        "screen_name": "anildash",
+        "location": "NYC: 40.739069,-73.987082",
+        "description": "Cofounder @thinkup & @activateinc • Blog at http://t.co/Ytws16sDrz • anil@dashes.com • 646 833-8659 • The intern who maintains this account has been fired.",
+        "url": "http://t.co/zUrxsZkiRa",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/zUrxsZkiRa",
+                "expanded_url": "http://anildash.com",
+                "display_url": "anildash.com",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": [
+              {
+                "url": "http://t.co/Ytws16sDrz",
+                "expanded_url": "http://dashes.com",
+                "display_url": "dashes.com",
+                "indices": [
+                  44,
+                  66
+                ]
+              }
+            ]
+          }
+        },
+        "protected": false,
+        "followers_count": 496946,
+        "friends_count": 2311,
+        "listed_count": 6482,
+        "created_at": "Sat Dec 02 09:15:15 +0000 2006",
+        "favourites_count": 149506,
+        "utc_offset": -14400,
+        "time_zone": "Eastern Time (US & Canada)",
+        "geo_enabled": true,
+        "verified": true,
+        "statuses_count": 60746,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "131516",
+        "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/378252063/dark-floral-pattern.jpg",
+        "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/378252063/dark-floral-pattern.jpg",
+        "profile_background_tile": true,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/450813957461524480/iNanfzj4_normal.jpeg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/450813957461524480/iNanfzj4_normal.jpeg",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/36823/1386963407",
+        "profile_link_color": "800080",
+        "profile_sidebar_border_color": "EEEEEE",
+        "profile_sidebar_fill_color": "EFEFEF",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": true,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 45,
+      "favorite_count": 88,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [],
+        "user_mentions": []
+      },
+      "favorited": false,
+      "retweeted": true,
+      "lang": "en"
+    },
+    "retweet_count": 45,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "anildash",
+          "name": "Anil Dash",
+          "id": 36823,
+          "id_str": "36823",
+          "indices": [
+            3,
+            12
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "lang": "en"
+  },
+  {
+    "created_at": "Tue May 27 18:36:02 +0000 2014",
+    "id": 471359187575140350,
+    "id_str": "471359187575140352",
+    "text": "This is a pretty punny video. You might groan, but it’s funny.  http://t.co/Q0qcjUApti",
+    "source": "<a href=\"http://bufferapp.com\" rel=\"nofollow\">Buffer</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/Q0qcjUApti",
+          "expanded_url": "http://cbsn.ws/1h3N880",
+          "display_url": "cbsn.ws/1h3N880",
+          "indices": [
+            64,
+            86
+          ]
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Tue May 27 15:24:09 +0000 2014",
+    "id": 471310898695794700,
+    "id_str": "471310898695794688",
+    "text": "Just hanging out under the couch, like you do. http://t.co/1z8GGl5Zrv",
+    "source": "<a href=\"http://bufferapp.com\" rel=\"nofollow\">Buffer</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [],
+      "media": [
+        {
+          "id": 471310898305699840,
+          "id_str": "471310898305699840",
+          "indices": [
+            47,
+            69
+          ],
+          "media_url": "http://pbs.twimg.com/media/Bopuw9BIEAAAYVN.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/Bopuw9BIEAAAYVN.jpg",
+          "url": "http://t.co/1z8GGl5Zrv",
+          "display_url": "pic.twitter.com/1z8GGl5Zrv",
+          "expanded_url": "http://twitter.com/CDMoyer/status/471310898695794688/photo/1",
+          "type": "photo",
+          "sizes": {
+            "medium": {
+              "w": 600,
+              "h": 385,
+              "resize": "fit"
+            },
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "small": {
+              "w": 340,
+              "h": 218,
+              "resize": "fit"
+            },
+            "large": {
+              "w": 1023,
+              "h": 658,
+              "resize": "fit"
+            }
+          }
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Tue May 27 12:45:13 +0000 2014",
+    "id": 471270901649260540,
+    "id_str": "471270901649260544",
+    "text": "As a console.log devotee, this snippet to add line numbers and such seems cool. http://t.co/1nXycxHFOt",
+    "source": "<a href=\"http://bufferapp.com\" rel=\"nofollow\">Buffer</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 1,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/1nXycxHFOt",
+          "expanded_url": "http://bit.ly/1r1xApr",
+          "display_url": "bit.ly/1r1xApr",
+          "indices": [
+            80,
+            102
+          ]
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Tue May 27 03:10:39 +0000 2014",
+    "id": 471126305703219200,
+    "id_str": "471126305703219200",
+    "text": "RT @GlennF: As promised, my long post-mortem on my Magazine book Kickstarter. I tell all about budget, profit, &amp; the rest. https://t.co/pEu…",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Mon May 26 23:50:20 +0000 2014",
+      "id": 471075895252246500,
+      "id_str": "471075895252246528",
+      "text": "As promised, my long post-mortem on my Magazine book Kickstarter. I tell all about budget, profit, &amp; the rest. https://t.co/pEuRWxv4P9",
+      "source": "<a href=\"http://tapbots.com/software/tweetbot/mac\" rel=\"nofollow\">Tweetbot for Mac</a>",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 8315692,
+        "id_str": "8315692",
+        "name": "Glenn Fleishman",
+        "screen_name": "GlennF",
+        "location": "Seattle, WA",
+        "description": "Editor and publisher of The Magazine, host of The New Disruptors, regular contributor to The Economist, and two-time Jeopardy! champ.",
+        "url": "http://t.co/XiGRKy8IpL",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/XiGRKy8IpL",
+                "expanded_url": "http://glog.glennf.com/",
+                "display_url": "glog.glennf.com",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 14453,
+        "friends_count": 1863,
+        "listed_count": 1039,
+        "created_at": "Mon Aug 20 21:39:39 +0000 2007",
+        "favourites_count": 29738,
+        "utc_offset": -25200,
+        "time_zone": "Pacific Time (US & Canada)",
+        "geo_enabled": true,
+        "verified": false,
+        "statuses_count": 223981,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "CCD645",
+        "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/378800000080626207/6479bd27f95059b5f64e88025d1e6314.jpeg",
+        "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/378800000080626207/6479bd27f95059b5f64e88025d1e6314.jpeg",
+        "profile_background_tile": true,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/414611534677938176/pRyOivF0_normal.jpeg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/414611534677938176/pRyOivF0_normal.jpeg",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/8315692/1400738153",
+        "profile_link_color": "97C7C7",
+        "profile_sidebar_border_color": "FFFFFF",
+        "profile_sidebar_fill_color": "A07332",
+        "profile_text_color": "000000",
+        "profile_use_background_image": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": false,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 12,
+      "favorite_count": 16,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "url": "https://t.co/pEuRWxv4P9",
+            "expanded_url": "https://medium.com/p/c667a955ce2f",
+            "display_url": "medium.com/p/c667a955ce2f",
+            "indices": [
+              115,
+              138
+            ]
+          }
+        ],
+        "user_mentions": []
+      },
+      "favorited": false,
+      "retweeted": true,
+      "possibly_sensitive": false,
+      "lang": "en"
+    },
+    "retweet_count": 12,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "https://t.co/pEuRWxv4P9",
+          "expanded_url": "https://medium.com/p/c667a955ce2f",
+          "display_url": "medium.com/p/c667a955ce2f",
+          "indices": [
+            143,
+            144
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "GlennF",
+          "name": "Glenn Fleishman",
+          "id": 8315692,
+          "id_str": "8315692",
+          "indices": [
+            3,
+            10
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon May 26 18:36:09 +0000 2014",
+    "id": 470996828549546000,
+    "id_str": "470996828549545985",
+    "text": "I’m not going to say I love a parade. But I do love bagpipes. http://t.co/fta0b5CvS5",
+    "source": "<a href=\"http://bufferapp.com\" rel=\"nofollow\">Buffer</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [],
+      "media": [
+        {
+          "id": 470996828222390300,
+          "id_str": "470996828222390273",
+          "indices": [
+            62,
+            84
+          ],
+          "media_url": "http://pbs.twimg.com/media/BolRHqyIAAE-Mj8.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/BolRHqyIAAE-Mj8.jpg",
+          "url": "http://t.co/fta0b5CvS5",
+          "display_url": "pic.twitter.com/fta0b5CvS5",
+          "expanded_url": "http://twitter.com/CDMoyer/status/470996828549545985/photo/1",
+          "type": "photo",
+          "sizes": {
+            "large": {
+              "w": 800,
+              "h": 600,
+              "resize": "fit"
+            },
+            "medium": {
+              "w": 600,
+              "h": 450,
+              "resize": "fit"
+            },
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "small": {
+              "w": 340,
+              "h": 255,
+              "resize": "fit"
+            }
+          }
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon May 26 16:20:37 +0000 2014",
+    "id": 470962721325072400,
+    "id_str": "470962721325072384",
+    "text": "This was me, 25 years ago or so. Nostalgia. http://t.co/t0Hafe89w4",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [],
+      "media": [
+        {
+          "id": 470962719689302000,
+          "id_str": "470962719689302016",
+          "indices": [
+            44,
+            66
+          ],
+          "media_url": "http://pbs.twimg.com/media/BokyGSmIYAAHUa7.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/BokyGSmIYAAHUa7.jpg",
+          "url": "http://t.co/t0Hafe89w4",
+          "display_url": "pic.twitter.com/t0Hafe89w4",
+          "expanded_url": "http://twitter.com/CDMoyer/status/470962721325072384/photo/1",
+          "type": "photo",
+          "sizes": {
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "large": {
+              "w": 1024,
+              "h": 696,
+              "resize": "fit"
+            },
+            "medium": {
+              "w": 600,
+              "h": 408,
+              "resize": "fit"
+            },
+            "small": {
+              "w": 340,
+              "h": 231,
+              "resize": "fit"
+            }
+          }
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon May 26 15:24:10 +0000 2014",
+    "id": 470948513610989600,
+    "id_str": "470948513610989568",
+    "text": "I accidentally made a beer ad, I think. http://t.co/vLUJS3mIUK",
+    "source": "<a href=\"http://bufferapp.com\" rel=\"nofollow\">Buffer</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 1,
+    "favorite_count": 3,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [],
+      "media": [
+        {
+          "id": 470948513158012900,
+          "id_str": "470948513158012928",
+          "indices": [
+            40,
+            62
+          ],
+          "media_url": "http://pbs.twimg.com/media/BoklLXJIIAAQV_k.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/BoklLXJIIAAQV_k.jpg",
+          "url": "http://t.co/vLUJS3mIUK",
+          "display_url": "pic.twitter.com/vLUJS3mIUK",
+          "expanded_url": "http://twitter.com/CDMoyer/status/470948513610989568/photo/1",
+          "type": "photo",
+          "sizes": {
+            "large": {
+              "w": 800,
+              "h": 1067,
+              "resize": "fit"
+            },
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "small": {
+              "w": 340,
+              "h": 453,
+              "resize": "fit"
+            },
+            "medium": {
+              "w": 600,
+              "h": 800,
+              "resize": "fit"
+            }
+          }
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon May 26 12:45:06 +0000 2014",
+    "id": 470908485161746400,
+    "id_str": "470908485161746432",
+    "text": "Facebook really wants me to trust their algorithm. They seem to move \"most recent\" every time they update the app.  (Hidden in “more” now. )",
+    "source": "<a href=\"http://bufferapp.com\" rel=\"nofollow\">Buffer</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Sun May 25 17:30:59 +0000 2014",
+    "id": 470618040154214400,
+    "id_str": "470618040154214400",
+    "text": "Fellow fathers, let's teach our boys:  women don't owe them sex &amp; to listen to and support the women in their lives. http://t.co/M0Kc11Jbbj",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 4,
+    "favorite_count": 2,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [],
+      "media": [
+        {
+          "id": 470618038442532860,
+          "id_str": "470618038442532866",
+          "indices": [
+            121,
+            143
+          ],
+          "media_url": "http://pbs.twimg.com/media/Bof4nM5CIAINm05.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/Bof4nM5CIAINm05.jpg",
+          "url": "http://t.co/M0Kc11Jbbj",
+          "display_url": "pic.twitter.com/M0Kc11Jbbj",
+          "expanded_url": "http://twitter.com/CDMoyer/status/470618040154214400/photo/1",
+          "type": "photo",
+          "sizes": {
+            "large": {
+              "w": 510,
+              "h": 542,
+              "resize": "fit"
+            },
+            "small": {
+              "w": 340,
+              "h": 361,
+              "resize": "fit"
+            },
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "medium": {
+              "w": 510,
+              "h": 542,
+              "resize": "fit"
+            }
+          }
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Sat May 24 19:33:14 +0000 2014",
+    "id": 470286419563647000,
+    "id_str": "470286419563646976",
+    "text": "RT @asym: Hotstuff: Live stream has started! Jick is drawing a crashed alien spacecraft. http://t.co/KQlpIfYGiJ",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Sat May 24 19:05:01 +0000 2014",
+      "id": 470279319982702600,
+      "id_str": "470279319982702592",
+      "text": "Hotstuff: Live stream has started! Jick is drawing a crashed alien spacecraft. http://t.co/KQlpIfYGiJ",
+      "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 16733102,
+        "id_str": "16733102",
+        "name": "Asymmetric Pub. LLC",
+        "screen_name": "asym",
+        "location": "Arizona, etc.",
+        "description": "The people who work on Kingdom of Loathing",
+        "url": "http://t.co/VQQkoBCPvS",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/VQQkoBCPvS",
+                "expanded_url": "http://kingdomofloathing.com/",
+                "display_url": "kingdomofloathing.com",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 6707,
+        "friends_count": 0,
+        "listed_count": 258,
+        "created_at": "Tue Oct 14 03:46:28 +0000 2008",
+        "favourites_count": 9,
+        "utc_offset": -25200,
+        "time_zone": "Arizona",
+        "geo_enabled": false,
+        "verified": false,
+        "statuses_count": 2463,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "C0DEED",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_tile": false,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/62407449/sm_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/62407449/sm_normal.jpg",
+        "profile_link_color": "0084B4",
+        "profile_sidebar_border_color": "C0DEED",
+        "profile_sidebar_fill_color": "DDEEF6",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "default_profile": true,
+        "default_profile_image": false,
+        "following": true,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 12,
+      "favorite_count": 6,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "url": "http://t.co/KQlpIfYGiJ",
+            "expanded_url": "http://twitch.tv/kol",
+            "display_url": "twitch.tv/kol",
+            "indices": [
+              79,
+              101
+            ]
+          }
+        ],
+        "user_mentions": []
+      },
+      "favorited": false,
+      "retweeted": true,
+      "possibly_sensitive": false,
+      "lang": "en"
+    },
+    "retweet_count": 12,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/KQlpIfYGiJ",
+          "expanded_url": "http://twitch.tv/kol",
+          "display_url": "twitch.tv/kol",
+          "indices": [
+            89,
+            111
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "asym",
+          "name": "Asymmetric Pub. LLC",
+          "id": 16733102,
+          "id_str": "16733102",
+          "indices": [
+            3,
+            8
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Sat May 24 17:12:34 +0000 2014",
+    "id": 470251018593517600,
+    "id_str": "470251018593517568",
+    "text": "\"Dad, I'm going to count your face hairs. 1,2,3, oops lost count. 1,2,3,53, ok, about a million.\" -Charlotte",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri May 23 22:50:56 +0000 2014",
+    "id": 469973786222411800,
+    "id_str": "469973786222411776",
+    "text": "@michellej Hmm… did nobody tell you that twitter isn't super secret? ;)",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 469973509389963260,
+    "in_reply_to_status_id_str": "469973509389963264",
+    "in_reply_to_user_id": 3954241,
+    "in_reply_to_user_id_str": "3954241",
+    "in_reply_to_screen_name": "michellej",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "michellej",
+          "name": "Michelle Jones",
+          "id": 3954241,
+          "id_str": "3954241",
+          "indices": [
+            0,
+            10
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri May 23 22:50:18 +0000 2014",
+    "id": 469973626062917600,
+    "id_str": "469973626062917632",
+    "text": "@nb3004 You forgot the @popo.  (cc: @magnachef @kevinpurdy @qrush )",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 469971222412161000,
+    "in_reply_to_status_id_str": "469971222412161024",
+    "in_reply_to_user_id": 5452072,
+    "in_reply_to_user_id_str": "5452072",
+    "in_reply_to_screen_name": "nb3004",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "nb3004",
+          "name": "Nicholas Barone",
+          "id": 5452072,
+          "id_str": "5452072",
+          "indices": [
+            0,
+            7
+          ]
+        },
+        {
+          "screen_name": "popo",
+          "name": "Steve Poland",
+          "id": 2247381,
+          "id_str": "2247381",
+          "indices": [
+            23,
+            28
+          ]
+        },
+        {
+          "screen_name": "magnachef",
+          "name": "Dan Magnuszewski",
+          "id": 23703410,
+          "id_str": "23703410",
+          "indices": [
+            36,
+            46
+          ]
+        },
+        {
+          "screen_name": "kevinpurdy",
+          "name": "Kevin Purdy",
+          "id": 14687182,
+          "id_str": "14687182",
+          "indices": [
+            47,
+            58
+          ]
+        },
+        {
+          "screen_name": "qrush",
+          "name": "Nick Quaranto",
+          "id": 5743852,
+          "id_str": "5743852",
+          "indices": [
+            59,
+            65
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri May 23 21:38:07 +0000 2014",
+    "id": 469955460326772740,
+    "id_str": "469955460326772737",
+    "text": "In Beta 102: the wild world of DRM\n@kevinpurdy: Those are the orangoutangs?\n@christi3k: Sure Kevin. You keep track of the monkeys.",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "kevinpurdy",
+          "name": "Kevin Purdy",
+          "id": 14687182,
+          "id_str": "14687182",
+          "indices": [
+            35,
+            46
+          ]
+        },
+        {
+          "screen_name": "christi3k",
+          "name": "Christie Koehler Ⓥ",
+          "id": 14111858,
+          "id_str": "14111858",
+          "indices": [
+            76,
+            86
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri May 23 19:36:49 +0000 2014",
+    "id": 469924934601687040,
+    "id_str": "469924934601687040",
+    "text": "The kids don't care that it's 57F out, the pool is open, clean and over 70. (Meanwhile, Jen is building a fire.) https://t.co/ICcxNNtUV3",
+    "source": "<a href=\"http://www.apple.com\" rel=\"nofollow\">iOS</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "https://t.co/ICcxNNtUV3",
+          "expanded_url": "https://www.carousel.com/photos/cc/tGOikUhLbiwfOBq",
+          "display_url": "carousel.com/photos/cc/tGOi…",
+          "indices": [
+            113,
+            136
+          ]
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri May 23 19:03:43 +0000 2014",
+    "id": 469916604080607200,
+    "id_str": "469916604080607232",
+    "text": "@gnuconsulting someone squat on this quick before mr. Bishop makes us all regret it.",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 469878882657513500,
+    "in_reply_to_status_id_str": "469878882657513472",
+    "in_reply_to_user_id": 15060778,
+    "in_reply_to_user_id_str": "15060778",
+    "in_reply_to_screen_name": "gnuconsulting",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "gnuconsulting",
+          "name": "David Bishop",
+          "id": 15060778,
+          "id_str": "15060778",
+          "indices": [
+            0,
+            14
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri May 23 18:36:11 +0000 2014",
+    "id": 469909672888381440,
+    "id_str": "469909672888381440",
+    "text": "Do you love dystopian sci-fi and the English language? Give Dhalgren a try. - https://t.co/EmQ8bAUOn8",
+    "source": "<a href=\"http://bufferapp.com\" rel=\"nofollow\">Buffer</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "https://t.co/EmQ8bAUOn8",
+          "expanded_url": "https://www.goodreads.com/book/show/85867.Dhalgren",
+          "display_url": "goodreads.com/book/show/8586…",
+          "indices": [
+            78,
+            101
+          ]
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri May 23 15:24:03 +0000 2014",
+    "id": 469861323636236300,
+    "id_str": "469861323636236288",
+    "text": "Heard Just Breathe on @nbcblacklist, promptly picked up the album, BackSpacer. First Pearl Jam album bought in a decade, it's amazing.",
+    "source": "<a href=\"http://bufferapp.com\" rel=\"nofollow\">Buffer</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "NBCBlacklist",
+          "name": "The Blacklist",
+          "id": 1344919338,
+          "id_str": "1344919338",
+          "indices": [
+            22,
+            35
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri May 23 13:14:35 +0000 2014",
+    "id": 469828741028663300,
+    "id_str": "469828741028663296",
+    "text": "Why does @twitter let me submit the report form if they ignore it because I clicked the radio button saying I'm not directly involved.",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "twitter",
+          "name": "Twitter",
+          "id": 783214,
+          "id_str": "783214",
+          "indices": [
+            9,
+            17
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri May 23 05:27:17 +0000 2014",
+    "id": 469711139098857500,
+    "id_str": "469711139098857472",
+    "text": "@phildzikiy there's something about those songs during the hard feeling formational teenage and early adult years. ie. First kiss song.",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 469673477885018100,
+    "in_reply_to_status_id_str": "469673477885018112",
+    "in_reply_to_user_id": 272230417,
+    "in_reply_to_user_id_str": "272230417",
+    "in_reply_to_screen_name": "phildzikiy",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "phildzikiy",
+          "name": "Phil Dzikiy",
+          "id": 272230417,
+          "id_str": "272230417",
+          "indices": [
+            0,
+            11
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Thu May 22 21:32:15 +0000 2014",
+    "id": 469591596863066100,
+    "id_str": "469591596863066112",
+    "text": "Ever wanted your dictionary to be filled with artistry and a love of language? http://t.co/eHrwfGnBsI",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/eHrwfGnBsI",
+          "expanded_url": "http://jsomers.net/blog/dictionary",
+          "display_url": "jsomers.net/blog/dictionary",
+          "indices": [
+            79,
+            101
+          ]
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Thu May 22 20:49:41 +0000 2014",
+    "id": 469580881959858200,
+    "id_str": "469580881959858176",
+    "text": "@sarajchipps Are you using  plugin to make it  painless? http://t.co/noNE3s4zar",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 469579951587729400,
+    "in_reply_to_status_id_str": "469579951587729409",
+    "in_reply_to_user_id": 15524875,
+    "in_reply_to_user_id_str": "15524875",
+    "in_reply_to_screen_name": "SaraJChipps",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/noNE3s4zar",
+          "expanded_url": "http://blog.travisthieman.com/github-selfies/",
+          "display_url": "blog.travisthieman.com/github-selfies/",
+          "indices": [
+            57,
+            79
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "SaraJChipps",
+          "name": "Sara Chipps",
+          "id": 15524875,
+          "id_str": "15524875",
+          "indices": [
+            0,
+            12
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Thu May 22 19:13:35 +0000 2014",
+    "id": 469556698882269200,
+    "id_str": "469556698882269185",
+    "text": "RT @jennschiffer: you can be *for* http://t.co/VS1gW7H0kE or *against* actual facts re: stuff that happen(ed). it's not about where the let…",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Thu May 22 18:21:44 +0000 2014",
+      "id": 469543649689477100,
+      "id_str": "469543649689477120",
+      "text": "you can be *for* http://t.co/VS1gW7H0kE or *against* actual facts re: stuff that happen(ed). it's not about where the letter was crossposted",
+      "source": "web",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 12524622,
+        "id_str": "12524622",
+        "name": "literally css",
+        "screen_name": "jennschiffer",
+        "location": "new jersey on purpose",
+        "description": "engineer at @bocoup • queen of http://t.co/zaBLoHQudM & #jerseyscript • indulging in tech gossip with no connection 2 truth, having fun while it lasts",
+        "url": "http://t.co/PrLXDKEliN",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/PrLXDKEliN",
+                "expanded_url": "http://jennmoney.biz",
+                "display_url": "jennmoney.biz",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": [
+              {
+                "url": "http://t.co/zaBLoHQudM",
+                "expanded_url": "http://make8bitart.com",
+                "display_url": "make8bitart.com",
+                "indices": [
+                  31,
+                  53
+                ]
+              }
+            ]
+          }
+        },
+        "protected": false,
+        "followers_count": 7052,
+        "friends_count": 1159,
+        "listed_count": 323,
+        "created_at": "Tue Jan 22 05:42:15 +0000 2008",
+        "favourites_count": 18079,
+        "utc_offset": -14400,
+        "time_zone": "Eastern Time (US & Canada)",
+        "geo_enabled": true,
+        "verified": false,
+        "statuses_count": 30940,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "FFFFFF",
+        "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/454274435055230978/1Ww8jwZg.png",
+        "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/454274435055230978/1Ww8jwZg.png",
+        "profile_background_tile": true,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/470890961741295616/FLaOD-Fv_normal.jpeg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/470890961741295616/FLaOD-Fv_normal.jpeg",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/12524622/1399692016",
+        "profile_link_color": "FF00AA",
+        "profile_sidebar_border_color": "000000",
+        "profile_sidebar_fill_color": "99CCCC",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": true,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 6,
+      "favorite_count": 24,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "url": "http://t.co/VS1gW7H0kE",
+            "expanded_url": "http://aboutfeminism.me",
+            "display_url": "aboutfeminism.me",
+            "indices": [
+              17,
+              39
+            ]
+          }
+        ],
+        "user_mentions": []
+      },
+      "favorited": false,
+      "retweeted": true,
+      "possibly_sensitive": false,
+      "lang": "en"
+    },
+    "retweet_count": 6,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/VS1gW7H0kE",
+          "expanded_url": "http://aboutfeminism.me",
+          "display_url": "aboutfeminism.me",
+          "indices": [
+            35,
+            57
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "jennschiffer",
+          "name": "jennmoneydollars",
+          "id": 12524622,
+          "id_str": "12524622",
+          "indices": [
+            3,
+            16
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Thu May 22 19:13:22 +0000 2014",
+    "id": 469556643345489900,
+    "id_str": "469556643345489920",
+    "text": "RT @anildash: Please support @metafilter's inadvertent crowdfunding campaign: https://t.co/lnB8uNaoMa How much do we have to pay to get rid…",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Thu May 22 18:43:58 +0000 2014",
+      "id": 469549245838917600,
+      "id_str": "469549245838917632",
+      "text": "Please support @metafilter's inadvertent crowdfunding campaign: https://t.co/lnB8uNaoMa How much do we have to pay to get rid of that blue?",
+      "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 36823,
+        "id_str": "36823",
+        "name": "Anil Dash",
+        "screen_name": "anildash",
+        "location": "NYC: 40.739069,-73.987082",
+        "description": "Cofounder @thinkup & @activateinc • Blog at http://t.co/Ytws16sDrz • anil@dashes.com • 646 833-8659 • The intern who maintains this account has been fired.",
+        "url": "http://t.co/zUrxsZkiRa",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/zUrxsZkiRa",
+                "expanded_url": "http://anildash.com",
+                "display_url": "anildash.com",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": [
+              {
+                "url": "http://t.co/Ytws16sDrz",
+                "expanded_url": "http://dashes.com",
+                "display_url": "dashes.com",
+                "indices": [
+                  44,
+                  66
+                ]
+              }
+            ]
+          }
+        },
+        "protected": false,
+        "followers_count": 496946,
+        "friends_count": 2311,
+        "listed_count": 6482,
+        "created_at": "Sat Dec 02 09:15:15 +0000 2006",
+        "favourites_count": 149506,
+        "utc_offset": -14400,
+        "time_zone": "Eastern Time (US & Canada)",
+        "geo_enabled": true,
+        "verified": true,
+        "statuses_count": 60746,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "131516",
+        "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/378252063/dark-floral-pattern.jpg",
+        "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/378252063/dark-floral-pattern.jpg",
+        "profile_background_tile": true,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/450813957461524480/iNanfzj4_normal.jpeg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/450813957461524480/iNanfzj4_normal.jpeg",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/36823/1386963407",
+        "profile_link_color": "800080",
+        "profile_sidebar_border_color": "EEEEEE",
+        "profile_sidebar_fill_color": "EFEFEF",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": true,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 16,
+      "favorite_count": 22,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "url": "https://t.co/lnB8uNaoMa",
+            "expanded_url": "https://login.metafilter.com/funding.mefi",
+            "display_url": "login.metafilter.com/funding.mefi",
+            "indices": [
+              64,
+              87
+            ]
+          }
+        ],
+        "user_mentions": [
+          {
+            "screen_name": "metafilter",
+            "name": "MetaFilter",
+            "id": 8495642,
+            "id_str": "8495642",
+            "indices": [
+              15,
+              26
+            ]
+          }
+        ]
+      },
+      "favorited": false,
+      "retweeted": true,
+      "possibly_sensitive": false,
+      "lang": "en"
+    },
+    "retweet_count": 16,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "https://t.co/lnB8uNaoMa",
+          "expanded_url": "https://login.metafilter.com/funding.mefi",
+          "display_url": "login.metafilter.com/funding.mefi",
+          "indices": [
+            78,
+            101
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "anildash",
+          "name": "Anil Dash",
+          "id": 36823,
+          "id_str": "36823",
+          "indices": [
+            3,
+            12
+          ]
+        },
+        {
+          "screen_name": "metafilter",
+          "name": "MetaFilter",
+          "id": 8495642,
+          "id_str": "8495642",
+          "indices": [
+            29,
+            40
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Thu May 22 19:11:13 +0000 2014",
+    "id": 469556101378486300,
+    "id_str": "469556101378486272",
+    "text": "I had a great time with some tests for @thinkup last night and this morning. http://t.co/O2oqUli9Sq",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 3,
+    "favorite_count": 3,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "thinkup",
+          "name": "ThinkUp",
+          "id": 100127476,
+          "id_str": "100127476",
+          "indices": [
+            39,
+            47
+          ]
+        }
+      ],
+      "media": [
+        {
+          "id": 469556100837031940,
+          "id_str": "469556100837031936",
+          "indices": [
+            77,
+            99
+          ],
+          "media_url": "http://pbs.twimg.com/media/BoQyyTCCQAAluKR.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/BoQyyTCCQAAluKR.jpg",
+          "url": "http://t.co/O2oqUli9Sq",
+          "display_url": "pic.twitter.com/O2oqUli9Sq",
+          "expanded_url": "http://twitter.com/CDMoyer/status/469556101378486272/photo/1",
+          "type": "photo",
+          "sizes": {
+            "small": {
+              "w": 340,
+              "h": 529,
+              "resize": "fit"
+            },
+            "large": {
+              "w": 437,
+              "h": 680,
+              "resize": "fit"
+            },
+            "medium": {
+              "w": 437,
+              "h": 680,
+              "resize": "fit"
+            },
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            }
+          }
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Thu May 22 14:40:11 +0000 2014",
+    "id": 469487895925899260,
+    "id_str": "469487895925899264",
+    "text": "@mikebaz @thinkup Heh, that's been driving people crazy.  Should be fixed soon! The code is written https://t.co/tn7tOQkQla",
+    "source": "web",
+    "truncated": false,
+    "in_reply_to_status_id": 469459945378037760,
+    "in_reply_to_status_id_str": "469459945378037760",
+    "in_reply_to_user_id": 17000681,
+    "in_reply_to_user_id_str": "17000681",
+    "in_reply_to_screen_name": "mikebaz",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 2,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "https://t.co/tn7tOQkQla",
+          "expanded_url": "https://github.com/ginatrapani/ThinkUp/pull/1941",
+          "display_url": "github.com/ginatrapani/Th…",
+          "indices": [
+            100,
+            123
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "mikebaz",
+          "name": "Michael C.Bazarewsky",
+          "id": 17000681,
+          "id_str": "17000681",
+          "indices": [
+            0,
+            8
+          ]
+        },
+        {
+          "screen_name": "thinkup",
+          "name": "ThinkUp",
+          "id": 100127476,
+          "id_str": "100127476",
+          "indices": [
+            9,
+            17
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Thu May 22 12:14:41 +0000 2014",
+    "id": 469451280319283200,
+    "id_str": "469451280319283201",
+    "text": "I love getting this email after hours of fighting with a failing build on @travisci http://t.co/xfldZga58E",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "travisci",
+          "name": "Travis CI",
+          "id": 252481460,
+          "id_str": "252481460",
+          "indices": [
+            74,
+            83
+          ]
+        }
+      ],
+      "media": [
+        {
+          "id": 469451278603780100,
+          "id_str": "469451278603780097",
+          "indices": [
+            84,
+            106
+          ],
+          "media_url": "http://pbs.twimg.com/media/BoPTc1yIAAEsjpr.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/BoPTc1yIAAEsjpr.jpg",
+          "url": "http://t.co/xfldZga58E",
+          "display_url": "pic.twitter.com/xfldZga58E",
+          "expanded_url": "http://twitter.com/CDMoyer/status/469451280319283201/photo/1",
+          "type": "photo",
+          "sizes": {
+            "small": {
+              "w": 340,
+              "h": 604,
+              "resize": "fit"
+            },
+            "large": {
+              "w": 576,
+              "h": 1024,
+              "resize": "fit"
+            },
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "medium": {
+              "w": 576,
+              "h": 1024,
+              "resize": "fit"
+            }
+          }
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Thu May 22 00:31:28 +0000 2014",
+    "id": 469274309853466600,
+    "id_str": "469274309853466624",
+    "text": "@Oyster can we search the library on the web? I often read about books and want to add them to my reading list when I'm not on my phone.",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": 577367735,
+    "in_reply_to_user_id_str": "577367735",
+    "in_reply_to_screen_name": "Oyster",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "Oyster",
+          "name": "Oyster",
+          "id": 577367735,
+          "id_str": "577367735",
+          "indices": [
+            0,
+            7
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon May 19 18:51:15 +0000 2014",
+    "id": 468463913164869600,
+    "id_str": "468463913164869632",
+    "text": "I've decided to only eat these fresh blackberries that I bought today forever.  Soooooo goooood. http://t.co/Rd1yxsJ0Mf",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [],
+      "media": [
+        {
+          "id": 468463912544120800,
+          "id_str": "468463912544120832",
+          "indices": [
+            97,
+            119
+          ],
+          "media_url": "http://pbs.twimg.com/media/BoBRcklIMAAC8fZ.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/BoBRcklIMAAC8fZ.jpg",
+          "url": "http://t.co/Rd1yxsJ0Mf",
+          "display_url": "pic.twitter.com/Rd1yxsJ0Mf",
+          "expanded_url": "http://twitter.com/CDMoyer/status/468463913164869632/photo/1",
+          "type": "photo",
+          "sizes": {
+            "large": {
+              "w": 1024,
+              "h": 1365,
+              "resize": "fit"
+            },
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "small": {
+              "w": 340,
+              "h": 453,
+              "resize": "fit"
+            },
+            "medium": {
+              "w": 600,
+              "h": 800,
+              "resize": "fit"
+            }
+          }
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon May 19 15:37:13 +0000 2014",
+    "id": 468415084696723460,
+    "id_str": "468415084696723457",
+    "text": "RT @michellej: Wrote about a new @thinkup insight. It's tied with the F bomb one as my favorite. Not sure what that says about me.  http://…",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Mon May 19 15:31:21 +0000 2014",
+      "id": 468413608678793200,
+      "id_str": "468413608678793216",
+      "text": "Wrote about a new @thinkup insight. It's tied with the F bomb one as my favorite. Not sure what that says about me.  http://t.co/SCKAmqU9HK",
+      "source": "<a href=\"https://about.twitter.com/products/tweetdeck\" rel=\"nofollow\">TweetDeck</a>",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 3954241,
+        "id_str": "3954241",
+        "name": "Michelle Jones",
+        "screen_name": "michellej",
+        "location": "Louisville, Kentucky",
+        "description": "Player to be named later.",
+        "url": "http://t.co/AC3ZZkt0gQ",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/AC3ZZkt0gQ",
+                "expanded_url": "http://www.consuminglouisville.com",
+                "display_url": "consuminglouisville.com",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 3432,
+        "friends_count": 1330,
+        "listed_count": 246,
+        "created_at": "Mon Apr 09 23:24:12 +0000 2007",
+        "favourites_count": 15458,
+        "utc_offset": -14400,
+        "time_zone": "Eastern Time (US & Canada)",
+        "geo_enabled": false,
+        "verified": false,
+        "statuses_count": 36221,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "3C2C22",
+        "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/451035991088701440/bzgx9YMO.jpeg",
+        "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/451035991088701440/bzgx9YMO.jpeg",
+        "profile_background_tile": true,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/427881166478139394/FjpaEgbW_normal.jpeg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/427881166478139394/FjpaEgbW_normal.jpeg",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/3954241/1382912070",
+        "profile_link_color": "3C78A6",
+        "profile_sidebar_border_color": "FFFFFF",
+        "profile_sidebar_fill_color": "281E17",
+        "profile_text_color": "7A5C45",
+        "profile_use_background_image": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": true,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 1,
+      "favorite_count": 2,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "url": "http://t.co/SCKAmqU9HK",
+            "expanded_url": "http://blog.thinkup.com/post/86215706167/new-insight-congratulations-on-your-super-power",
+            "display_url": "blog.thinkup.com/post/862157061…",
+            "indices": [
+              117,
+              139
+            ]
+          }
+        ],
+        "user_mentions": [
+          {
+            "screen_name": "thinkup",
+            "name": "ThinkUp",
+            "id": 100127476,
+            "id_str": "100127476",
+            "indices": [
+              18,
+              26
+            ]
+          }
+        ]
+      },
+      "favorited": true,
+      "retweeted": true,
+      "possibly_sensitive": false,
+      "lang": "en"
+    },
+    "retweet_count": 1,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/SCKAmqU9HK",
+          "expanded_url": "http://blog.thinkup.com/post/86215706167/new-insight-congratulations-on-your-super-power",
+          "display_url": "blog.thinkup.com/post/862157061…",
+          "indices": [
+            139,
+            140
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "michellej",
+          "name": "Michelle Jones",
+          "id": 3954241,
+          "id_str": "3954241",
+          "indices": [
+            3,
+            13
+          ]
+        },
+        {
+          "screen_name": "thinkup",
+          "name": "ThinkUp",
+          "id": 100127476,
+          "id_str": "100127476",
+          "indices": [
+            33,
+            41
+          ]
+        }
+      ]
+    },
+    "favorited": true,
+    "retweeted": true,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Sat May 17 17:28:29 +0000 2014",
+    "id": 467718309086248960,
+    "id_str": "467718309086248960",
+    "text": "@ashedryden After it being broken forever for all PDFs, installed https://t.co/6YjniZhLGr (pdf.js extension), which is better. (not perfect)",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 467717093669228540,
+    "in_reply_to_status_id_str": "467717093669228545",
+    "in_reply_to_user_id": 9510922,
+    "in_reply_to_user_id_str": "9510922",
+    "in_reply_to_screen_name": "ashedryden",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "https://t.co/6YjniZhLGr",
+          "expanded_url": "https://chrome.google.com/webstore/detail/pdf-viewer/oemmndcbldboiebfnladdacbdfmadadm?hl=en",
+          "display_url": "chrome.google.com/webstore/detai…",
+          "indices": [
+            66,
+            89
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "ashedryden",
+          "name": "[CRYING INTENSIFIES]",
+          "id": 9510922,
+          "id_str": "9510922",
+          "indices": [
+            0,
+            11
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri May 16 01:06:43 +0000 2014",
+    "id": 467108852753002500,
+    "id_str": "467108852753002496",
+    "text": "RT @femfreq: \"Curbing Online Abuse Isn’t Impossible. Here’s Where We Start” by @laura_hudson http://t.co/0zhWLd0jut",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Thu May 15 21:39:27 +0000 2014",
+      "id": 467056690853335040,
+      "id_str": "467056690853335040",
+      "text": "\"Curbing Online Abuse Isn’t Impossible. Here’s Where We Start” by @laura_hudson http://t.co/0zhWLd0jut",
+      "source": "<a href=\"https://about.twitter.com/products/tweetdeck\" rel=\"nofollow\">TweetDeck</a>",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 56768257,
+        "id_str": "56768257",
+        "name": "Feminist Frequency",
+        "screen_name": "femfreq",
+        "location": "California",
+        "description": "Feminist Frequency is a video webseries that critically explores the representations of women in pop culture narratives. Created and hosted by Anita Sarkeesian.",
+        "url": "http://t.co/cX6Y33HIQ3",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/cX6Y33HIQ3",
+                "expanded_url": "http://www.feministfrequency.com",
+                "display_url": "feministfrequency.com",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 78742,
+        "friends_count": 1330,
+        "listed_count": 1913,
+        "created_at": "Tue Jul 14 18:12:29 +0000 2009",
+        "favourites_count": 1110,
+        "utc_offset": -25200,
+        "time_zone": "Pacific Time (US & Canada)",
+        "geo_enabled": false,
+        "verified": false,
+        "statuses_count": 3400,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "C0DEED",
+        "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/248694262/TwitterTemplate-NEW.jpg",
+        "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/248694262/TwitterTemplate-NEW.jpg",
+        "profile_background_tile": false,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/378800000098106734/80ff231b36590db42da8e7045109fd4b_normal.jpeg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000098106734/80ff231b36590db42da8e7045109fd4b_normal.jpeg",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/56768257/1398200839",
+        "profile_link_color": "DE2859",
+        "profile_sidebar_border_color": "FFFFFF",
+        "profile_sidebar_fill_color": "E1F2E5",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": true,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 107,
+      "favorite_count": 83,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "url": "http://t.co/0zhWLd0jut",
+            "expanded_url": "http://www.wired.com/2014/05/fighting-online-harassment/",
+            "display_url": "wired.com/2014/05/fighti…",
+            "indices": [
+              80,
+              102
+            ]
+          }
+        ],
+        "user_mentions": [
+          {
+            "screen_name": "laura_hudson",
+            "name": "Laura Hudson",
+            "id": 15642209,
+            "id_str": "15642209",
+            "indices": [
+              66,
+              79
+            ]
+          }
+        ]
+      },
+      "favorited": false,
+      "retweeted": true,
+      "possibly_sensitive": false,
+      "lang": "en"
+    },
+    "retweet_count": 107,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/0zhWLd0jut",
+          "expanded_url": "http://www.wired.com/2014/05/fighting-online-harassment/",
+          "display_url": "wired.com/2014/05/fighti…",
+          "indices": [
+            93,
+            115
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "femfreq",
+          "name": "Feminist Frequency",
+          "id": 56768257,
+          "id_str": "56768257",
+          "indices": [
+            3,
+            11
+          ]
+        },
+        {
+          "screen_name": "laura_hudson",
+          "name": "Laura Hudson",
+          "id": 15642209,
+          "id_str": "15642209",
+          "indices": [
+            79,
+            92
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Wed May 14 20:04:12 +0000 2014",
+    "id": 466670334113239040,
+    "id_str": "466670334113239041",
+    "text": "RT @capndesign: This is the shape of an HTML email before and after inlining CSS. http://t.co/Y1yRxDKM8o",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Wed May 14 20:00:47 +0000 2014",
+      "id": 466669474368598000,
+      "id_str": "466669474368598016",
+      "text": "This is the shape of an HTML email before and after inlining CSS. http://t.co/Y1yRxDKM8o",
+      "source": "web",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 5504,
+        "id_str": "5504",
+        "name": "Matt Jacobs",
+        "screen_name": "capndesign",
+        "location": "Brooklyn, NY",
+        "description": "I design and build products for fun and profit. I did it for Six Apart and OkCupid; now I’m building @kidpostapp and working with @thinkup.",
+        "url": "http://t.co/iDrCLQYU1P",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/iDrCLQYU1P",
+                "expanded_url": "http://www.capndesign.com",
+                "display_url": "capndesign.com",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 1387,
+        "friends_count": 728,
+        "listed_count": 82,
+        "created_at": "Fri Sep 08 00:18:16 +0000 2006",
+        "favourites_count": 3837,
+        "utc_offset": -14400,
+        "time_zone": "Eastern Time (US & Canada)",
+        "geo_enabled": true,
+        "verified": false,
+        "statuses_count": 5758,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "F1F1F1",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_tile": true,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/458683475629838336/9FSA_3UQ_normal.jpeg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/458683475629838336/9FSA_3UQ_normal.jpeg",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/5504/1398200269",
+        "profile_link_color": "F84141",
+        "profile_sidebar_border_color": "F84141",
+        "profile_sidebar_fill_color": "FFB034",
+        "profile_text_color": "000000",
+        "profile_use_background_image": false,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": true,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 4,
+      "favorite_count": 7,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [],
+        "user_mentions": [],
+        "media": [
+          {
+            "id": 466669472901001200,
+            "id_str": "466669472901001217",
+            "indices": [
+              66,
+              88
+            ],
+            "media_url": "http://pbs.twimg.com/media/Bnnxab_IcAEAU0w.png",
+            "media_url_https": "https://pbs.twimg.com/media/Bnnxab_IcAEAU0w.png",
+            "url": "http://t.co/Y1yRxDKM8o",
+            "display_url": "pic.twitter.com/Y1yRxDKM8o",
+            "expanded_url": "http://twitter.com/capndesign/status/466669474368598016/photo/1",
+            "type": "photo",
+            "sizes": {
+              "small": {
+                "w": 240,
+                "h": 680,
+                "resize": "fit"
+              },
+              "thumb": {
+                "w": 150,
+                "h": 150,
+                "resize": "crop"
+              },
+              "large": {
+                "w": 269,
+                "h": 761,
+                "resize": "fit"
+              },
+              "medium": {
+                "w": 269,
+                "h": 761,
+                "resize": "fit"
+              }
+            }
+          }
+        ]
+      },
+      "favorited": false,
+      "retweeted": true,
+      "possibly_sensitive": false,
+      "lang": "en"
+    },
+    "retweet_count": 4,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "capndesign",
+          "name": "Matt Jacobs",
+          "id": 5504,
+          "id_str": "5504",
+          "indices": [
+            3,
+            14
+          ]
+        }
+      ],
+      "media": [
+        {
+          "id": 466669472901001200,
+          "id_str": "466669472901001217",
+          "indices": [
+            82,
+            104
+          ],
+          "media_url": "http://pbs.twimg.com/media/Bnnxab_IcAEAU0w.png",
+          "media_url_https": "https://pbs.twimg.com/media/Bnnxab_IcAEAU0w.png",
+          "url": "http://t.co/Y1yRxDKM8o",
+          "display_url": "pic.twitter.com/Y1yRxDKM8o",
+          "expanded_url": "http://twitter.com/capndesign/status/466669474368598016/photo/1",
+          "type": "photo",
+          "sizes": {
+            "small": {
+              "w": 240,
+              "h": 680,
+              "resize": "fit"
+            },
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "large": {
+              "w": 269,
+              "h": 761,
+              "resize": "fit"
+            },
+            "medium": {
+              "w": 269,
+              "h": 761,
+              "resize": "fit"
+            }
+          },
+          "source_status_id": 466669474368598000,
+          "source_status_id_str": "466669474368598016"
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Tue May 13 21:25:06 +0000 2014",
+    "id": 466328303859957760,
+    "id_str": "466328303859957760",
+    "text": "@ginatrapani @kevinpurdy @thinkup I did say Buffalo is all about people gathering and eating fattening food and a certain shape of monument.",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 466324796448706560,
+    "in_reply_to_status_id_str": "466324796448706560",
+    "in_reply_to_user_id": 930061,
+    "in_reply_to_user_id_str": "930061",
+    "in_reply_to_screen_name": "ginatrapani",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "ginatrapani",
+          "name": "Gina Trapani",
+          "id": 930061,
+          "id_str": "930061",
+          "indices": [
+            0,
+            12
+          ]
+        },
+        {
+          "screen_name": "kevinpurdy",
+          "name": "Kevin Purdy",
+          "id": 14687182,
+          "id_str": "14687182",
+          "indices": [
+            13,
+            24
+          ]
+        },
+        {
+          "screen_name": "thinkup",
+          "name": "ThinkUp",
+          "id": 100127476,
+          "id_str": "100127476",
+          "indices": [
+            25,
+            33
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon May 12 12:50:53 +0000 2014",
+    "id": 465836509787349000,
+    "id_str": "465836509787348992",
+    "text": "Pleasantly surprised that more and more books I search for are already available with my @Oyster subscription. (It's Netflix for books.)",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 2,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "Oyster",
+          "name": "Oyster",
+          "id": 577367735,
+          "id_str": "577367735",
+          "indices": [
+            89,
+            96
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Sat May 10 15:03:12 +0000 2014",
+    "id": 465145034690805760,
+    "id_str": "465145034690805760",
+    "text": "Spring. My house looks like a family circus comic, but with dog prints. http://t.co/1EyrQQzmIM",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [],
+      "media": [
+        {
+          "id": 465145034099392500,
+          "id_str": "465145034099392512",
+          "indices": [
+            72,
+            94
+          ],
+          "media_url": "http://pbs.twimg.com/media/BnSG8a6IAAAtjj-.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/BnSG8a6IAAAtjj-.jpg",
+          "url": "http://t.co/1EyrQQzmIM",
+          "display_url": "pic.twitter.com/1EyrQQzmIM",
+          "expanded_url": "http://twitter.com/CDMoyer/status/465145034690805760/photo/1",
+          "type": "photo",
+          "sizes": {
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "small": {
+              "w": 340,
+              "h": 453,
+              "resize": "fit"
+            },
+            "medium": {
+              "w": 600,
+              "h": 800,
+              "resize": "fit"
+            },
+            "large": {
+              "w": 768,
+              "h": 1024,
+              "resize": "fit"
+            }
+          }
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Sat May 10 01:42:58 +0000 2014",
+    "id": 464943645888892900,
+    "id_str": "464943645888892928",
+    "text": "@qrush I think you lose 1 * (number of times you couldn't draw) health each time you need to draw.  It's an aggressive timer.",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 464916779962101760,
+    "in_reply_to_status_id_str": "464916779962101761",
+    "in_reply_to_user_id": 5743852,
+    "in_reply_to_user_id_str": "5743852",
+    "in_reply_to_screen_name": "qrush",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "qrush",
+          "name": "Nick Quaranto",
+          "id": 5743852,
+          "id_str": "5743852",
+          "indices": [
+            0,
+            6
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri May 09 17:54:50 +0000 2014",
+    "id": 464825839272853500,
+    "id_str": "464825839272853507",
+    "text": "RT @Maustallica: Have you ever thought to yourself \"what's the most 90s thing that could ever feasibly exist\"? Well, wonder no more. http:/…",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Fri May 09 08:18:44 +0000 2014",
+      "id": 464680855668293600,
+      "id_str": "464680855668293632",
+      "text": "Have you ever thought to yourself \"what's the most 90s thing that could ever feasibly exist\"? Well, wonder no more. http://t.co/AqLx5uJtL2",
+      "source": "web",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 25628352,
+        "id_str": "25628352",
+        "name": "Jehan Ranasinghe",
+        "screen_name": "Maustallica",
+        "location": "England",
+        "description": "Writer, geek, gamer, philanthropist, raconteur, outlaw, owl enthusiast and animation blogger. You may read his words on the internet, if that's what you're into",
+        "url": "http://t.co/cPxu0PHJde",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/cPxu0PHJde",
+                "expanded_url": "http://jehanimation.tumblr.com/",
+                "display_url": "jehanimation.tumblr.com",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 421,
+        "friends_count": 429,
+        "listed_count": 21,
+        "created_at": "Sat Mar 21 02:57:05 +0000 2009",
+        "favourites_count": 13,
+        "utc_offset": 3600,
+        "time_zone": "London",
+        "geo_enabled": true,
+        "verified": false,
+        "statuses_count": 22242,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "737855",
+        "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/434746647172481024/6K0LB8Vd.jpeg",
+        "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/434746647172481024/6K0LB8Vd.jpeg",
+        "profile_background_tile": true,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/434739458953314304/9WABPLp3_normal.jpeg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/434739458953314304/9WABPLp3_normal.jpeg",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/25628352/1392486952",
+        "profile_link_color": "0073FF",
+        "profile_sidebar_border_color": "000000",
+        "profile_sidebar_fill_color": "04258F",
+        "profile_text_color": "000000",
+        "profile_use_background_image": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": false,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 18270,
+      "favorite_count": 12399,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [],
+        "user_mentions": [],
+        "media": [
+          {
+            "id": 464680853059022850,
+            "id_str": "464680853059022848",
+            "indices": [
+              116,
+              138
+            ],
+            "media_url": "http://pbs.twimg.com/media/BnLgxhyCMAA8u4e.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/BnLgxhyCMAA8u4e.jpg",
+            "url": "http://t.co/AqLx5uJtL2",
+            "display_url": "pic.twitter.com/AqLx5uJtL2",
+            "expanded_url": "http://twitter.com/Maustallica/status/464680855668293632/photo/1",
+            "type": "photo",
+            "sizes": {
+              "thumb": {
+                "w": 150,
+                "h": 150,
+                "resize": "crop"
+              },
+              "small": {
+                "w": 340,
+                "h": 453,
+                "resize": "fit"
+              },
+              "medium": {
+                "w": 480,
+                "h": 640,
+                "resize": "fit"
+              },
+              "large": {
+                "w": 480,
+                "h": 640,
+                "resize": "fit"
+              }
+            }
+          }
+        ]
+      },
+      "favorited": false,
+      "retweeted": true,
+      "possibly_sensitive": false,
+      "lang": "en"
+    },
+    "retweet_count": 18270,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "Maustallica",
+          "name": "Jehan Ranasinghe",
+          "id": 25628352,
+          "id_str": "25628352",
+          "indices": [
+            3,
+            15
+          ]
+        }
+      ],
+      "media": [
+        {
+          "id": 464680853059022850,
+          "id_str": "464680853059022848",
+          "indices": [
+            139,
+            140
+          ],
+          "media_url": "http://pbs.twimg.com/media/BnLgxhyCMAA8u4e.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/BnLgxhyCMAA8u4e.jpg",
+          "url": "http://t.co/AqLx5uJtL2",
+          "display_url": "pic.twitter.com/AqLx5uJtL2",
+          "expanded_url": "http://twitter.com/Maustallica/status/464680855668293632/photo/1",
+          "type": "photo",
+          "sizes": {
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "small": {
+              "w": 340,
+              "h": 453,
+              "resize": "fit"
+            },
+            "medium": {
+              "w": 480,
+              "h": 640,
+              "resize": "fit"
+            },
+            "large": {
+              "w": 480,
+              "h": 640,
+              "resize": "fit"
+            }
+          },
+          "source_status_id": 464680855668293600,
+          "source_status_id_str": "464680855668293632"
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Thu May 08 20:57:43 +0000 2014",
+    "id": 464509474594906100,
+    "id_str": "464509474594906113",
+    "text": "RT @kevinpurdy: For your drive-home listen: @ginatrapani returns to gab and celebrate 100 episodes of &lt;In Beta&gt;: http://t.co/N24wMxN160",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Thu May 08 20:53:38 +0000 2014",
+      "id": 464508445396566000,
+      "id_str": "464508445396566016",
+      "text": "For your drive-home listen: @ginatrapani returns to gab and celebrate 100 episodes of &lt;In Beta&gt;: http://t.co/N24wMxN160",
+      "source": "<a href=\"http://twitter.com/carbonandroid\" rel=\"nofollow\">Carbon for Android</a>",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 14687182,
+        "id_str": "14687182",
+        "name": "Kevin Purdy",
+        "screen_name": "kevinpurdy",
+        "location": "Buffalo, NY",
+        "description": "Schooner-rigged and rakish freelance writer, with a long and lissome hull",
+        "url": "http://t.co/8O4w52nE77",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/8O4w52nE77",
+                "expanded_url": "http://www.thepurdman.com",
+                "display_url": "thepurdman.com",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 10519,
+        "friends_count": 719,
+        "listed_count": 913,
+        "created_at": "Wed May 07 14:44:40 +0000 2008",
+        "favourites_count": 1508,
+        "utc_offset": -14400,
+        "time_zone": "Eastern Time (US & Canada)",
+        "geo_enabled": false,
+        "verified": false,
+        "statuses_count": 12319,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "022330",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme15/bg.png",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme15/bg.png",
+        "profile_background_tile": false,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/468721026973462529/5qdTE4VH_normal.jpeg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/468721026973462529/5qdTE4VH_normal.jpeg",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/14687182/1400586847",
+        "profile_link_color": "0084B4",
+        "profile_sidebar_border_color": "A8C7F7",
+        "profile_sidebar_fill_color": "C0DFEC",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": true,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 1,
+      "favorite_count": 1,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "url": "http://t.co/N24wMxN160",
+            "expanded_url": "http://5by5.TV/inbeta/100",
+            "display_url": "5by5.TV/inbeta/100",
+            "indices": [
+              103,
+              125
+            ]
+          }
+        ],
+        "user_mentions": [
+          {
+            "screen_name": "ginatrapani",
+            "name": "Gina Trapani",
+            "id": 930061,
+            "id_str": "930061",
+            "indices": [
+              28,
+              40
+            ]
+          }
+        ]
+      },
+      "favorited": false,
+      "retweeted": true,
+      "possibly_sensitive": false,
+      "lang": "en"
+    },
+    "retweet_count": 1,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/N24wMxN160",
+          "expanded_url": "http://5by5.TV/inbeta/100",
+          "display_url": "5by5.TV/inbeta/100",
+          "indices": [
+            119,
+            141
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "kevinpurdy",
+          "name": "Kevin Purdy",
+          "id": 14687182,
+          "id_str": "14687182",
+          "indices": [
+            3,
+            14
+          ]
+        },
+        {
+          "screen_name": "ginatrapani",
+          "name": "Gina Trapani",
+          "id": 930061,
+          "id_str": "930061",
+          "indices": [
+            44,
+            56
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Thu May 08 15:18:19 +0000 2014",
+    "id": 464424062672834560,
+    "id_str": "464424062672834560",
+    "text": "RT @honkfestival: Premature abstraction is just another form of premature optimization, where you're trying to optimize for being right abo…",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Wed May 07 15:39:36 +0000 2014",
+      "id": 464067030841163800,
+      "id_str": "464067030841163777",
+      "text": "Premature abstraction is just another form of premature optimization, where you're trying to optimize for being right about the future.",
+      "source": "<a href=\"http://tapbots.com/software/tweetbot/mac\" rel=\"nofollow\">Tweetbot for Mac</a>",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 20342510,
+        "id_str": "20342510",
+        "name": "Aaron Olson",
+        "screen_name": "honkfestival",
+        "location": "☕️",
+        "description": "data horticulturalist at @Shopify",
+        "url": null,
+        "entities": {
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 471,
+        "friends_count": 524,
+        "listed_count": 16,
+        "created_at": "Sun Feb 08 00:12:33 +0000 2009",
+        "favourites_count": 0,
+        "utc_offset": -14400,
+        "time_zone": "Eastern Time (US & Canada)",
+        "geo_enabled": false,
+        "verified": false,
+        "statuses_count": 6429,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "C6E2EE",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme2/bg.gif",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme2/bg.gif",
+        "profile_background_tile": false,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/378800000167159164/955057f0ccf0a5de29283f16b72ba406_normal.png",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000167159164/955057f0ccf0a5de29283f16b72ba406_normal.png",
+        "profile_link_color": "1F98C7",
+        "profile_sidebar_border_color": "C6E2EE",
+        "profile_sidebar_fill_color": "DAECF4",
+        "profile_text_color": "663B12",
+        "profile_use_background_image": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": false,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 44,
+      "favorite_count": 14,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [],
+        "user_mentions": []
+      },
+      "favorited": false,
+      "retweeted": true,
+      "lang": "en"
+    },
+    "retweet_count": 44,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "honkfestival",
+          "name": "Aaron Olson",
+          "id": 20342510,
+          "id_str": "20342510",
+          "indices": [
+            3,
+            16
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "lang": "en"
+  },
+  {
+    "created_at": "Thu May 08 14:56:06 +0000 2014",
+    "id": 464418471703752700,
+    "id_str": "464418471703752704",
+    "text": "\"Why do we tell you to turn it off and on again? Because we don't have the slightest clue what's wrong with it…\" http://t.co/sBZrsOuNY4",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/sBZrsOuNY4",
+          "expanded_url": "http://stilldrinking.org/programming-sucks",
+          "display_url": "stilldrinking.org/programming-su…",
+          "indices": [
+            113,
+            135
+          ]
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Tue May 06 23:52:26 +0000 2014",
+    "id": 463828665915035650,
+    "id_str": "463828665915035648",
+    "text": "RT @AlanHungover: Say the opposite of these words:\n1) Always.\n2) Coming.\n3) From.\n4) Take. \n5) Me.\n6) Down.",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Tue May 06 23:13:06 +0000 2014",
+      "id": 463818767361798140,
+      "id_str": "463818767361798145",
+      "text": "Say the opposite of these words:\n1) Always.\n2) Coming.\n3) From.\n4) Take. \n5) Me.\n6) Down.",
+      "source": "<a href=\"http://bufferapp.com\" rel=\"nofollow\">Buffer</a>",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 490982935,
+        "id_str": "490982935",
+        "name": "Alan Garner",
+        "screen_name": "AlanHungover",
+        "location": "Las Vegas",
+        "description": "It's not a purse, it's called a satchel. Indiana Jones wears one. This Parody Account is in no way affiliated with The Hangover. Contact: alanhungover@gmail.com",
+        "url": null,
+        "entities": {
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 1030273,
+        "friends_count": 6,
+        "listed_count": 1890,
+        "created_at": "Mon Feb 13 03:53:29 +0000 2012",
+        "favourites_count": 268,
+        "utc_offset": -14400,
+        "time_zone": "Eastern Time (US & Canada)",
+        "geo_enabled": false,
+        "verified": false,
+        "statuses_count": 7786,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "C0DEED",
+        "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/424221291/baby.jpg",
+        "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/424221291/baby.jpg",
+        "profile_background_tile": true,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1825288290/gifsmall_normal.gif",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1825288290/gifsmall_normal.gif",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/490982935/1348116290",
+        "profile_link_color": "0084B4",
+        "profile_sidebar_border_color": "C0DEED",
+        "profile_sidebar_fill_color": "DDEEF6",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": false,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 448,
+      "favorite_count": 435,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [],
+        "user_mentions": []
+      },
+      "favorited": false,
+      "retweeted": true,
+      "lang": "en"
+    },
+    "retweet_count": 448,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "AlanHungover",
+          "name": "Alan Garner",
+          "id": 490982935,
+          "id_str": "490982935",
+          "indices": [
+            3,
+            16
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "lang": "en"
+  },
+  {
+    "created_at": "Tue May 06 15:43:13 +0000 2014",
+    "id": 463705552241975300,
+    "id_str": "463705552241975297",
+    "text": "RT @mrjakeparker: It's like @LEGO is TRYING to make horrible things for me to step on. http://t.co/uJ9TbPZk9V",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Tue May 06 13:09:30 +0000 2014",
+      "id": 463666868780163100,
+      "id_str": "463666868780163073",
+      "text": "It's like @LEGO is TRYING to make horrible things for me to step on. http://t.co/uJ9TbPZk9V",
+      "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 13205002,
+        "id_str": "13205002",
+        "name": "Jake Parker",
+        "screen_name": "mrjakeparker",
+        "location": "Utah",
+        "description": "Building a universe one story at a time.\r\nCheck out my web comic: http://t.co/VSg6vH9tLJ",
+        "url": "http://t.co/1R1cbRAvMF",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/1R1cbRAvMF",
+                "expanded_url": "http://mrjakeparker.com/",
+                "display_url": "mrjakeparker.com",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": [
+              {
+                "url": "http://t.co/VSg6vH9tLJ",
+                "expanded_url": "http://www.skullchaser.com",
+                "display_url": "skullchaser.com",
+                "indices": [
+                  66,
+                  88
+                ]
+              }
+            ]
+          }
+        },
+        "protected": false,
+        "followers_count": 7317,
+        "friends_count": 447,
+        "listed_count": 361,
+        "created_at": "Thu Feb 07 14:16:34 +0000 2008",
+        "favourites_count": 289,
+        "utc_offset": -14400,
+        "time_zone": "Eastern Time (US & Canada)",
+        "geo_enabled": false,
+        "verified": false,
+        "statuses_count": 5125,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "000000",
+        "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/455070450/antlerboywallpaper.jpg",
+        "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/455070450/antlerboywallpaper.jpg",
+        "profile_background_tile": false,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/378800000708064642/56a37d0c1f5b202a61af49668911f588_normal.jpeg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000708064642/56a37d0c1f5b202a61af49668911f588_normal.jpeg",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/13205002/1400779808",
+        "profile_link_color": "5BBCFF",
+        "profile_sidebar_border_color": "000000",
+        "profile_sidebar_fill_color": "E0FF92",
+        "profile_text_color": "000000",
+        "profile_use_background_image": false,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": false,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 6,
+      "favorite_count": 25,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [],
+        "user_mentions": [
+          {
+            "screen_name": "Lego",
+            "name": "Lego",
+            "id": 12053,
+            "id_str": "12053",
+            "indices": [
+              10,
+              15
+            ]
+          }
+        ],
+        "media": [
+          {
+            "id": 463666868155215900,
+            "id_str": "463666868155215872",
+            "indices": [
+              69,
+              91
+            ],
+            "media_url": "http://pbs.twimg.com/media/Bm9Gj1qCcAAhgfW.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/Bm9Gj1qCcAAhgfW.jpg",
+            "url": "http://t.co/uJ9TbPZk9V",
+            "display_url": "pic.twitter.com/uJ9TbPZk9V",
+            "expanded_url": "http://twitter.com/mrjakeparker/status/463666868780163073/photo/1",
+            "type": "photo",
+            "sizes": {
+              "large": {
+                "w": 769,
+                "h": 1024,
+                "resize": "fit"
+              },
+              "thumb": {
+                "w": 150,
+                "h": 150,
+                "resize": "crop"
+              },
+              "small": {
+                "w": 340,
+                "h": 453,
+                "resize": "fit"
+              },
+              "medium": {
+                "w": 600,
+                "h": 799,
+                "resize": "fit"
+              }
+            }
+          }
+        ]
+      },
+      "favorited": false,
+      "retweeted": true,
+      "possibly_sensitive": false,
+      "lang": "en"
+    },
+    "retweet_count": 6,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "mrjakeparker",
+          "name": "Jake Parker",
+          "id": 13205002,
+          "id_str": "13205002",
+          "indices": [
+            3,
+            16
+          ]
+        },
+        {
+          "screen_name": "Lego",
+          "name": "Lego",
+          "id": 12053,
+          "id_str": "12053",
+          "indices": [
+            28,
+            33
+          ]
+        }
+      ],
+      "media": [
+        {
+          "id": 463666868155215900,
+          "id_str": "463666868155215872",
+          "indices": [
+            87,
+            109
+          ],
+          "media_url": "http://pbs.twimg.com/media/Bm9Gj1qCcAAhgfW.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/Bm9Gj1qCcAAhgfW.jpg",
+          "url": "http://t.co/uJ9TbPZk9V",
+          "display_url": "pic.twitter.com/uJ9TbPZk9V",
+          "expanded_url": "http://twitter.com/mrjakeparker/status/463666868780163073/photo/1",
+          "type": "photo",
+          "sizes": {
+            "large": {
+              "w": 769,
+              "h": 1024,
+              "resize": "fit"
+            },
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "small": {
+              "w": 340,
+              "h": 453,
+              "resize": "fit"
+            },
+            "medium": {
+              "w": 600,
+              "h": 799,
+              "resize": "fit"
+            }
+          },
+          "source_status_id": 463666868780163100,
+          "source_status_id_str": "463666868780163073"
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon May 05 22:40:42 +0000 2014",
+    "id": 463448227032080400,
+    "id_str": "463448227032080384",
+    "text": "These would be 99.755% less disappointing if they were gooey mounds-style coconut filled. Artificial flavor. Bah. http://t.co/M8moGK2A5I",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [],
+      "media": [
+        {
+          "id": 463448225307848700,
+          "id_str": "463448225307848704",
+          "indices": [
+            114,
+            136
+          ],
+          "media_url": "http://pbs.twimg.com/media/Bm5_tJlCcAAnPeA.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/Bm5_tJlCcAAnPeA.jpg",
+          "url": "http://t.co/M8moGK2A5I",
+          "display_url": "pic.twitter.com/M8moGK2A5I",
+          "expanded_url": "http://twitter.com/CDMoyer/status/463448227032080384/photo/1",
+          "type": "photo",
+          "sizes": {
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "small": {
+              "w": 340,
+              "h": 453,
+              "resize": "fit"
+            },
+            "medium": {
+              "w": 600,
+              "h": 800,
+              "resize": "fit"
+            },
+            "large": {
+              "w": 768,
+              "h": 1024,
+              "resize": "fit"
+            }
+          }
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon May 05 22:22:38 +0000 2014",
+    "id": 463443680968572900,
+    "id_str": "463443680968572929",
+    "text": "I have a confession:  I really, really like Meat Loaf's Bat out of Hell.  Jim Steinman, Todd Rundgren and Meat Loaf… can you go wrong?",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon May 05 22:17:48 +0000 2014",
+    "id": 463442463852879900,
+    "id_str": "463442463852879872",
+    "text": "I have a confession:  I really, really like Meat Load's Bat out of Hell.  Jim Steinman, Todd Rundgren and Meat Loaf… can you go wrong?",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon May 05 14:58:08 +0000 2014",
+    "id": 463331818242990100,
+    "id_str": "463331818242990081",
+    "text": "RT @michellej: On the @thinkup blog: The F You Say http://t.co/e4GPyrBKQH",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Mon May 05 14:52:39 +0000 2014",
+      "id": 463330438031740900,
+      "id_str": "463330438031740928",
+      "text": "On the @thinkup blog: The F You Say http://t.co/e4GPyrBKQH",
+      "source": "<a href=\"https://about.twitter.com/products/tweetdeck\" rel=\"nofollow\">TweetDeck</a>",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 3954241,
+        "id_str": "3954241",
+        "name": "Michelle Jones",
+        "screen_name": "michellej",
+        "location": "Louisville, Kentucky",
+        "description": "Player to be named later.",
+        "url": "http://t.co/AC3ZZkt0gQ",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/AC3ZZkt0gQ",
+                "expanded_url": "http://www.consuminglouisville.com",
+                "display_url": "consuminglouisville.com",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 3432,
+        "friends_count": 1330,
+        "listed_count": 246,
+        "created_at": "Mon Apr 09 23:24:12 +0000 2007",
+        "favourites_count": 15458,
+        "utc_offset": -14400,
+        "time_zone": "Eastern Time (US & Canada)",
+        "geo_enabled": false,
+        "verified": false,
+        "statuses_count": 36221,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "3C2C22",
+        "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/451035991088701440/bzgx9YMO.jpeg",
+        "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/451035991088701440/bzgx9YMO.jpeg",
+        "profile_background_tile": true,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/427881166478139394/FjpaEgbW_normal.jpeg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/427881166478139394/FjpaEgbW_normal.jpeg",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/3954241/1382912070",
+        "profile_link_color": "3C78A6",
+        "profile_sidebar_border_color": "FFFFFF",
+        "profile_sidebar_fill_color": "281E17",
+        "profile_text_color": "7A5C45",
+        "profile_use_background_image": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": true,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 1,
+      "favorite_count": 3,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "url": "http://t.co/e4GPyrBKQH",
+            "expanded_url": "http://blog.thinkup.com/post/84828127412/the-f-you-say",
+            "display_url": "blog.thinkup.com/post/848281274…",
+            "indices": [
+              36,
+              58
+            ]
+          }
+        ],
+        "user_mentions": [
+          {
+            "screen_name": "thinkup",
+            "name": "ThinkUp",
+            "id": 100127476,
+            "id_str": "100127476",
+            "indices": [
+              7,
+              15
+            ]
+          }
+        ]
+      },
+      "favorited": false,
+      "retweeted": true,
+      "possibly_sensitive": false,
+      "lang": "en"
+    },
+    "retweet_count": 1,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/e4GPyrBKQH",
+          "expanded_url": "http://blog.thinkup.com/post/84828127412/the-f-you-say",
+          "display_url": "blog.thinkup.com/post/848281274…",
+          "indices": [
+            51,
+            73
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "michellej",
+          "name": "Michelle Jones",
+          "id": 3954241,
+          "id_str": "3954241",
+          "indices": [
+            3,
+            13
+          ]
+        },
+        {
+          "screen_name": "thinkup",
+          "name": "ThinkUp",
+          "id": 100127476,
+          "id_str": "100127476",
+          "indices": [
+            22,
+            30
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon May 05 14:11:12 +0000 2014",
+    "id": 463320008349986800,
+    "id_str": "463320008349986816",
+    "text": "It feels like a Licensed to Ill kind of morning.  I may slowly and lowly rhyme and steal my way all the way to Brooklyn with Mr. Revere.",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Sun May 04 17:03:13 +0000 2014",
+    "id": 463000907610091500,
+    "id_str": "463000907610091520",
+    "text": "RT @nb3004: This is video explains very clearly why I'm not designing auto rotating banners anymore. http://t.co/fnmkbG8rYA",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Sun May 04 15:59:13 +0000 2014",
+      "id": 462984804603297800,
+      "id_str": "462984804603297792",
+      "text": "This is video explains very clearly why I'm not designing auto rotating banners anymore. http://t.co/fnmkbG8rYA",
+      "source": "<a href=\"http://bufferapp.com\" rel=\"nofollow\">Buffer</a>",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 5452072,
+        "id_str": "5452072",
+        "name": "Nicholas Barone",
+        "screen_name": "nb3004",
+        "location": "Buffalo, NY",
+        "description": "I like building websites and companies.",
+        "url": "http://t.co/PBLHKsR6PR",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/PBLHKsR6PR",
+                "expanded_url": "http://nicholasbarone.com",
+                "display_url": "nicholasbarone.com",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 799,
+        "friends_count": 398,
+        "listed_count": 58,
+        "created_at": "Tue Apr 24 03:14:55 +0000 2007",
+        "favourites_count": 572,
+        "utc_offset": -14400,
+        "time_zone": "Eastern Time (US & Canada)",
+        "geo_enabled": true,
+        "verified": false,
+        "statuses_count": 3320,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "B0AA94",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+        "profile_background_tile": false,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/2567251397/9jpcdcyyfl47f4rc817i_normal.jpeg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/2567251397/9jpcdcyyfl47f4rc817i_normal.jpeg",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/5452072/1348418778",
+        "profile_link_color": "6B9E29",
+        "profile_sidebar_border_color": "5AB4FF",
+        "profile_sidebar_fill_color": "EEEEEE",
+        "profile_text_color": "8F8F8F",
+        "profile_use_background_image": false,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": true,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 2,
+      "favorite_count": 0,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "url": "http://t.co/fnmkbG8rYA",
+            "expanded_url": "http://buff.ly/1hpdz2j",
+            "display_url": "buff.ly/1hpdz2j",
+            "indices": [
+              89,
+              111
+            ]
+          }
+        ],
+        "user_mentions": []
+      },
+      "favorited": false,
+      "retweeted": true,
+      "possibly_sensitive": false,
+      "lang": "en"
+    },
+    "retweet_count": 2,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/fnmkbG8rYA",
+          "expanded_url": "http://buff.ly/1hpdz2j",
+          "display_url": "buff.ly/1hpdz2j",
+          "indices": [
+            101,
+            123
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "nb3004",
+          "name": "Nicholas Barone",
+          "id": 5452072,
+          "id_str": "5452072",
+          "indices": [
+            3,
+            10
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Sun May 04 14:13:25 +0000 2014",
+    "id": 462958176821055500,
+    "id_str": "462958176821055488",
+    "text": "@qrush do you want to keep all 3? ;)",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 462938019033403400,
+    "in_reply_to_status_id_str": "462938019033403392",
+    "in_reply_to_user_id": 5743852,
+    "in_reply_to_user_id_str": "5743852",
+    "in_reply_to_screen_name": "qrush",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "qrush",
+          "name": "Nick Quaranto",
+          "id": 5743852,
+          "id_str": "5743852",
+          "indices": [
+            0,
+            6
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Sun May 04 14:03:27 +0000 2014",
+    "id": 462955667167662100,
+    "id_str": "462955667167662080",
+    "text": "RT @pourmecoffee: Twenty-eight men answered Shackleton's Antarctic expedition ad http://t.co/uGLsKU8Qkc http://t.co/wpdAD4iQzB",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Sun May 04 00:18:55 +0000 2014",
+      "id": 462748167357091840,
+      "id_str": "462748167357091840",
+      "text": "Twenty-eight men answered Shackleton's Antarctic expedition ad http://t.co/uGLsKU8Qkc http://t.co/wpdAD4iQzB",
+      "source": "<a href=\"https://about.twitter.com/products/tweetdeck\" rel=\"nofollow\">TweetDeck</a>",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 16906137,
+        "id_str": "16906137",
+        "name": "pourmecoffee",
+        "screen_name": "pourmecoffee",
+        "location": "USA",
+        "description": "Muttering sarcasm to power http://t.co/CD3GxwBQD8",
+        "url": "http://t.co/FzcppA8OBt",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/FzcppA8OBt",
+                "expanded_url": "http://pourmecoffee.tumblr.com",
+                "display_url": "pourmecoffee.tumblr.com",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": [
+              {
+                "url": "http://t.co/CD3GxwBQD8",
+                "expanded_url": "http://j.mp/pmcrules",
+                "display_url": "j.mp/pmcrules",
+                "indices": [
+                  27,
+                  49
+                ]
+              }
+            ]
+          }
+        },
+        "protected": false,
+        "followers_count": 161508,
+        "friends_count": 1176,
+        "listed_count": 5591,
+        "created_at": "Wed Oct 22 14:33:38 +0000 2008",
+        "favourites_count": 0,
+        "utc_offset": -14400,
+        "time_zone": "Eastern Time (US & Canada)",
+        "geo_enabled": false,
+        "verified": true,
+        "statuses_count": 32683,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "E5E4E2",
+        "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/662888785/d00klxo2rtnjlkz4oilr.jpeg",
+        "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/662888785/d00klxo2rtnjlkz4oilr.jpeg",
+        "profile_background_tile": false,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/421566216/coffee1242220886_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/421566216/coffee1242220886_normal.jpg",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/16906137/1398194242",
+        "profile_link_color": "6F4E37",
+        "profile_sidebar_border_color": "FFFFFF",
+        "profile_sidebar_fill_color": "FFFFF0",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": false,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 556,
+      "favorite_count": 431,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "url": "http://t.co/uGLsKU8Qkc",
+            "expanded_url": "http://www.pbs.org/wgbh/nova/shackleton/1914/team.html",
+            "display_url": "pbs.org/wgbh/nova/shac…",
+            "indices": [
+              63,
+              85
+            ]
+          }
+        ],
+        "user_mentions": [],
+        "media": [
+          {
+            "id": 462748165783822340,
+            "id_str": "462748165783822336",
+            "indices": [
+              86,
+              108
+            ],
+            "media_url": "http://pbs.twimg.com/media/BmwDAUoCIAAM_H4.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/BmwDAUoCIAAM_H4.jpg",
+            "url": "http://t.co/wpdAD4iQzB",
+            "display_url": "pic.twitter.com/wpdAD4iQzB",
+            "expanded_url": "http://twitter.com/pourmecoffee/status/462748167357091840/photo/1",
+            "type": "photo",
+            "sizes": {
+              "large": {
+                "w": 464,
+                "h": 269,
+                "resize": "fit"
+              },
+              "thumb": {
+                "w": 150,
+                "h": 150,
+                "resize": "crop"
+              },
+              "medium": {
+                "w": 464,
+                "h": 269,
+                "resize": "fit"
+              },
+              "small": {
+                "w": 340,
+                "h": 197,
+                "resize": "fit"
+              }
+            }
+          }
+        ]
+      },
+      "favorited": false,
+      "retweeted": true,
+      "possibly_sensitive": false,
+      "lang": "en"
+    },
+    "retweet_count": 556,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/uGLsKU8Qkc",
+          "expanded_url": "http://www.pbs.org/wgbh/nova/shackleton/1914/team.html",
+          "display_url": "pbs.org/wgbh/nova/shac…",
+          "indices": [
+            81,
+            103
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "pourmecoffee",
+          "name": "pourmecoffee",
+          "id": 16906137,
+          "id_str": "16906137",
+          "indices": [
+            3,
+            16
+          ]
+        }
+      ],
+      "media": [
+        {
+          "id": 462748165783822340,
+          "id_str": "462748165783822336",
+          "indices": [
+            104,
+            126
+          ],
+          "media_url": "http://pbs.twimg.com/media/BmwDAUoCIAAM_H4.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/BmwDAUoCIAAM_H4.jpg",
+          "url": "http://t.co/wpdAD4iQzB",
+          "display_url": "pic.twitter.com/wpdAD4iQzB",
+          "expanded_url": "http://twitter.com/pourmecoffee/status/462748167357091840/photo/1",
+          "type": "photo",
+          "sizes": {
+            "large": {
+              "w": 464,
+              "h": 269,
+              "resize": "fit"
+            },
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "medium": {
+              "w": 464,
+              "h": 269,
+              "resize": "fit"
+            },
+            "small": {
+              "w": 340,
+              "h": 197,
+              "resize": "fit"
+            }
+          },
+          "source_status_id": 462748167357091840,
+          "source_status_id_str": "462748167357091840"
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri May 02 22:03:48 +0000 2014",
+    "id": 462351775849148400,
+    "id_str": "462351775849148416",
+    "text": "I'm worried that TDD, the web, URLs and even collaboration may be dead!  https://t.co/iQC3kXymRI",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "https://t.co/iQC3kXymRI",
+          "expanded_url": "https://medium.com/p/a39b2d94aad2",
+          "display_url": "medium.com/p/a39b2d94aad2",
+          "indices": [
+            73,
+            96
+          ]
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri May 02 18:42:52 +0000 2014",
+    "id": 462301212646178800,
+    "id_str": "462301212646178817",
+    "text": "One pooped puppy. http://t.co/d6077YmCGL",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [],
+      "media": [
+        {
+          "id": 462301212050612200,
+          "id_str": "462301212050612224",
+          "indices": [
+            18,
+            40
+          ],
+          "media_url": "http://pbs.twimg.com/media/BmpsgMOCYAA5gn1.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/BmpsgMOCYAA5gn1.jpg",
+          "url": "http://t.co/d6077YmCGL",
+          "display_url": "pic.twitter.com/d6077YmCGL",
+          "expanded_url": "http://twitter.com/CDMoyer/status/462301212646178817/photo/1",
+          "type": "photo",
+          "sizes": {
+            "large": {
+              "w": 1024,
+              "h": 1365,
+              "resize": "fit"
+            },
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "small": {
+              "w": 340,
+              "h": 453,
+              "resize": "fit"
+            },
+            "medium": {
+              "w": 600,
+              "h": 800,
+              "resize": "fit"
+            }
+          }
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri May 02 14:46:28 +0000 2014",
+    "id": 462241718855667700,
+    "id_str": "462241718855667712",
+    "text": "I might be doing gratitude wrong.  The only thanks I said last month was to myself.  https://t.co/0CMtsDePwq via @thinkup",
+    "source": "<a href=\"http://twitter.com/tweetbutton\" rel=\"nofollow\">Tweet Button</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "https://t.co/0CMtsDePwq",
+          "expanded_url": "https://cdmoyer.thinkup.com/?u=CDMoyer&n=twitter&d=2014-05-02&s=thankscount",
+          "display_url": "cdmoyer.thinkup.com/?u=CDMoyer&n=t…",
+          "indices": [
+            85,
+            108
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "thinkup",
+          "name": "ThinkUp",
+          "id": 100127476,
+          "id_str": "100127476",
+          "indices": [
+            113,
+            121
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Thu May 01 21:41:37 +0000 2014",
+    "id": 461983806241533950,
+    "id_str": "461983806241533952",
+    "text": "Have we lost something with on demand programming. Thinking about how much fun friends had talking about \"this weeks Lost episode\" together.",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Thu May 01 21:37:32 +0000 2014",
+    "id": 461982778670579700,
+    "id_str": "461982778670579712",
+    "text": "I wasn't sold on @AgentsofSHIELD at first. Now I'm anticipating episodes in a way I haven't since binge-watching became a thing.",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "AgentsofSHIELD",
+          "name": "Agents of SHIELD",
+          "id": 1112465706,
+          "id_str": "1112465706",
+          "indices": [
+            17,
+            32
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Wed Apr 30 16:11:01 +0000 2014",
+    "id": 461538220753571840,
+    "id_str": "461538220753571841",
+    "text": "The infographic is obviously designed to make a point, but it's still worth a look: http://t.co/RSD9SYEnnH",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/RSD9SYEnnH",
+          "expanded_url": "http://www.gatesnotes.com/Health/Most-Lethal-Animal-Mosquito-Week",
+          "display_url": "gatesnotes.com/Health/Most-Le…",
+          "indices": [
+            84,
+            106
+          ]
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Tue Apr 29 01:13:58 +0000 2014",
+    "id": 460950083479928800,
+    "id_str": "460950083479928832",
+    "text": "I can beat my 8-year old son 50% of the time at Magic: the Gathering... Still got it.",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 3,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri Apr 25 19:25:03 +0000 2014",
+    "id": 459775110229274600,
+    "id_str": "459775110229274624",
+    "text": "So, here's a thing I wrote for the memorial service for my Dad: http://t.co/rTM1ZnAhfD",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 2,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/rTM1ZnAhfD",
+          "expanded_url": "http://youtu.be/pFX0UxGKM5Y",
+          "display_url": "youtu.be/pFX0UxGKM5Y",
+          "indices": [
+            64,
+            86
+          ]
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri Apr 25 19:18:36 +0000 2014",
+    "id": 459773487142699000,
+    "id_str": "459773487142699008",
+    "text": "RT @nrrrdcore: What you can do: Listen to her, motivate her, RT her.",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Fri Apr 25 18:26:24 +0000 2014",
+      "id": 459760353887260700,
+      "id_str": "459760353887260672",
+      "text": "What you can do: Listen to her, motivate her, RT her.",
+      "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 18496432,
+        "id_str": "18496432",
+        "name": "Julie Ann Horvath",
+        "screen_name": "nrrrdcore",
+        "location": "Seattle",
+        "description": "Tiny Multicultural Thug. Does design and code things @andyet. Seriously ☤ Carecore. Fearless voice for How Things Should Be™.",
+        "url": "http://t.co/MpZpzEKRTn",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/MpZpzEKRTn",
+                "expanded_url": "http://julieannhorvath.com",
+                "display_url": "julieannhorvath.com",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 23627,
+        "friends_count": 676,
+        "listed_count": 703,
+        "created_at": "Wed Dec 31 02:39:14 +0000 2008",
+        "favourites_count": 10264,
+        "utc_offset": -25200,
+        "time_zone": "Pacific Time (US & Canada)",
+        "geo_enabled": true,
+        "verified": false,
+        "statuses_count": 15506,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "FFFFFF",
+        "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/606579843/q2ygld2s5eo2b6kria06.jpeg",
+        "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/606579843/q2ygld2s5eo2b6kria06.jpeg",
+        "profile_background_tile": true,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/468496006498111489/5_JeJHLF_normal.jpeg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/468496006498111489/5_JeJHLF_normal.jpeg",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/18496432/1400534209",
+        "profile_link_color": "000000",
+        "profile_sidebar_border_color": "0A0A09",
+        "profile_sidebar_fill_color": "FDF68F",
+        "profile_text_color": "0D0D0C",
+        "profile_use_background_image": false,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": true,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 25,
+      "favorite_count": 24,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [],
+        "user_mentions": []
+      },
+      "favorited": false,
+      "retweeted": true,
+      "lang": "en"
+    },
+    "retweet_count": 25,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "nrrrdcore",
+          "name": "Julie Ann Horvath",
+          "id": 18496432,
+          "id_str": "18496432",
+          "indices": [
+            3,
+            13
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "lang": "en"
+  },
+  {
+    "created_at": "Thu Apr 24 17:34:22 +0000 2014",
+    "id": 459384869437849600,
+    "id_str": "459384869437849600",
+    "text": "Reading about Mr. Darcy the heartthrob increases reading speed? http://t.co/fKT3KKDnlv",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/fKT3KKDnlv",
+          "expanded_url": "http://blog.oysterbooks.com/post/83721339244/our-graph-shows-reading-speed-on-the-y-axis-over",
+          "display_url": "blog.oysterbooks.com/post/837213392…",
+          "indices": [
+            64,
+            86
+          ]
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Thu Apr 24 04:15:23 +0000 2014",
+    "id": 459183797469474800,
+    "id_str": "459183797469474816",
+    "text": "@benedictevans I upgrade my phone every year or two.   But my family has 1st and 2nd generation iPads still in use.",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 459183169112006660,
+    "in_reply_to_status_id_str": "459183169112006656",
+    "in_reply_to_user_id": 1236101,
+    "in_reply_to_user_id_str": "1236101",
+    "in_reply_to_screen_name": "BenedictEvans",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "BenedictEvans",
+          "name": "Benedict Evans",
+          "id": 1236101,
+          "id_str": "1236101",
+          "indices": [
+            0,
+            14
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Sun Apr 20 22:52:54 +0000 2014",
+    "id": 458015480960532500,
+    "id_str": "458015480960532480",
+    "text": "@Spacekatgal warning: this can backfire. http://t.co/gELt0NIzCx",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 457989341416292350,
+    "in_reply_to_status_id_str": "457989341416292352",
+    "in_reply_to_user_id": 17264476,
+    "in_reply_to_user_id_str": "17264476",
+    "in_reply_to_screen_name": "Spacekatgal",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "Spacekatgal",
+          "name": "Brianna Wu",
+          "id": 17264476,
+          "id_str": "17264476",
+          "indices": [
+            0,
+            12
+          ]
+        }
+      ],
+      "media": [
+        {
+          "id": 458015480432042000,
+          "id_str": "458015480432041984",
+          "indices": [
+            41,
+            63
+          ],
+          "media_url": "http://pbs.twimg.com/media/BlsypxzIIAAwgnw.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/BlsypxzIIAAwgnw.jpg",
+          "url": "http://t.co/gELt0NIzCx",
+          "display_url": "pic.twitter.com/gELt0NIzCx",
+          "expanded_url": "http://twitter.com/CDMoyer/status/458015480960532480/photo/1",
+          "type": "photo",
+          "sizes": {
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "small": {
+              "w": 340,
+              "h": 453,
+              "resize": "fit"
+            },
+            "medium": {
+              "w": 600,
+              "h": 800,
+              "resize": "fit"
+            },
+            "large": {
+              "w": 768,
+              "h": 1024,
+              "resize": "fit"
+            }
+          }
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri Apr 18 19:31:47 +0000 2014",
+    "id": 457240091933814800,
+    "id_str": "457240091933814784",
+    "text": "RT @gnuconsulting: If you’ve ever made something and then been sad because not everybody loved it, go here: http://t.co/rIiRKT43kO",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Fri Apr 18 19:13:56 +0000 2014",
+      "id": 457235600706662400,
+      "id_str": "457235600706662400",
+      "text": "If you’ve ever made something and then been sad because not everybody loved it, go here: http://t.co/rIiRKT43kO",
+      "source": "<a href=\"http://twitterrific.com\" rel=\"nofollow\">Twitterrific for Mac</a>",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 15060778,
+        "id_str": "15060778",
+        "name": "David Bishop",
+        "screen_name": "gnuconsulting",
+        "location": "Buffalo, NY",
+        "description": "Feminist. Sysadmin. Dead Sexy.",
+        "url": "http://t.co/fmOVwhTMia",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/fmOVwhTMia",
+                "expanded_url": "http://gnuconsulting.com/blog/",
+                "display_url": "gnuconsulting.com/blog/",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 135,
+        "friends_count": 156,
+        "listed_count": 8,
+        "created_at": "Mon Jun 09 15:49:33 +0000 2008",
+        "favourites_count": 52,
+        "utc_offset": -14400,
+        "time_zone": "Eastern Time (US & Canada)",
+        "geo_enabled": false,
+        "verified": false,
+        "statuses_count": 4187,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "FFFFFF",
+        "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/446103428146532352/ls-_NLD2.jpeg",
+        "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/446103428146532352/ls-_NLD2.jpeg",
+        "profile_background_tile": true,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/1424244726/gnuconsulting_normal.png",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/1424244726/gnuconsulting_normal.png",
+        "profile_link_color": "0084B4",
+        "profile_sidebar_border_color": "FFFFFF",
+        "profile_sidebar_fill_color": "FFFFFF",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": true,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 1,
+      "favorite_count": 0,
+      "entities": {
+        "hashtags": [],
+        "symbols": [],
+        "urls": [
+          {
+            "url": "http://t.co/rIiRKT43kO",
+            "expanded_url": "http://awfulreviewposters.tumblr.com",
+            "display_url": "awfulreviewposters.tumblr.com",
+            "indices": [
+              89,
+              111
+            ]
+          }
+        ],
+        "user_mentions": []
+      },
+      "favorited": false,
+      "retweeted": true,
+      "possibly_sensitive": false,
+      "lang": "en"
+    },
+    "retweet_count": 1,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/rIiRKT43kO",
+          "expanded_url": "http://awfulreviewposters.tumblr.com",
+          "display_url": "awfulreviewposters.tumblr.com",
+          "indices": [
+            108,
+            130
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "gnuconsulting",
+          "name": "David Bishop",
+          "id": 15060778,
+          "id_str": "15060778",
+          "indices": [
+            3,
+            17
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Wed Apr 16 17:36:43 +0000 2014",
+    "id": 456486359528529900,
+    "id_str": "456486359528529920",
+    "text": "Dear past self, thanks for acknowledging that this was strange code that I'd wonder about later. But this comment doesn't help:\n// Muhahah",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 3,
+    "favorite_count": 6,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Wed Apr 16 16:31:42 +0000 2014",
+    "id": 456469995367575550,
+    "id_str": "456469995367575552",
+    "text": "@gnuconsulting we're watching chamber of secrets. Because CJ finished the book. It's education and fun. ;)",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 456443705688588300,
+    "in_reply_to_status_id_str": "456443705688588289",
+    "in_reply_to_user_id": 15060778,
+    "in_reply_to_user_id_str": "15060778",
+    "in_reply_to_screen_name": "gnuconsulting",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "gnuconsulting",
+          "name": "David Bishop",
+          "id": 15060778,
+          "id_str": "15060778",
+          "indices": [
+            0,
+            14
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Tue Apr 15 22:21:50 +0000 2014",
+    "id": 456195722186993660,
+    "id_str": "456195722186993665",
+    "text": "Oops.  I just read some comments on the internet.",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Tue Apr 15 16:09:21 +0000 2014",
+    "id": 456101981967228900,
+    "id_str": "456101981967228928",
+    "text": "@dlamb I did this. And I have to leave the room while she lowers my car payment because it's too confrontational for me. ;)",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 456100424680886300,
+    "in_reply_to_status_id_str": "456100424680886272",
+    "in_reply_to_user_id": 18024634,
+    "in_reply_to_user_id_str": "18024634",
+    "in_reply_to_screen_name": "dlamb",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "dlamb",
+          "name": "Devin Lamb",
+          "id": 18024634,
+          "id_str": "18024634",
+          "indices": [
+            0,
+            6
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Tue Apr 15 01:17:16 +0000 2014",
+    "id": 455877483032633340,
+    "id_str": "455877483032633344",
+    "text": "Always read graphs carefully. http://t.co/5X6BKKY7hG",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 1,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/5X6BKKY7hG",
+          "expanded_url": "http://data.heapanalytics.com/how-to-lie-with-data-visualization/",
+          "display_url": "data.heapanalytics.com/how-to-lie-wit…",
+          "indices": [
+            30,
+            52
+          ]
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon Apr 14 20:32:58 +0000 2014",
+    "id": 455805937681326100,
+    "id_str": "455805937681326080",
+    "text": "I guess I can remove the ❄ from my name now.  I'm wearing sandals.",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon Apr 14 20:30:19 +0000 2014",
+    "id": 455805268815654900,
+    "id_str": "455805268815654912",
+    "text": "Great post by @ginatrapani about \"Why doesn't @thinkup do X (yet)?\" - http://t.co/TcWhQeYPd7",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/TcWhQeYPd7",
+          "expanded_url": "http://blog.thinkup.com/post/82715980132/a-thousand-nos",
+          "display_url": "blog.thinkup.com/post/827159801…",
+          "indices": [
+            70,
+            92
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "ginatrapani",
+          "name": "Gina Trapani",
+          "id": 930061,
+          "id_str": "930061",
+          "indices": [
+            14,
+            26
+          ]
+        },
+        {
+          "screen_name": "thinkup",
+          "name": "ThinkUp",
+          "id": 100127476,
+          "id_str": "100127476",
+          "indices": [
+            46,
+            54
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon Apr 14 15:58:55 +0000 2014",
+    "id": 455736968056696800,
+    "id_str": "455736968056696832",
+    "text": "@gnuconsulting Yeah.  #1 is basically what I wear.  #2 is like what my wife just got, because she's stylish. ;)",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 455736824372019200,
+    "in_reply_to_status_id_str": "455736824372019200",
+    "in_reply_to_user_id": 15060778,
+    "in_reply_to_user_id_str": "15060778",
+    "in_reply_to_screen_name": "gnuconsulting",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "gnuconsulting",
+          "name": "David Bishop",
+          "id": 15060778,
+          "id_str": "15060778",
+          "indices": [
+            0,
+            14
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon Apr 14 15:54:20 +0000 2014",
+    "id": 455735816304607200,
+    "id_str": "455735816304607232",
+    "text": "@gnuconsulting I assumed your avatar is what you look like when somebody has messed up your live servers.  Or dropped the wrong database.",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 455731594347560960,
+    "in_reply_to_status_id_str": "455731594347560960",
+    "in_reply_to_user_id": 15060778,
+    "in_reply_to_user_id_str": "15060778",
+    "in_reply_to_screen_name": "gnuconsulting",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "gnuconsulting",
+          "name": "David Bishop",
+          "id": 15060778,
+          "id_str": "15060778",
+          "indices": [
+            0,
+            14
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon Apr 14 15:53:23 +0000 2014",
+    "id": 455735578391093250,
+    "id_str": "455735578391093249",
+    "text": "@gnuconsulting I don't think I'm hipster enough to vote for #2.  I suspect #2 fits current trends more, but I'm getting old.  My vote: #1",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 455730132498788350,
+    "in_reply_to_status_id_str": "455730132498788352",
+    "in_reply_to_user_id": 15060778,
+    "in_reply_to_user_id_str": "15060778",
+    "in_reply_to_screen_name": "gnuconsulting",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "gnuconsulting",
+          "name": "David Bishop",
+          "id": 15060778,
+          "id_str": "15060778",
+          "indices": [
+            0,
+            14
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Sun Apr 13 21:16:43 +0000 2014",
+    "id": 455454561214271500,
+    "id_str": "455454561214271488",
+    "text": "If real life was like scrabble, I'd use the words suq, qat and qi a lot more. (My phone thinks they're all typos.)",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri Apr 11 20:56:02 +0000 2014",
+    "id": 454724577382244350,
+    "id_str": "454724577382244352",
+    "text": "@kevinpurdy that sounds awesome.",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 454724187777560600,
+    "in_reply_to_status_id_str": "454724187777560577",
+    "in_reply_to_user_id": 14687182,
+    "in_reply_to_user_id_str": "14687182",
+    "in_reply_to_screen_name": "kevinpurdy",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "kevinpurdy",
+          "name": "Kevin Purdy",
+          "id": 14687182,
+          "id_str": "14687182",
+          "indices": [
+            0,
+            11
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri Apr 11 20:41:55 +0000 2014",
+    "id": 454721027231084540,
+    "id_str": "454721027231084544",
+    "text": "It warms my geeky parental heart when Charlie runs up and whispers in my ear, \"Dad, &lt;Harry potter spoiler about Sirius&gt;, did you know!?\"",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri Apr 11 19:39:23 +0000 2014",
+    "id": 454705290332500000,
+    "id_str": "454705290332499968",
+    "text": "@kevinpurdy I want to challenge that comparison, but there are copious footnotes.  But, the end is so neat.  I'm torn. (like a power towel)",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 454678729495564300,
+    "in_reply_to_status_id_str": "454678729495564288",
+    "in_reply_to_user_id": 14687182,
+    "in_reply_to_user_id_str": "14687182",
+    "in_reply_to_screen_name": "kevinpurdy",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "kevinpurdy",
+          "name": "Kevin Purdy",
+          "id": 14687182,
+          "id_str": "14687182",
+          "indices": [
+            0,
+            11
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri Apr 11 13:07:03 +0000 2014",
+    "id": 454606554801524740,
+    "id_str": "454606554801524736",
+    "text": "RT @anttikettunen: #heartbleed explained simply: “@villesundberg: XKCD explains Heartbleed. http://t.co/fvJbVkTLOp http://t.co/Mvfiz9oE7y”",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Fri Apr 11 07:41:53 +0000 2014",
+      "id": 454524723582750700,
+      "id_str": "454524723582750720",
+      "text": "#heartbleed explained simply: “@villesundberg: XKCD explains Heartbleed. http://t.co/fvJbVkTLOp http://t.co/Mvfiz9oE7y”",
+      "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+      "truncated": false,
+      "in_reply_to_status_id": 454514620271587300,
+      "in_reply_to_status_id_str": "454514620271587329",
+      "in_reply_to_user_id": 30264494,
+      "in_reply_to_user_id_str": "30264494",
+      "in_reply_to_screen_name": "villesundberg",
+      "user": {
+        "id": 87373548,
+        "id_str": "87373548",
+        "name": "Antti Kettunen",
+        "screen_name": "anttikettunen",
+        "location": "Finland",
+        "description": "Enjoying my life as a husband, father & Christian. Drupal Architect & Open Source Champion @Tietocorp / Partner @Bank4Hope",
+        "url": null,
+        "entities": {
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 243,
+        "friends_count": 470,
+        "listed_count": 27,
+        "created_at": "Wed Nov 04 05:43:40 +0000 2009",
+        "favourites_count": 10,
+        "utc_offset": 10800,
+        "time_zone": "Helsinki",
+        "geo_enabled": true,
+        "verified": false,
+        "statuses_count": 2045,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "1A1B1F",
+        "profile_background_image_url": "http://abs.twimg.com/images/themes/theme9/bg.gif",
+        "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme9/bg.gif",
+        "profile_background_tile": false,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/378800000571135862/08f17a125528db452c0c8b1009e100d4_normal.jpeg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000571135862/08f17a125528db452c0c8b1009e100d4_normal.jpeg",
+        "profile_link_color": "2FC2EF",
+        "profile_sidebar_border_color": "181A1E",
+        "profile_sidebar_fill_color": "252429",
+        "profile_text_color": "666666",
+        "profile_use_background_image": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": false,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 16,
+      "favorite_count": 6,
+      "entities": {
+        "hashtags": [
+          {
+            "text": "heartbleed",
+            "indices": [
+              0,
+              11
+            ]
+          }
+        ],
+        "symbols": [],
+        "urls": [
+          {
+            "url": "http://t.co/fvJbVkTLOp",
+            "expanded_url": "http://www.xkcd.com/1354/",
+            "display_url": "xkcd.com/1354/",
+            "indices": [
+              73,
+              95
+            ]
+          }
+        ],
+        "user_mentions": [
+          {
+            "screen_name": "villesundberg",
+            "name": "Ville Sundberg",
+            "id": 30264494,
+            "id_str": "30264494",
+            "indices": [
+              31,
+              45
+            ]
+          }
+        ],
+        "media": [
+          {
+            "id": 454514620275781600,
+            "id_str": "454514620275781633",
+            "indices": [
+              96,
+              118
+            ],
+            "media_url": "http://pbs.twimg.com/media/Bk7Co5bCcAEPVFJ.png",
+            "media_url_https": "https://pbs.twimg.com/media/Bk7Co5bCcAEPVFJ.png",
+            "url": "http://t.co/Mvfiz9oE7y",
+            "display_url": "pic.twitter.com/Mvfiz9oE7y",
+            "expanded_url": "http://twitter.com/villesundberg/status/454514620271587329/photo/1",
+            "type": "photo",
+            "sizes": {
+              "thumb": {
+                "w": 150,
+                "h": 150,
+                "resize": "crop"
+              },
+              "large": {
+                "w": 640,
+                "h": 1364,
+                "resize": "fit"
+              },
+              "medium": {
+                "w": 563,
+                "h": 1200,
+                "resize": "fit"
+              },
+              "small": {
+                "w": 319,
+                "h": 680,
+                "resize": "fit"
+              }
+            },
+            "source_status_id": 454514620271587300,
+            "source_status_id_str": "454514620271587329"
+          }
+        ]
+      },
+      "favorited": false,
+      "retweeted": true,
+      "possibly_sensitive": false,
+      "lang": "en"
+    },
+    "retweet_count": 16,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [
+        {
+          "text": "heartbleed",
+          "indices": [
+            19,
+            30
+          ]
+        }
+      ],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/fvJbVkTLOp",
+          "expanded_url": "http://www.xkcd.com/1354/",
+          "display_url": "xkcd.com/1354/",
+          "indices": [
+            92,
+            114
+          ]
+        }
+      ],
+      "user_mentions": [
+        {
+          "screen_name": "anttikettunen",
+          "name": "Antti Kettunen",
+          "id": 87373548,
+          "id_str": "87373548",
+          "indices": [
+            3,
+            17
+          ]
+        },
+        {
+          "screen_name": "villesundberg",
+          "name": "Ville Sundberg",
+          "id": 30264494,
+          "id_str": "30264494",
+          "indices": [
+            50,
+            64
+          ]
+        }
+      ],
+      "media": [
+        {
+          "id": 454514620275781600,
+          "id_str": "454514620275781633",
+          "indices": [
+            115,
+            137
+          ],
+          "media_url": "http://pbs.twimg.com/media/Bk7Co5bCcAEPVFJ.png",
+          "media_url_https": "https://pbs.twimg.com/media/Bk7Co5bCcAEPVFJ.png",
+          "url": "http://t.co/Mvfiz9oE7y",
+          "display_url": "pic.twitter.com/Mvfiz9oE7y",
+          "expanded_url": "http://twitter.com/villesundberg/status/454514620271587329/photo/1",
+          "type": "photo",
+          "sizes": {
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "large": {
+              "w": 640,
+              "h": 1364,
+              "resize": "fit"
+            },
+            "medium": {
+              "w": 563,
+              "h": 1200,
+              "resize": "fit"
+            },
+            "small": {
+              "w": 319,
+              "h": 680,
+              "resize": "fit"
+            }
+          },
+          "source_status_id": 454514620271587300,
+          "source_status_id_str": "454514620271587329"
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri Apr 11 02:57:45 +0000 2014",
+    "id": 454453219532365800,
+    "id_str": "454453219532365824",
+    "text": "Fallon is becoming must see TV for me.  Evoking memories of watching Letterman with my mom 20 years ago when that was fresh and hip.",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Thu Apr 10 14:32:39 +0000 2014",
+    "id": 454265709208797200,
+    "id_str": "454265709208797184",
+    "text": "You ever click the album view in your music player and reminisce about getting a new (cd|album|tape) and reading thorough the liner notes?",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Wed Apr 09 19:52:18 +0000 2014",
+    "id": 453983762066309100,
+    "id_str": "453983762066309122",
+    "text": "@christi3k Because we say The Internet.  \"I'm going to put these cat pics on the Internet with the Electricity.\"",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 453982310119903200,
+    "in_reply_to_status_id_str": "453982310119903232",
+    "in_reply_to_user_id": 14111858,
+    "in_reply_to_user_id_str": "14111858",
+    "in_reply_to_screen_name": "christi3k",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "christi3k",
+          "name": "Christie Koehler Ⓥ",
+          "id": 14111858,
+          "id_str": "14111858",
+          "indices": [
+            0,
+            10
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Tue Apr 08 23:35:37 +0000 2014",
+    "id": 453677575915569150,
+    "id_str": "453677575915569152",
+    "text": "Programming-based roguelike.  Awesome.  http://t.co/efDwABo6Ps",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 2,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/efDwABo6Ps",
+          "expanded_url": "http://alexnisnevich.github.io/untrusted/",
+          "display_url": "alexnisnevich.github.io/untrusted/",
+          "indices": [
+            40,
+            62
+          ]
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Tue Apr 08 19:42:02 +0000 2014",
+    "id": 453618790723375100,
+    "id_str": "453618790723375104",
+    "text": "Going to Chipotle and skipping the chips is a shining example of self control, right?",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Tue Apr 08 15:00:48 +0000 2014",
+    "id": 453548015320842240,
+    "id_str": "453548015320842240",
+    "text": "RT @BarackObama: Retweet if you believe women deserve the same pay as men for the same work. #FairFutureNow",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Tue Apr 08 14:37:38 +0000 2014",
+      "id": 453542186630795260,
+      "id_str": "453542186630795264",
+      "text": "Retweet if you believe women deserve the same pay as men for the same work. #FairFutureNow",
+      "source": "web",
+      "truncated": false,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 813286,
+        "id_str": "813286",
+        "name": "Barack Obama",
+        "screen_name": "BarackObama",
+        "location": "Washington, DC",
+        "description": "This account is run by Organizing for Action staff. Tweets from the President are signed -bo.",
+        "url": "http://t.co/O5Woad92z1",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "http://t.co/O5Woad92z1",
+                "expanded_url": "http://www.barackobama.com",
+                "display_url": "barackobama.com",
+                "indices": [
+                  0,
+                  22
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 43223708,
+        "friends_count": 650574,
+        "listed_count": 207087,
+        "created_at": "Mon Mar 05 22:08:25 +0000 2007",
+        "favourites_count": 5,
+        "utc_offset": -14400,
+        "time_zone": "Eastern Time (US & Canada)",
+        "geo_enabled": false,
+        "verified": true,
+        "statuses_count": 11804,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": true,
+        "profile_background_color": "77B0DC",
+        "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/451819093436268544/kLbRvwBg.png",
+        "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/451819093436268544/kLbRvwBg.png",
+        "profile_background_tile": false,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/451007105391022080/iu1f7brY_normal.png",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/451007105391022080/iu1f7brY_normal.png",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/813286/1398357410",
+        "profile_link_color": "2574AD",
+        "profile_sidebar_border_color": "FFFFFF",
+        "profile_sidebar_fill_color": "C2E0F6",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": false,
+        "follow_request_sent": false,
+        "notifications": false
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "retweet_count": 11510,
+      "favorite_count": 4010,
+      "entities": {
+        "hashtags": [
+          {
+            "text": "FairFutureNow",
+            "indices": [
+              76,
+              90
+            ]
+          }
+        ],
+        "symbols": [],
+        "urls": [],
+        "user_mentions": []
+      },
+      "favorited": false,
+      "retweeted": true,
+      "lang": "en"
+    },
+    "retweet_count": 11510,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [
+        {
+          "text": "FairFutureNow",
+          "indices": [
+            93,
+            107
+          ]
+        }
+      ],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "BarackObama",
+          "name": "Barack Obama",
+          "id": 813286,
+          "id_str": "813286",
+          "indices": [
+            3,
+            15
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": true,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri Apr 04 20:06:55 +0000 2014",
+    "id": 452175503248461800,
+    "id_str": "452175503248461824",
+    "text": "@glebs282 1) when will the next Nintendo console be released? \n1a) what storage media will it use.  \n\nUse your future goggles!",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 452175160913977340,
+    "in_reply_to_status_id_str": "452175160913977344",
+    "in_reply_to_user_id": 79880959,
+    "in_reply_to_user_id_str": "79880959",
+    "in_reply_to_screen_name": "glebs282",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "glebs282",
+          "name": "gleebs",
+          "id": 79880959,
+          "id_str": "79880959",
+          "indices": [
+            0,
+            9
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Fri Apr 04 19:24:43 +0000 2014",
+    "id": 452164883270746100,
+    "id_str": "452164883270746112",
+    "text": "Why didn't we have tests on this when I was a kid!? http://t.co/hdtyvB2s5p",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [],
+      "media": [
+        {
+          "id": 452164882415513600,
+          "id_str": "452164882415513600",
+          "indices": [
+            52,
+            74
+          ],
+          "media_url": "http://pbs.twimg.com/media/BkZpkJxIcAA17an.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/BkZpkJxIcAA17an.jpg",
+          "url": "http://t.co/hdtyvB2s5p",
+          "display_url": "pic.twitter.com/hdtyvB2s5p",
+          "expanded_url": "http://twitter.com/CDMoyer/status/452164883270746112/photo/1",
+          "type": "photo",
+          "sizes": {
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "small": {
+              "w": 340,
+              "h": 453,
+              "resize": "fit"
+            },
+            "medium": {
+              "w": 600,
+              "h": 800,
+              "resize": "fit"
+            },
+            "large": {
+              "w": 768,
+              "h": 1024,
+              "resize": "fit"
+            }
+          }
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Wed Apr 02 22:55:49 +0000 2014",
+    "id": 451493233655181300,
+    "id_str": "451493233655181313",
+    "text": "@josephjpeters That favorite was ironic.",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 451492340386267140,
+    "in_reply_to_status_id_str": "451492340386267137",
+    "in_reply_to_user_id": 221618035,
+    "in_reply_to_user_id_str": "221618035",
+    "in_reply_to_screen_name": "josephjpeters",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "josephjpeters",
+          "name": "Joe Peters",
+          "id": 221618035,
+          "id_str": "221618035",
+          "indices": [
+            0,
+            14
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Wed Apr 02 22:06:00 +0000 2014",
+    "id": 451480694548488200,
+    "id_str": "451480694548488192",
+    "text": "@agent37x Chromechast never appealed to me, but the amazon thing seems like it's got potential.  Assuming it gets that hot game… Towerfall?",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 451480420253581300,
+    "in_reply_to_status_id_str": "451480420253581312",
+    "in_reply_to_user_id": 267886029,
+    "in_reply_to_user_id_str": "267886029",
+    "in_reply_to_screen_name": "agent37x",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "agent37x",
+          "name": "Tom R",
+          "id": 267886029,
+          "id_str": "267886029",
+          "indices": [
+            0,
+            9
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Wed Apr 02 22:01:43 +0000 2014",
+    "id": 451479618210365440,
+    "id_str": "451479618210365440",
+    "text": "Just me?  In vim, replacing a line with another in several places:\n/thing&lt;enter&gt;\np\ndd\nn\np \n!Doh! My buffer is now the thing I was replacing.",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Wed Apr 02 21:59:00 +0000 2014",
+    "id": 451478934270390300,
+    "id_str": "451478934270390272",
+    "text": "@agent37x I think I have a 2nd gen roku, and I think it's crashed or bugged out twice in several 100s of hours of use.  (netflix and amazon)",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 451478531579858940,
+    "in_reply_to_status_id_str": "451478531579858944",
+    "in_reply_to_user_id": 267886029,
+    "in_reply_to_user_id_str": "267886029",
+    "in_reply_to_screen_name": "agent37x",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "agent37x",
+          "name": "Tom R",
+          "id": 267886029,
+          "id_str": "267886029",
+          "indices": [
+            0,
+            9
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Wed Apr 02 21:48:09 +0000 2014",
+    "id": 451476203312930800,
+    "id_str": "451476203312930816",
+    "text": "So.  Amazon Fire TV is Ouya + Roku for the price of one?",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Wed Apr 02 17:11:35 +0000 2014",
+    "id": 451406601291694100,
+    "id_str": "451406601291694080",
+    "text": "@livercat @ericnagel @Farchyld @jaygerland this is probably what that stickies app on old macs was for.",
+    "source": "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>",
+    "truncated": false,
+    "in_reply_to_status_id": 451394181760811000,
+    "in_reply_to_status_id_str": "451394181760811008",
+    "in_reply_to_user_id": 8016142,
+    "in_reply_to_user_id_str": "8016142",
+    "in_reply_to_screen_name": "livercat",
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 0,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": [
+        {
+          "screen_name": "livercat",
+          "name": "livercat",
+          "id": 8016142,
+          "id_str": "8016142",
+          "indices": [
+            0,
+            9
+          ]
+        },
+        {
+          "screen_name": "ericnagel",
+          "name": "Eric Nagel",
+          "id": 2522211,
+          "id_str": "2522211",
+          "indices": [
+            10,
+            20
+          ]
+        },
+        {
+          "screen_name": "Farchyld",
+          "name": "Bobby K.",
+          "id": 16548222,
+          "id_str": "16548222",
+          "indices": [
+            21,
+            30
+          ]
+        },
+        {
+          "screen_name": "jaygerland",
+          "name": "Jay Gerland",
+          "id": 1068451,
+          "id_str": "1068451",
+          "indices": [
+            31,
+            42
+          ]
+        }
+      ]
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Wed Apr 02 15:01:41 +0000 2014",
+    "id": 451373913025437700,
+    "id_str": "451373913025437696",
+    "text": "Does anyone else regularly use their browser's address bar as a place to super temporarily stick notes or paste text to look at?",
+    "source": "<a href=\"http://itunes.apple.com/us/app/twitter/id409789998?mt=12\" rel=\"nofollow\">Twitter for Mac</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 12145232,
+      "id_str": "12145232",
+      "name": "Chris Moyer",
+      "screen_name": "CDMoyer",
+      "location": "Buffalo, NY",
+      "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+      "url": "http://t.co/8NCBQ5WBQU",
+      "entities": {
+        "url": {
+          "urls": [
+            {
+              "url": "http://t.co/8NCBQ5WBQU",
+              "expanded_url": "http://inarow.net/",
+              "display_url": "inarow.net",
+              "indices": [
+                0,
+                22
+              ]
+            }
+          ]
+        },
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 443,
+      "friends_count": 245,
+      "listed_count": 38,
+      "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+      "favourites_count": 169,
+      "utc_offset": -14400,
+      "time_zone": "Eastern Time (US & Canada)",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 937,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "FFFFFF",
+      "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+      "profile_background_tile": true,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+      "profile_link_color": "101A73",
+      "profile_sidebar_border_color": "FFFFFF",
+      "profile_sidebar_fill_color": "C0DFEC",
+      "profile_text_color": "000000",
+      "profile_use_background_image": true,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 1,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "lang": "en"
+  }
+]

--- a/webapp/plugins/twitter/tests/data/testoftwittercrawler/cdmoyer/users_show_13771532.json
+++ b/webapp/plugins/twitter/tests/data/testoftwittercrawler/cdmoyer/users_show_13771532.json
@@ -1,0 +1,98 @@
+{
+  "id": 12145232,
+  "id_str": "12145232",
+  "name": "Chris Moyer",
+  "screen_name": "CDMoyer",
+  "location": "Buffalo, NY",
+  "description": "I love building things on the internet. \nFan of books, video games, music. \nI might tweet puppy or kid pics.",
+  "url": "http://t.co/8NCBQ5WBQU",
+  "entities": {
+    "url": {
+      "urls": [
+        {
+          "url": "http://t.co/8NCBQ5WBQU",
+          "expanded_url": "http://inarow.net/",
+          "display_url": "inarow.net",
+          "indices": [
+            0,
+            22
+          ]
+        }
+      ]
+    },
+    "description": {
+      "urls": []
+    }
+  },
+  "protected": false,
+  "followers_count": 443,
+  "friends_count": 245,
+  "listed_count": 38,
+  "created_at": "Sat Jan 12 05:50:44 +0000 2008",
+  "favourites_count": 169,
+  "utc_offset": -14400,
+  "time_zone": "Eastern Time (US & Canada)",
+  "geo_enabled": true,
+  "verified": false,
+  "statuses_count": 937,
+  "lang": "en",
+  "status": {
+    "created_at": "Wed May 28 15:24:30 +0000 2014",
+    "id": 471673373765156860,
+    "id_str": "471673373765156864",
+    "text": "Ever found yourself googling \"add commas to a number in javascript?\"  You have?  Me too.  This is a better solution: http://t.co/HpQrJ0u6j6",
+    "source": "<a href=\"http://bufferapp.com\" rel=\"nofollow\">Buffer</a>",
+    "truncated": false,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweet_count": 0,
+    "favorite_count": 2,
+    "entities": {
+      "hashtags": [],
+      "symbols": [],
+      "urls": [
+        {
+          "url": "http://t.co/HpQrJ0u6j6",
+          "expanded_url": "http://bit.ly/1gxe53m",
+          "display_url": "bit.ly/1gxe53m",
+          "indices": [
+            117,
+            139
+          ]
+        }
+      ],
+      "user_mentions": []
+    },
+    "favorited": false,
+    "retweeted": false,
+    "possibly_sensitive": false,
+    "lang": "en"
+  },
+  "contributors_enabled": false,
+  "is_translator": false,
+  "is_translation_enabled": false,
+  "profile_background_color": "FFFFFF",
+  "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+  "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/689573892/616919f89b717f8c18802b9cf7caa32c.jpeg",
+  "profile_background_tile": true,
+  "profile_image_url": "http://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+  "profile_image_url_https": "https://pbs.twimg.com/profile_images/421641487051272192/IfEg0PgG_normal.jpeg",
+  "profile_banner_url": "https://pbs.twimg.com/profile_banners/12145232/1400821585",
+  "profile_link_color": "101A73",
+  "profile_sidebar_border_color": "FFFFFF",
+  "profile_sidebar_fill_color": "C0DFEC",
+  "profile_text_color": "000000",
+  "profile_use_background_image": true,
+  "default_profile": false,
+  "default_profile_image": false,
+  "following": false,
+  "follow_request_sent": false,
+  "notifications": false
+}


### PR DESCRIPTION
Using many twitter clients, images end up in the entities->media with the url and the image source,
such as the official twitter client.  These photos are then replaced with a t.co short link
which is not easily/possibly expanded to the actual image url.  But this data is available at
crawl time for us to grab and store properly in the links table.

References #1765
