### PR TITLE
Fixed a headline bug when generating weekly Instagram insights.

### DIFF
--- a/webapp/plugins/insightsgenerator/insights/frequency.php
+++ b/webapp/plugins/insightsgenerator/insights/frequency.php
@@ -115,13 +115,16 @@ class FrequencyInsight extends InsightPluginParent implements InsightPlugin {
                             )),
                         ));
                 } else {
-                    $info  = array(
-                       'headline '=> $info['headline'],
-                       'text' => "Huh, nothing. Fill the emptiness inside you by donating to an underfunded classroom",
-                       'button' => array(
-                            "url" => "http://www.donorschoose.org/",
-                            "label"  => "Give to DonorsChoose.org",
-                    ));
+                    $info  = $this->getVariableCopy(
+						array(
+						   'headline'=> "%username didn't have any new %posts this week",
+						   'text' => "Huh, nothing. Fill the emptiness inside you by donating to an underfunded classroom",
+						   'button' => array(
+								"url" => "http://www.donorschoose.org/",
+								"label"  => "Give to DonorsChoose.org",
+						   )
+                    	)
+					);
 
                 }
             }


### PR DESCRIPTION
When a user has one or less Instagram - or any other non-Twitter or non-Facebook network - posts, the Insight generation failed with an InsightFieldNotSetException.

This fixed changed the default headline and wrapped the info array in the getVariableCopy function to fill the name and post type.