### PR TITLE
Issue #2236 - Fixes Forgotton Passwords for self-hosting

### DIFF
--- a/tests/TestOfForgotPasswordController.php
+++ b/tests/TestOfForgotPasswordController.php
@@ -61,7 +61,7 @@ class TestOfForgotPasswordController extends ThinkUpUnitTestCase {
 
     public function testOfControllerWithBadEmailAddress() {
         $_POST['email'] = 'im a broken email address';
-        $_POST['Submit'] = "Send Reset";
+        $_POST['Submit'] = "Send";
 
         $controller = new ForgotPasswordController(true);
         $result = $controller->go();
@@ -75,7 +75,7 @@ class TestOfForgotPasswordController extends ThinkUpUnitTestCase {
         $config->setValue('app_title_prefix', '');
         $site_root_path = $config->getValue('site_root_path');
         $_POST['email'] = 'me@example.com';
-        $_POST['Submit'] = "Send Reset";
+        $_POST['Submit'] = "Send";
         $_SERVER['HTTP_HOST'] = "mytestthinkup";
         $controller = new ForgotPasswordController(true);
         $result = $controller->go();
@@ -98,7 +98,7 @@ http:\/\/mytestthinkup'.str_replace('/', '\/', $site_root_path).'session\/reset.
         $config->setValue('app_title_prefix', "Angelina Jolie's ");
         $site_root_path = $config->getValue('site_root_path');
         $_POST['email'] = 'me@example.com';
-        $_POST['Submit'] = "Send Reset";
+        $_POST['Submit'] = "Send";
         $_SERVER['HTTP_HOST'] = "mytestthinkup";
         $controller = new ForgotPasswordController(true);
         $result = $controller->go();
@@ -121,7 +121,7 @@ http:\/\/mytestthinkup'.str_replace('/', '\/', $site_root_path).'session\/reset.
         $config->setValue('app_title_prefix', '');
         $site_root_path = $config->getValue('site_root_path');
         $_POST['email'] = 'me@example.com';
-        $_POST['Submit'] = "Send Reset";
+        $_POST['Submit'] = "Send";
         $_SERVER['HTTP_HOST'] = "mytestthinkup";
         $_SERVER['HTTPS'] = true;
         $controller = new ForgotPasswordController(true);

--- a/tests/WebTestOfForgottonPassword.php
+++ b/tests/WebTestOfForgottonPassword.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ *
+ * ThinkUp/tests/WebTestOfForgottonPassword.php
+ *
+ * Copyright (c) 2015 James Bell
+ *
+ * LICENSE:
+ *
+ * This file is part of ThinkUp (http://thinkup.com).
+ *
+ * ThinkUp is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * ThinkUp is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with ThinkUp.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @author James Bell <james.bell[at]gmail[dot]com>
+ * @license http://www.gnu.org/licenses/gpl.html
+ * @copyright 2015 James Bell
+ */
+require_once dirname(__FILE__).'/init.tests.php';
+require_once THINKUP_WEBAPP_PATH.'_lib/extlib/simpletest/autorun.php';
+require_once THINKUP_WEBAPP_PATH.'_lib/extlib/simpletest/web_tester.php';
+
+class WebTestOfForgottonPassword extends ThinkUpWebTestCase {
+
+    public function setUp() {
+        parent::setUp();
+        $this->builders = self::buildData();
+    }
+
+    public function tearDown() {
+        $this->builders = null;
+        $test_email = FileDataManager::getDataPath(Mailer::EMAIL);
+
+        if (file_exists($test_email)) {
+            unlink($test_email);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testForgotPasswordSuccess() {
+        $config = Config::getInstance();
+        $this->get($this->url.'/session/login.php');
+
+        $this->click('Forgot your password?');
+        $this->assertTitle($config->getValue('app_title_prefix') . 'ThinkUp');
+        $this->assertText('Reset your password');
+
+        $this->setField('email', 'me@example.com');
+        $this->click('Send');
+        $this->assertPattern('/Password recovery information has been sent to your email address./');
+        $email_file = Mailer::getLastMail();
+        $this->assertFalse(empty($email_file));
+        preg_match('/reset it:\n(http.*)/m', $email_file, $urls);
+        $this->get($urls[1]);
+
+        $this->assertNoPattern('/You have reached this page in error/');
+        $this->assertText('Reset your password');
+        $this->setField('password', 'abc123');
+        $this->setField('password_confirm', 'abc123');
+        $this->click('Send');
+
+        $this->assertText('Welcome');
+        $this->assertPattern('/You have changed your password/');
+    }
+
+    public function testForgotPasswordNoAccount() {
+        $config = Config::getInstance();
+        $this->get($this->url.'/session/login.php');
+
+        $this->click('Forgot your password?');
+        $this->assertTitle($config->getValue('app_title_prefix') . 'ThinkUp');
+        $this->assertText('Reset your password');
+
+        $this->setField('email', 'arthurdent@example.com');
+        $this->click('Send');
+        $this->assertNoPattern('/Password recovery information has been sent to your email address./');
+        $this->assertPattern('/Error: account does not exist./');
+    }
+}

--- a/tests/all_integration_tests.php
+++ b/tests/all_integration_tests.php
@@ -38,6 +38,7 @@ $web_tests->add(new WebTestOfChangePassword());
 $web_tests->add(new WebTestOfCrawlerRun());
 $web_tests->add(new WebTestOfCSRFToken());
 $web_tests->add(new WebTestOfDeleteInstance());
+$web_tests->add(new WebTestOfForgottonPassword());
 $web_tests->add(new WebTestOfLogin());
 $web_tests->add(new WebTestOfLogout());
 $web_tests->add(new WebTestOfRegistration());

--- a/webapp/_lib/controller/class.ForgotPasswordController.php
+++ b/webapp/_lib/controller/class.ForgotPasswordController.php
@@ -36,7 +36,7 @@ class ForgotPasswordController extends ThinkUpController {
         $config = Config::getInstance();
         $this->addToView('is_registration_open', $config->getValue('is_registration_open'));
 
-        if (isset($_POST['Submit']) && $_POST['Submit'] == 'Send Reset') {
+        if (isset($_POST['Submit']) && $_POST['Submit'] == 'Send') {
             $this->disableCaching();
 
             $dao = DAOFactory::getDAO('OwnerDAO');


### PR DESCRIPTION
This is a fix for https://github.com/ThinkUpLLC/ThinkUp/issues/2236

Since the ThinkUp version two redesign was merged into master, the forgotten passwords functionality for self-hosted systems has not worked. The controller had a check for the value of the submit button in order to send out the forgotten passwords template. However, the redesign changed the text (and hence the value) of the button, and the controller has never been changed to catch up.

This commit makes that change, updates the controller tests and adds an end-to-end test to catch the regression in future.