### PR TITLE
Issue 2127: Most-shared/retweeted post

### DIFF
--- a/webapp/_lib/view/insights.tpl
+++ b/webapp/_lib/view/insights.tpl
@@ -68,7 +68,7 @@
 
 <div class="panel panel-default insight insight-default insight-{$i->slug|replace:'_':'-'}
   {if $i->emphasis > '1'}insight-hero{/if} insight-{$color|strip} {if
-  (isset($i->related_data.hero_image) and $i->emphasis > '1') | $i->slug eq 'weekly_graph'}insight-wide{/if}" id="insight-{$i->id}">
+  (isset($i->related_data.hero_image) and $i->emphasis > '1') | $i->slug eq 'weekly_graph'}insight-wide{/if} {if $i->slug|strstr:'eoy'}insight-eoy insight-wide{/if}" id="insight-{$i->id}">
   <div class="panel-heading{if $i->header_image neq ''} panel-heading-illustrated{/if}">
     <h2 class="panel-title">{$i->headline}</h2>
     {if ($i->slug eq 'posts_on_this_day_popular_flashback')}

--- a/webapp/plugins/insightsgenerator/insights/eoymostretweetedpost.php
+++ b/webapp/plugins/insightsgenerator/insights/eoymostretweetedpost.php
@@ -1,0 +1,171 @@
+<?php
+/*
+ Plugin Name: Most retweeted post (End of Year)
+ Description: User's most retweeted post in current year.
+ When: Annually on December 8
+ */
+/**
+ *
+ * ThinkUp/webapp/plugins/insightsgenerator/insights/eoymostretweetedpost.php
+ *
+ * LICENSE:
+ *
+ * This file is part of ThinkUp (http://thinkup.com).
+ *
+ * ThinkUp is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * ThinkUp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with ThinkUp.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * EOYMostRetweetedPost (name of file)
+ *
+ * Description of what this class does
+ *
+ * Copyright (c) 2014 Adam Pash
+ *
+ * @author Adam Pash adam.pash@gmail.com
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2014 Adam Pash
+ */
+
+class EOYMostRetweetedPostInsight extends InsightPluginParent implements InsightPlugin {
+
+    public function generateInsight(Instance $instance, User $user, $last_week_of_posts, $number_days) {
+
+        $slug = 'eoy_most_retweeted';
+        $date = '12-08';
+        $year = date('Y');
+
+        $should_generate_insight = self::shouldGenerateEndOfYearAnnualInsight(
+            $slug,
+            $instance,
+            $insight_date = "$year-$date",
+            false,
+            $day_of_year = $date,
+            $excluded_networks = array('facebook')
+        );
+        if ($should_generate_insight) {
+            parent::generateInsight($instance, $user, $last_week_of_posts, $number_days);
+            $this->logger->logInfo("Begin generating insight", __METHOD__.','.__LINE__);
+            $filename = basename(__FILE__, ".php");
+
+            $insight = new Insight();
+            $insight->instance_id = $instance->id;
+            $insight->slug = $slug;
+            $insight->date = date('Y-m-d');
+            $insight->eoy = true;
+
+            $top_three_shared = $this->topThreeThisYear($instance);
+
+            $copy = array(
+                'twitter' => array(
+                    'normal' => array(
+                        'headline' => "%username's most-retweeted tweet of %year",
+                        'body' => "Tweet, retweet, repeat. In %year, " .
+                            "%username earned the most retweets for these gems."
+                    ),
+                    'one' => array(
+                        'headline' => "%username's most-retweeted tweet of %year",
+                        'body' => "Tweet, retweet, repeat. In %year, " .
+                            "%username earned the most retweets for this gem."
+                    ),
+                    'none' => array(
+                        'headline' => "Retweets aren't everything",
+                        'body' => "%username didn't get any retweets in %year, " .
+                            "which is a-okay. We're not all here to broadcast."
+                    ),
+                ),
+                'facebook' => array(
+                    'normal' => array(
+                        'headline' => "%username's most-shared status update of %year",
+                        'body' => "With shares on the rise, %year was a bull " .
+                            "market for %username's most-shared status updates."
+                    ),
+                    'one' => array(
+                        'headline' => "%username's most-shared status update of %year",
+                        'body' => "With shares on the rise, %year was a " .
+                            "bull market for %username's most-shared status update."
+                    ),
+                    'none' => array(
+                        'headline' => "Shares aren't everything",
+                        'body' => "No one shared %username's status updates on " .
+                            "Facebook in %year — not that there's anything wrong " .
+                            "with that. Sometimes it's best to keep things close-knit."
+                    ),
+                )
+            );
+
+            $network = $instance->network;
+
+            if (sizeof($top_three_shared) > 1) {
+                $type = 'normal';
+            } else if (sizeof($top_three_shared) == 1) {
+                $type = 'one';
+            } else {
+                $type = 'none';
+            }
+
+            $insight->headline = $this->getVariableCopy(
+                array(
+                    $copy[$network][$type]['headline']
+                ),
+                array(
+                    'year' => $year
+                )
+            );
+            $insight->text = $this->getVariableCopy(
+                array(
+                    $copy[$network][$type]['body']
+                ),
+                array(
+                    'year' => $year
+                )
+            );
+
+            $insight->emphasis = Insight::EMPHASIS_HIGH;
+            $insight->filename = $filename;
+
+            foreach ($top_three_shared as $post) {
+                $post->count = $post->retweet_count_cache . " " .
+                    $this->terms->getNoun('retweet', $post->retweet_count_cache > 1);
+            }
+            $insight->setPosts($top_three_shared);
+
+            $this->insight_dao->insertInsight($insight);
+            $insight = null;
+
+            $this->logger->logInfo("Done generating insight", __METHOD__.','.__LINE__);
+        }
+    }
+
+    /**
+     * Get three most retweeted posts this year
+     * @param Instance $instance
+     * @param str $order Defaults to 'retweets'
+     * @return array Three most retweeted posts in descending order
+     */
+    public function topThreeThisYear(Instance $instance, $order='retweets') {
+        $post_dao = DAOFactory::getDAO('PostDAO');
+        $days = TimeHelper::getDaysSinceJanFirst();
+        $posts = $post_dao->getAllPostsByUsernameOrderedBy(
+            $instance->network_username,
+            $network=$instance->network,
+            $count=3,
+            $order_by=$order,
+            $in_last_x_days = $days,
+            $iterator = false,
+            $is_public = false
+        );
+        return $posts;
+    }
+}
+
+$insights_plugin_registrar = PluginRegistrarInsights::getInstance();
+$insights_plugin_registrar->registerInsightPlugin('EOYMostRetweetedPostInsight');

--- a/webapp/plugins/insightsgenerator/tests/TestOfEOYMostRetweetedPostInsight.php
+++ b/webapp/plugins/insightsgenerator/tests/TestOfEOYMostRetweetedPostInsight.php
@@ -1,0 +1,445 @@
+<?php
+/**
+ *
+ * webapp/plugins/insightsgenerator/tests/TestOfEOYMostRetweetedPostInsight.php
+ *
+ * LICENSE:
+ *
+ * This file is part of ThinkUp (http://thinkup.com).
+ *
+ * ThinkUp is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * ThinkUp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with ThinkUp.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * EOYMostRetweetedPost (name of file)
+ *
+ * Description of what this class does
+ *
+ * Copyright (c) 2013 Adam Pash
+ *
+ * @author Adam Pash adam.pash@gmail.com
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2013 Adam Pash
+ */
+
+require_once dirname(__FILE__) . '/../../../../tests/init.tests.php';
+require_once THINKUP_WEBAPP_PATH.'_lib/extlib/simpletest/autorun.php';
+require_once THINKUP_WEBAPP_PATH.'_lib/extlib/simpletest/web_tester.php';
+require_once THINKUP_ROOT_PATH. 'webapp/plugins/insightsgenerator/model/class.InsightPluginParent.php';
+require_once THINKUP_ROOT_PATH. 'webapp/plugins/insightsgenerator/insights/eoymostretweetedpost.php';
+
+class TestOfEOYMostRetweetedPostInsight extends ThinkUpInsightUnitTestCase {
+
+    public function setUp() {
+        parent::setUp();
+
+        $this->instance = new Instance();
+        $this->instance->id = 10;
+        $this->instance->network_username = 'buffy';
+        $this->instance->network = 'twitter';
+
+    }
+
+    public function tearDown() {
+        parent::tearDown();
+    }
+
+    public function testConstructor() {
+        $insight_plugin = new EOYMostRetweetedPostInsight();
+        $this->assertIsA($insight_plugin, 'EOYMostRetweetedPostInsight' );
+    }
+
+    public function testTopThreePosts() {
+        $insight_plugin = new EOYMostRetweetedPostInsight();
+
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'This is very shared',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 100
+            )
+        );
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'This is pretty well shared',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 50
+            )
+        );
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'This is least shared',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 25
+            )
+        );
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'These Sochi games are kind of a cluster already.',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 1
+            )
+        );
+        $posts = $insight_plugin->topThreeThisYear($this->instance);
+
+        // test that query returns 3 results sorted by retweets descending
+        $this->assertEqual(3, sizeof($posts));
+        $this->assertEqual(100, $posts[0]->retweet_count_cache);
+        $this->assertEqual(50, $posts[1]->retweet_count_cache);
+        $this->assertEqual(25, $posts[2]->retweet_count_cache);
+
+        // test only counts from this year
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'These Sochi games are kind of a cluster already.',
+            'pub_date' => '2013-12-07',
+            'author_username' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 1000
+            )
+        );
+
+        $posts = $insight_plugin->topThreeThisYear($this->instance);
+        $this->assertEqual(100, $posts[0]->retweet_count_cache);
+    }
+
+    public function testTwitterNormalCase() {
+        // Set up and test normal twitter case
+        $builders = self::setUpPublicInsight($this->instance);
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'This is very shared',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 100
+            )
+        );
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'This is pretty well shared',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 50
+            )
+        );
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'This is least shared',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 25
+            )
+        );
+
+        $posts = array();
+        $insight_plugin = new EOYMostRetweetedPostInsight();
+        $insight_plugin->generateInsight($this->instance, null, $posts, 3);
+
+        // Assert that insight got inserted
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('eoy_most_retweeted', $this->instance->id, $today);
+        $this->assertNotNull($result);
+        $this->assertIsA($result, "Insight");
+        $year = date('Y');
+        $this->assertEqual("@buffy's most-retweeted tweet of $year", $result->headline);
+        $this->assertEqual("Tweet, retweet, repeat. In $year, @buffy earned the " .
+            "most retweets for these gems.", $result->text);
+
+        $this->dumpRenderedInsight($result, "Normal case, Twitter");
+    }
+
+    public function testFacebookNormalCase() {
+        // set up and test facebook
+        $this->instance->network_username = 'Buffy Summers';
+        $this->instance->network = 'facebook';
+        $builders = self::setUpPublicInsight($this->instance);
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'This is very shared',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'author_fullname' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 100
+            )
+        );
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'This is pretty well shared',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'author_fullname' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 50
+            )
+        );
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'This is least shared',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'author_fullname' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 1
+            )
+        );
+
+        $posts = array();
+        $insight_plugin = new EOYMostRetweetedPostInsight();
+        $insight_plugin->generateInsight($this->instance, null, $posts, 3);
+
+        // Assert that insight got inserted
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('eoy_most_retweeted', $this->instance->id, $today);
+        // $this->debug(Utils::varDumpToString($result));
+        $this->assertNotNull($result);
+        $this->assertIsA($result, "Insight");
+        $year = date('Y');
+        $this->assertEqual("Buffy Summers's most-shared status update of $year", $result->headline);
+        $this->assertEqual("With shares on the rise, $year was a bull market for " .
+            "Buffy Summers's most-shared status updates.", $result->text);
+
+        $this->dumpRenderedInsight($result, "Normal case: Facebook");
+        // $this->dumpAllHTML();
+    }
+
+    // Text variations in amount: if matches == 1
+    public function testTwitterOneMatch() {
+        // on twitter
+        // set up single popular post
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'This is very shared',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 100
+            )
+        );
+
+        $posts = array();
+        $insight_plugin = new EOYMostRetweetedPostInsight();
+        $insight_plugin->generateInsight($this->instance, null, $posts, 3);
+
+        // Assert that insight got inserted
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('eoy_most_retweeted', $this->instance->id, $today);
+        // $this->debug(Utils::varDumpToString($result));
+        $this->assertNotNull($result);
+        $this->assertIsA($result, "Insight");
+        $year = date('Y');
+        $this->assertEqual("@buffy's most-retweeted tweet of $year", $result->headline);
+        $this->assertEqual("Tweet, retweet, repeat. In $year, @buffy earned the " .
+            "most retweets for this gem.", $result->text);
+
+        $this->dumpRenderedInsight($result, "One match: Twitter");
+    }
+
+    public function testFacebookOneMatch() {
+        // now test facebook
+        $this->instance->network_username = 'Buffy Summers';
+        $this->instance->network = 'facebook';
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'This is very shared',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 100
+            )
+        );
+
+        $posts = array();
+        $insight_plugin = new EOYMostRetweetedPostInsight();
+        $insight_plugin->generateInsight($this->instance, null, $posts, 3);
+
+        // Assert that insight got inserted
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('eoy_most_retweeted', $this->instance->id, $today);
+        // $this->debug(Utils::varDumpToString($result));
+        $this->assertNotNull($result);
+        $this->assertIsA($result, "Insight");
+        $year = date('Y');
+        $this->assertEqual("Buffy Summers's most-shared status update of $year", $result->headline);
+        $this->assertEqual("With shares on the rise, $year was a bull market for " .
+            "Buffy Summers's most-shared status update.", $result->text);
+
+        $this->dumpRenderedInsight($result, "One match: Facebook");
+    }
+
+    // test if user had no shares this year
+    public function testTwitterNoMatches() {
+        // on twitter
+        // set up single popular post
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'This is very shared',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 0
+            )
+        );
+
+        $posts = array();
+        $insight_plugin = new EOYMostRetweetedPostInsight();
+        $insight_plugin->generateInsight($this->instance, null, $posts, 3);
+
+        // Assert that insight got inserted
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('eoy_most_retweeted', $this->instance->id, $today);
+        // $this->debug(Utils::varDumpToString($result));
+        $this->assertNotNull($result);
+        $this->assertIsA($result, "Insight");
+        $year = date('Y');
+        $this->assertEqual("Retweets aren't everything", $result->headline);
+        $this->assertEqual("@buffy didn't get any retweets in $year, which is a-okay. " .
+            "We're not all here to broadcast.", $result->text);
+
+        $this->dumpRenderedInsight($result, "No matches: Twitter");
+    }
+
+    public function testFacebookNoMatches() {
+        // now test facebook
+        $this->instance->network_username = 'Buffy Summers';
+        $this->instance->network = 'facebook';
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'This is very shared',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 0
+            )
+        );
+
+        $posts = array();
+        $insight_plugin = new EOYMostRetweetedPostInsight();
+        $insight_plugin->generateInsight($this->instance, null, $posts, 3);
+
+        // Assert that insight got inserted
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('eoy_most_retweeted', $this->instance->id, $today);
+        // $this->debug(Utils::varDumpToString($result));
+        $this->assertNotNull($result);
+        $this->assertIsA($result, "Insight");
+        $year = date('Y');
+        $this->assertEqual("Shares aren't everything", $result->headline);
+        $this->assertEqual("No one shared Buffy Summers's status updates on Facebook " .
+            "in $year — not that there's anything wrong with that. Sometimes it's best " .
+            "to keep things close-knit.", $result->text);
+
+        $this->dumpRenderedInsight($result, "No matches: Facebook");
+    }
+
+    public function testShareCount() {
+        // test twitter
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'This is very shared',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 100
+            )
+        );
+
+        $posts = array();
+        $insight_plugin = new EOYMostRetweetedPostInsight();
+        $insight_plugin->generateInsight($this->instance, null, $posts, 3);
+
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('eoy_most_retweeted', $this->instance->id, $today);
+        $this->assertPattern("/100 retweets/", $result->related_data);
+
+        // test one retweet
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'This is very shared',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 1
+            )
+        );
+
+        $posts = array();
+        $insight_plugin = new EOYMostRetweetedPostInsight();
+        $insight_plugin->generateInsight($this->instance, null, $posts, 3);
+
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('eoy_most_retweeted', $this->instance->id, $today);
+        $this->assertPattern("/1 retweet/", $result->related_data);
+        $this->assertNoPattern("/1 retweets/", $result->related_data);
+
+        // test facebook
+        $this->instance->network_username = 'Buffy Summers';
+        $this->instance->network = 'facebook';
+        $builders[] = FixtureBuilder::build('posts',
+            array(
+            'post_text' => 'This is very shared',
+            'pub_date' => '2014-02-07',
+            'author_username' => $this->instance->network_username,
+            'network' => $this->instance->network,
+            'retweet_count_cache' => 100
+            )
+        );
+
+        $posts = array();
+        $insight_plugin = new EOYMostRetweetedPostInsight();
+        $insight_plugin->generateInsight($this->instance, null, $posts, 3);
+
+        $insight_dao = new InsightMySQLDAO();
+        $today = date ('Y-m-d');
+        $result = $insight_dao->getInsight('eoy_most_retweeted', $this->instance->id, $today);
+        $this->assertPattern("/100 reshares/", $result->related_data);
+    }
+
+    private function dumpAllHTML() {
+        $controller = new InsightStreamController();
+        $_GET['u'] = $this->instance->network_username;
+        $_GET['n'] = $this->instance->network;
+        $_GET['d'] = date ('Y-m-d');
+        $_GET['s'] = 'eoy_most_retweeted';
+        $results = $controller->go();
+        //output this to an HTML file to see the insight fully rendered
+        $this->debug($results);
+    }
+
+    private function dumpRenderedInsight($result, $message) {
+        if (isset($message)) {
+            $this->debug("<h4 style=\"text-align: center; margin-top: 20px;\">$message</h4>");
+        }
+        $this->debug($this->getRenderedInsightInHTML($result));
+        $this->debug($this->getRenderedInsightInEmail($result));
+    }
+
+}
+

--- a/webapp/plugins/insightsgenerator/view/_posts_with_counts.tpl
+++ b/webapp/plugins/insightsgenerator/view/_posts_with_counts.tpl
@@ -1,0 +1,27 @@
+{*
+Renders an insight with an array of post objects in related_data.
+Includes related count data with the post objects.
+
+Parameters:
+$i (required) Insight object
+$posts: List of multiple posts
+*}
+
+{if isset($posts)}
+<ul class="body-list tweet-list
+{if count($posts) gt 2}body-list-show-some{else}body-list-show-all{/if}">
+{foreach from=$posts key=uid item=post name=bar}
+
+    <li class="list-item">
+      <h4 class="count-header">{$post->count}</h4>
+      {include file=$tpl_path|cat:"_post.tpl" post=$post}
+    </li>
+    {assign var="prev_post_year" value=$p->adj_pub_date|date_format:"%Y"}
+{/foreach}
+</ul>
+
+{if count($posts) gt 2}
+<button class="btn btn-default btn-block btn-see-all" data-text="Actually, please hide them"><span class="btn-text">See all {$posts|@count} tweets</span> <i class="fa fa-chevron-down icon"></i></button>
+{/if}
+
+{/if}

--- a/webapp/plugins/insightsgenerator/view/eoymostretweetedpost.tpl
+++ b/webapp/plugins/insightsgenerator/view/eoymostretweetedpost.tpl
@@ -1,0 +1,3 @@
+
+{include file=$tpl_path|cat:"_posts_with_counts.tpl" posts=$i->related_data.posts hide_avatar='true'}
+


### PR DESCRIPTION
The first of the EOYs! The insight itself is pretty basic, but a couple things to note about the rest of this commit:
1. I created a new tpl (_posts_with_counts.tpl) for embedding posts w/counts (many of our EOY posts call for this). I didn't do anything w/CSS — it's just an H4 with a class of "count-header" for later styling. It requires that each post has a count property (like "20 retweets").
   
   ![_posts_with_counts.tpl](http://files.adampash.com/s/ThinkUp_1A02BE94.png)
2. I've added a conditional to insights.tpl for slugs matching "eoy"; on match, it adds two classes: "insight-eoy insight-wide". Figured insight-eoy can handle our eoy-specific styling.

I realize I took a leap with those things, and you may prefer another route — totally cool! Just thought I'd get the ball rolling.
