### PR TITLE
Added chart-ready callback for image generation

### DIFF
--- a/webapp/plugins/insightsgenerator/view/_barchart.tpl
+++ b/webapp/plugins/insightsgenerator/view/_barchart.tpl
@@ -38,6 +38,9 @@
                   }
                 }
             });
+            if (typeof window.callPhantom !== "undefined" && window.callPhantom !== null) {
+              google.visualization.events.addListener(view_duration_chart_{/literal}{$i->id}{literal}, 'ready', window.callPhantom)
+            }
             view_duration_chart_{/literal}{$i->id}{literal}.draw();
         }
         {/literal}

--- a/webapp/plugins/insightsgenerator/view/_columnchart.tpl
+++ b/webapp/plugins/insightsgenerator/view/_columnchart.tpl
@@ -39,6 +39,9 @@
                   }
                 }
             });
+            if (typeof window.callPhantom !== "undefined" && window.callPhantom !== null) {
+              google.visualization.events.addListener(view_duration_chart_{/literal}{$i->id}{literal}, 'ready', window.callPhantom)
+            }
             view_duration_chart_{/literal}{$i->id}{literal}.draw();
         }
         {/literal}

--- a/webapp/plugins/insightsgenerator/view/_counthistorychart.tpl
+++ b/webapp/plugins/insightsgenerator/view/_counthistorychart.tpl
@@ -46,6 +46,9 @@ function drawChart{/literal}{$i->id}() {literal}{
           },
       },
   });
+  if (typeof window.callPhantom !== "undefined" && window.callPhantom !== null) {
+    google.visualization.events.addListener(count_history_chart_{/literal}{$i->id}{literal}, 'ready', window.callPhantom)
+  }
   count_history_chart_{/literal}{$i->id}{literal}.draw();
   }
   {/literal}

--- a/webapp/plugins/insightsgenerator/view/clickspike.tpl
+++ b/webapp/plugins/insightsgenerator/view/clickspike.tpl
@@ -38,6 +38,9 @@
                   },
                 }
             });
+            if (typeof window.callPhantom !== "undefined" && window.callPhantom !== null) {
+              google.visualization.events.addListener(click_totals_chart_{/literal}{$i->id}{literal}, 'ready', window.callPhantom)
+            }
             click_totals_chart_{/literal}{$i->id}{literal}.draw();
         }
         {/literal}

--- a/webapp/plugins/insightsgenerator/view/genderanalysis.tpl
+++ b/webapp/plugins/insightsgenerator/view/genderanalysis.tpl
@@ -28,6 +28,9 @@
           	}
 
             });
+            if (typeof window.callPhantom !== "undefined" && window.callPhantom !== null) {
+              google.visualization.events.addListener(gender_analysis_chart_{/literal}{$i->id}{literal}, 'ready', window.callPhantom)
+            }
             gender_analysis_chart_{/literal}{$i->id}{literal}.draw();
         }
         {/literal}

--- a/webapp/plugins/insightsgenerator/view/likespike.tpl
+++ b/webapp/plugins/insightsgenerator/view/likespike.tpl
@@ -34,6 +34,9 @@
                   },
                 }
             });
+            if (typeof window.callPhantom !== "undefined" && window.callPhantom !== null) {
+              google.visualization.events.addListener(likes_chart_{/literal}{$i->id}{literal}, 'ready', window.callPhantom)
+            }
             likes_chart_{/literal}{$i->id}{literal}.draw();
         }
         {/literal}

--- a/webapp/plugins/insightsgenerator/view/minutesviewed.tpl
+++ b/webapp/plugins/insightsgenerator/view/minutesviewed.tpl
@@ -34,6 +34,9 @@
                   },
                 }
             });
+            if (typeof window.callPhantom !== "undefined" && window.callPhantom !== null) {
+              google.visualization.events.addListener(likes_chart_{/literal}{$i->id}{literal}, 'ready', window.callPhantom)
+            }
             likes_chart_{/literal}{$i->id}{literal}.draw();
         }
         {/literal}

--- a/webapp/plugins/insightsgenerator/view/splitopinions.tpl
+++ b/webapp/plugins/insightsgenerator/view/splitopinions.tpl
@@ -27,6 +27,9 @@
                   colors: ['#7DD3F0', '#E6B8D4']
                 }
             });
+            if (typeof window.callPhantom !== "undefined" && window.callPhantom !== null) {
+              google.visualization.events.addListener(likes_dislikes_chart_{/literal}{$i->id}{literal}, 'ready', window.callPhantom)
+            }
             likes_dislikes_chart_{/literal}{$i->id}{literal}.draw();
         }
         {/literal}

--- a/webapp/plugins/insightsgenerator/view/subscriberchange.tpl
+++ b/webapp/plugins/insightsgenerator/view/subscriberchange.tpl
@@ -31,6 +31,9 @@
                   }
                 }
             });
+            if (typeof window.callPhantom !== "undefined" && window.callPhantom !== null) {
+              google.visualization.events.addListener(sub_change_chart_{/literal}{$i->id}{literal}, 'ready', window.callPhantom)
+            }
             sub_change_chart_{/literal}{$i->id}{literal}.draw();
         }
         {/literal}

--- a/webapp/plugins/insightsgenerator/view/viewduration.tpl
+++ b/webapp/plugins/insightsgenerator/view/viewduration.tpl
@@ -30,6 +30,9 @@
                   }
                 }
             });
+            if (typeof window.callPhantom !== "undefined" && window.callPhantom !== null) {
+              google.visualization.events.addListener(view_duration_chart_{/literal}{$i->id}{literal}, 'ready', window.callPhantom)
+            }
             view_duration_chart_{/literal}{$i->id}{literal}.draw();
         }
         {/literal}

--- a/webapp/plugins/insightsgenerator/view/viewspike.tpl
+++ b/webapp/plugins/insightsgenerator/view/viewspike.tpl
@@ -33,6 +33,9 @@
                   },
                 }
             });
+            if (typeof window.callPhantom !== "undefined" && window.callPhantom !== null) {
+              google.visualization.events.addListener(likes_chart_{/literal}{$i->id}{literal}, 'ready', window.callPhantom)
+            }
             likes_chart_{/literal}{$i->id}{literal}.draw();
         }
         {/literal}

--- a/webapp/plugins/insightsgenerator/view/weeklygraph.tpl
+++ b/webapp/plugins/insightsgenerator/view/weeklygraph.tpl
@@ -59,6 +59,9 @@
                   },
                 }
             });
+            if (typeof window.callPhantom !== "undefined" && window.callPhantom !== null) {
+              google.visualization.events.addListener(response_rates_chart_{/literal}{$i->id}{literal}, 'ready', window.callPhantom)
+            }
             response_rates_chart_{/literal}{$i->id}{literal}.draw();
         }
         {/literal}


### PR DESCRIPTION
I've tested the basics of this callback locally, but I won't be able to properly test this until the code is live somewhere publicly accessible. It's harmless code, though — basically, if window.callPhantom isn't defined (which it won't be on any normal browser), it's completely ignored. But it's injected in slimerjs/phantomjs, so it'll run when it's loaded via slimer. 

Then it should fire that callback when the chart is rendered. Right now the server has a 6-second timeout, so if the chart doesn't fire the callback before then (it should), it'll just take the screenshot of what's rendered. I think I should be able to test this on staging by hard-coding my user/pass into the url, so... yeah, let me know if that works for you! 
