### PR TITLE
Issue #2238: Fixes Dictionary insight test by using generated dates

### DIFF
--- a/webapp/plugins/insightsgenerator/tests/TestOfNewDictionaryWordsInsight.php
+++ b/webapp/plugins/insightsgenerator/tests/TestOfNewDictionaryWordsInsight.php
@@ -142,7 +142,7 @@ class TestOfNewDictionaryWordsInsight extends ThinkUpInsightUnitTestCase {
         $this->assertEqual('Before &ldquo;man crush&rdquo; went legit', $result->headline);
         $this->assertEqual('OxfordDictionariesOnline.com <a href="http://blog.oxforddictionaries.com/2014/12/oxford'.
             '-dictionaries-new-words-december-2014/">just added</a> "man crush" and "duckface" to their online '.
-            'dictionary, but no one has to explain them to @testy. Since August 2013, @testy used "man crush" 3 times '.
+            'dictionary, but no one has to explain them to @testy. Since ' . $str_earliest_mention . ', @testy used "man crush" 3 times '.
             'and "duckface" once.', $result->text);
 
         $data = unserialize($result->related_data);


### PR DESCRIPTION
This is a fix for https://github.com/ThinkUpLLC/ThinkUp/issues/2238, which is a unit test that has broken because the month has changed.

The previous version of the `NewDictionaryTest` was comparing text built by the insight with expected text that contained a fixed date string. This worked when it was first written, but only for a month, since the date string of the insight is created relative to the current date.

This commit the test to use the relative date, which is already used elsewhere in the test class, and should allow the test to be date invariant.