### PR TITLE
Add clearer first-run welcome messages

### DIFF
--- a/webapp/_lib/controller/class.InsightStreamController.php
+++ b/webapp/_lib/controller/class.InsightStreamController.php
@@ -182,11 +182,12 @@ class InsightStreamController extends ThinkUpController {
                 $site_root_path = $config->getValue('site_root_path');
                 $plugin_link = '<a href="'.$site_root_path.'account/?p=';
                 if (sizeof($owned_instances) > 0) {
-                    $this->addToView('message_header', "ThinkUp doesn't have any insights for you yet.");
                     if (!Utils::isThinkUpLLC()) {
+                        $this->addToView('message_header', "ThinkUp doesn't have any insights for you yet.");
                         $this->addToView('message_body', "Check back later, ".
                         "or <a href=\"".$site_root_path."crawler/updatenow.php\">update your ThinkUp data now</a>.");
                     } else {
+                        $this->addToView('message_header', "ThinkUp is analyzing your first insights.");
                         $this->addToView('message_body', "Check back later, or add another ".$plugin_link.
                         "twitter\">Twitter</a> or "."".$plugin_link."facebook\">Facebook</a> account.");
                     }

--- a/webapp/_lib/view/_firstrun.tpl
+++ b/webapp/_lib/view/_firstrun.tpl
@@ -1,0 +1,50 @@
+  <div class="container">
+    <div class="stream">
+      <div class="date-group today">
+          <div class="date-marker">
+              <div class="absolute">Today</div>
+          </div>
+
+          <div class="panel panel-default insight insight-default insight-purple insight-hero">
+            <div class="panel-heading">
+              <h2 class="panel-title insight-color-text">Watch your inbox.</h2>
+            </div>
+            <div class="panel-desktop-right">
+              <div class="panel-body">
+                <div class="panel-body-inner">
+                  <div style="float: left; padding-right: 14px;">
+                    <i class="fa fa-cog text-muted fa-spin fa-5x"></i>
+                  </div>
+                  <p>ThinkUp is analyzing your very first insights and will email them to you soon. Expect an email from <strong>team@thinkup.com</strong>.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="panel panel-default insight insight-default insight-bubblegum">
+            <div class="panel-heading">
+              <h2 class="panel-title insight-color-text">For Your Eyes Only?</h2>
+            </div>
+            <div class="panel-desktop-right">
+              <div class="panel-body">
+                <div class="panel-body-inner">
+                  <p>By default your insights are public but you can make them private at anytime. For each <a href="http://username.thinkup.com/account/?p=twitter">Twitter</a> or <a href="http://username.thinkup.com/account/?p=facebook">Facebook</a> account you've connected to ThinkUp choose "Everyone" or "Just You" to determine who can see.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="panel panel-default insight insight-default insight-sandalwood">
+            <div class="panel-heading">
+              <h2 class="panel-title insight-color-text">On the daily.</h2>
+            </div>
+            <div class="panel-desktop-right">
+              <div class="panel-body">
+                <div class="panel-body-inner">
+                  <p>We think you'll love the daily email of fresh insights from ThinkUp but if once a week is more your style we've got you covered. The <a href="https://www.thinkup.com/join/user/settings.php">choice</a> is yours.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+      </div>
+    </div>

--- a/webapp/_lib/view/insights.tpl
+++ b/webapp/_lib/view/insights.tpl
@@ -3,10 +3,14 @@
 
 <div class="container">
   {if $message_header}
+    {if !isset($thinkupllc_endpoint)}
     <div class="no-insights">
     {$message_header}
     {$message_body}
     </div>
+    {else}
+      {include file="_firstrun.tpl"}
+    {/if}
   {/if}
   <div class="stream{if count($insights) eq 1} stream-permalink{/if}">
 


### PR DESCRIPTION
They're sort of faux-insights in a new template, for users on thinkup.com.
