### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ except for the external libraries listed below.
 
 ## External Libraries
 
-- [Facebook Platform PHP5 SDK](https://github.com/facebook/php-sdk) (Included) 
+- [Facebook Platform PHP5 SDK](https://github.com/facebook/facebook-php-sdk) (Included) 
 - [SimpleTest](http://www.simpletest.org/) (Included)
 - [Smarty](http://smarty.net) (Included)
 - [Twitter OAuth by Abraham Williams](http://github.com/abraham/twitteroauth) (Included)
-- [ReCAPTCHA PHP library](http://recaptcha.net/plugins/php/) (Included)
+- [ReCAPTCHA PHP library](https://developers.google.com/recaptcha/docs/php) (Included)
 - [Twitter Text (PHP Edition)](https://github.com/ngnpope/twitter-text-php) (Included)
 - [Mandrill Library (PHP Edition)](https://mandrillapp.com/api/docs/index.php.html) (Included)


### PR DESCRIPTION
Fix links to Facebook Platform PHP5 SDK and ReCAPTCHA PHP library.

**Facebook Platform PHP5 SDK**
Old: https://github.com/facebook/php-sdk -> 404
New: https://github.com/facebook/facebook-php-sdk -> Works!

> Note: https://github.com/facebook/facebook-php-sdk-v4 is the latest version.

**ReCAPTCHA PHP library**
Old: http://recaptcha.net/plugins/php/ -> 404
New: https://developers.google.com/recaptcha/docs/php -> Works!

> Note: http://recaptcha.net/ redirects to https://developers.google.com/recaptcha/
