### PR TITLE
Issue #2206: Update GitHub repository URL

### DIFF
--- a/docs/source/changelog/0.01.rst
+++ b/docs/source/changelog/0.01.rst
@@ -12,5 +12,5 @@ http://groups.google.com/group/thinkup/browse_thread/thread/9f12e013ee2c4751
 Otherwise, compared to the 0.008 alpha, beta 0.1 includes a very long
 laundry list of bugfixes and updates. You can see the complete
 changelog here:
-http://github.com/ginatrapani/thinkup/compare/v0.008...v0.1
+https://github.com/ThinkUpLLC/ThinkUp/compare/v0.008...v0.1
 

--- a/docs/source/contribute/developers/devfromsource.rst
+++ b/docs/source/contribute/developers/devfromsource.rst
@@ -9,14 +9,14 @@ Quickfire Do's and Don't's
 --------------------------
 
 If you aren't familiar with git and GitHub, try reading the
-`ThinkUp Beginner's Guide <https://github.com/ginatrapani/ThinkUp/wiki/Developer-Guide%3A-ThinkUp-for-Beginners-by-a-Beginner>`_
+`ThinkUp Beginner's Guide <https://github.com/ThinkUpLLC/ThinkUp/wiki/Developer-Guide%3A-ThinkUp-for-Beginners-by-a-Beginner>`_
 and the `GitHub bootcamp documentation <http://help.github.com/#github_bootcamp>`_. If you're
 familiar with git and GitHub, here's the short version of what you need
 to know. Once you fork and download the ThinkUp code:
 
 -  **Don't develop on the master branch.** Always create a development
    branch specific to `the
-   issue <http://github.com/ginatrapani/thinkup/issues>`_ you're working
+   issue <https://github.com/ThinkUpLLC/ThinkUp/issues>`_ you're working
    on. Name it by issue # and description. For example, if you're
    working on Issue #100, a retweet bugfix, your development branch
    should be called 100-retweet-bugfix. If you decide to work on another
@@ -85,7 +85,7 @@ GitHub account and your hosting server.
 #. Create a free account on GitHub.
 
 #. Fork the project from
-   `ginatrapani/thinkup <http://github.com/ginatrapani/thinkup>`_
+   `ginatrapani/thinkup <https://github.com/ThinkUpLLC/ThinkUp>`_
 
 #. Make sure you've got an SSH public key created on your server and
    recorded in your GitHub account. You can see your SSH Public Keys on

--- a/docs/source/contribute/developers/howto/modifydb.rst
+++ b/docs/source/contribute/developers/howto/modifydb.rst
@@ -33,7 +33,7 @@ sql/build-db\_mysql-upcoming-release.sql file using the automated migratedb shel
 To do so, run the extras/scripts/migratedb script at the command line.
 First you'll need to create and edit your configuration file. Check out
 the
-`README <http://github.com/ginatrapani/ThinkUp/tree/master/extras/scripts/>`_
+`README <https://github.com/ThinkUpLLC/ThinkUp/tree/master/extras/scripts/>`_
 for instructions on how to do that.
 
 Run ThinkUp's tests to make sure the database creation script works.

--- a/docs/source/contribute/developers/pullrequestchecklist.rst
+++ b/docs/source/contribute/developers/pullrequestchecklist.rst
@@ -20,7 +20,7 @@ request, make sure that:
 #. **All existing unit tests pass.** Gina won't merge any code into the
    master development trunk that makes existing tests in
    ``/thinkup/tests/`` fail. Check out the `tests
-   README <http://github.com/ginatrapani/thinkup/blob/master/tests/README.md>`_
+   README <https://github.com/ThinkUpLLC/ThinkUp/blob/master/tests/README.md>`_
    for more on how to set up, run, and write tests.
 #. **You've added regression tests for your new code.** If you've fixed
    a bug, you should have added a test which fails in the current

--- a/docs/source/contribute/developers/setup.rst
+++ b/docs/source/contribute/developers/setup.rst
@@ -47,7 +47,7 @@ Set up Eclipse PDT to work with ThinkUp
   issues in Eclipse, install `this
   plugin <https://github.com/dgreen99/org.eclipse.mylyn.github/wiki>`_.
 
-  - Server: `http://github.com/ginatrapani/ThinkUp <http://github.com/ginatrapani/ThinkUp>`_
+  - Server: `https://github.com/ThinkUpLLC/ThinkUp <https://github.com/ThinkUpLLC/ThinkUp>`_
   - Find your GitHub API Key in `Applications <https://github.com/settings/applications>`_ under **Account settings**.
 
 Useful Keyboard Shortcuts

--- a/docs/source/contribute/developers/writecode/styleguide/php.rst
+++ b/docs/source/contribute/developers/writecode/styleguide/php.rst
@@ -63,7 +63,7 @@ Include docblocks in all code
 ThinkUp uses PHPDocumentor to ease code maintenance and `auto-generate class documentation 
 <http://thinkup.com/reference/>`_. Include PHPDoc-style “docblocks” in all of your PHP code. When writing your
 documentation, please use `PHPDocumentor's 
-syntax <http://github.com/ginatrapani/ThinkUp/wiki/ThinkUp-and-PHPDocumentor-(PHPDoc)>`_.
+syntax <https://github.com/ThinkUpLLC/ThinkUp/wiki/ThinkUp-and-PHPDocumentor-(PHPDoc)>`_.
 
 Keyword case
 ------------

--- a/docs/source/contribute/developers/writecode/unittests.rst
+++ b/docs/source/contribute/developers/writecode/unittests.rst
@@ -27,6 +27,6 @@ This list is a work in progress.
    API, do not query the live API in your tests. Instead, mock a class
    that returns all possible values that you expect from the API, and
    write tests against those values. For example, the `mock TwitterOAuth
-   class <http://github.com/ginatrapani/ThinkUp/blob/master/webapp/plugins/twitter/tests/classes/mock.TwitterOAuth.php>`_
+   class <https://github.com/ThinkUpLLC/ThinkUp/blob/master/webapp/plugins/twitter/tests/classes/mock.TwitterOAuth.php>`_
    reads test Twitter data from files stored in the testdata directory,
    instead of hitting Twitter.com live.

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -19,7 +19,7 @@ from your network. All you need is a web server that can run a PHP application.
 Gina Trapani, leads development on the project.
 
 ThinkUp's source code is licensed under the `GNU General Public License <http://www.gnu.org/licenses/gpl.html>`_ and
-is available on `GitHub <http://github.com/ginatrapani/ThinkUp>`_.
+is available on `GitHub <https://github.com/ThinkUpLLC/ThinkUp>`_.
 
 Find out more at http://thinkup.com.
 

--- a/extras/dev/makeplugin/makeplugin
+++ b/extras/dev/makeplugin/makeplugin
@@ -195,7 +195,7 @@ cat<< END >>'webapp/plugins/'$plugin_name_lcase'/controller/'$plugin_name_lcase'
 <?php
 /*
  Plugin Name: $1
- Plugin URI: http://github.com/ginatrapani/thinkup/tree/master/webapp/plugins/$plugin_name_lcase/
+ Plugin URI: https://github.com/ThinkUpLLC/ThinkUp/tree/master/webapp/plugins/$plugin_name_lcase/
  Description:
  Class: $1Plugin
  Icon: assets/img/plugin_icon.png

--- a/webapp/plugins/expandurls/controller/expandurls.php
+++ b/webapp/plugins/expandurls/controller/expandurls.php
@@ -1,7 +1,7 @@
 <?php
 /*
  Plugin Name: Expand URLs
- Plugin URI: http://github.com/ginatrapani/thinkup/tree/master/webapp/plugins/expandurls/
+ Plugin URI: https://github.com/ThinkUpLLC/ThinkUp/tree/master/webapp/plugins/expandurls/
  Description: Expand shortened links.
  Icon: link
  Version: 0.01

--- a/webapp/plugins/facebook/controller/facebook.php
+++ b/webapp/plugins/facebook/controller/facebook.php
@@ -1,7 +1,7 @@
 <?php
 /*
  Plugin Name: Facebook
- Plugin URI: http://github.com/ginatrapani/thinkup/tree/master/webapp/plugins/facebook/
+ Plugin URI: https://github.com/ThinkUpLLC/ThinkUp/tree/master/webapp/plugins/facebook/
  Description: Capture and display Facebook posts.
  Class: FacebookPlugin
  Icon: facebook

--- a/webapp/plugins/hellothinkup/controller/hellothinkup.php
+++ b/webapp/plugins/hellothinkup/controller/hellothinkup.php
@@ -1,7 +1,7 @@
 <?php
 /*
  Plugin Name: Hello ThinkUp
- Plugin URI: http://github.com/ginatrapani/thinkup/tree/master/webapp/plugins/hellothinkup/
+ Plugin URI: https://github.com/ThinkUpLLC/ThinkUp/tree/master/webapp/plugins/hellothinkup/
  Description: Developer example plugin.
  Class: HelloThinkUpPlugin
  Version: 0.01

--- a/webapp/plugins/insightsgenerator/controller/insightsgenerator.php
+++ b/webapp/plugins/insightsgenerator/controller/insightsgenerator.php
@@ -1,7 +1,7 @@
 <?php
 /*
  Plugin Name: Insights Generator
- Plugin URI: http://github.com/ginatrapani/thinkup/tree/master/webapp/plugins/insightsgenerator/
+ Plugin URI: https://github.com/ThinkUpLLC/ThinkUp/tree/master/webapp/plugins/insightsgenerator/
  Description: Pluggable plugin populates the insights stream.
  Class: InsightsGeneratorPlugin
  Icon: list

--- a/webapp/plugins/instagram/controller/instagram.php
+++ b/webapp/plugins/instagram/controller/instagram.php
@@ -1,7 +1,7 @@
 <?php
 /*
  Plugin Name: Instagram
- Plugin URI: http://github.com/ginatrapani/thinkup/tree/master/webapp/plugins/instagram/
+ Plugin URI: https://github.com/ThinkUpLLC/ThinkUp/tree/master/webapp/plugins/instagram/
  Description: Capture and display Instagram posts.
  Class: InstagramPlugin
  Icon: instagram

--- a/webapp/plugins/twitter/controller/twitter.php
+++ b/webapp/plugins/twitter/controller/twitter.php
@@ -1,7 +1,7 @@
 <?php
 /*
  Plugin Name: Twitter
- Plugin URI: http://github.com/ginatrapani/thinkup/tree/master/webapp/plugins/twitter/
+ Plugin URI: https://github.com/ThinkUpLLC/ThinkUp/tree/master/webapp/plugins/twitter/
  Description: Capture and display tweets.
  Icon: twitter
  Class: TwitterPlugin


### PR DESCRIPTION
All links in the app itself, and the documentation (*.rst files)updated to changed Github repo 
(i.e  https://github.com/ThinkUpLLC/ThinkUp).