### PR TITLE
Proof-of-Concept docker setup for ThinkUp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# ThinkUp Docker Setup
+#
+# Pre-requisite:
+# 0. Adjust your target mailserver in the variable MAIL_RELAY below to your
+#    liking. The default only works for Google-hosted domains.
+#
+# If you don't have an existing MySQL instance, use the included
+# docker-compose template:
+# 1. Run `docker-compose build` to build the image.
+# 2. Run `docker-compose up` to run both the mysql and thinkup containers.
+# 3. Use a browser for the initial configuration and database setup.
+#    (Use `mysql` as the hostname, `root` as the database user, and `thinkup`
+#    as the password for the database.)
+# 4. Run the database migrations via
+#    `docker exec thinkup_thinkup_1 php install/cli/upgrade.php --with-new-sql`
+#
+# Directions without Docker Compose:
+# 1. Build the Docker image via `docker build -t thinkup .
+# 2. Run the Docker container from the image via
+#    `docker run -p 80:80 --name thinkup thinkup
+# 3. Use a browser for the initial configuration and database setup
+# 4. Run the database migrations via
+#    `docker exec thinkup php install/cli/upgrade.php --with-new-sql`
+
+FROM php:5.6-apache
+
+ENV MAIL_RELAY=aspmx.l.google.com
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install -y zlib1g-dev libpng12-dev ssmtp \
+  && docker-php-ext-install gd pdo pdo_mysql zip
+
+ADD webapp /var/www/html
+RUN echo "session.save_path = '/tmp'" > /usr/local/etc/php/conf.d/session_save_path.ini \
+  && echo "sendmail_path = '/usr/lib/sendmail -t -i'" > /usr/local/etc/php/conf.d/sendmail_path.ini \
+  && sed -i -e "s/^mailhub=.*/mailhub=$MAIL_RELAY/g" /etc/ssmtp/ssmtp.conf \
+  && sed -i -e "s/^hostname=.*/hostname=thinkup.docker.local/g" /etc/ssmtp/ssmtp.conf \
+  && chmod -R 777 /var/www/html/data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+thinkup:
+  build: .
+  ports:
+   - "80:80"
+  links:
+   - mysql
+mysql:
+  image: mysql
+  volumes:
+    - /var/lib/mysql
+  environment:
+    MYSQL_ROOT_PASSWORD: thinkup


### PR DESCRIPTION
Having an official docker image available for a project really aids users in their evaluation journey. I didn't find any working images out there for ThinkUp and also no talk on mailing lists or GitHub issues about providing docker images, hence my personal attempt to get this to work. If you're not interested, I'll happy crawl back under my rock. It was still a fun challenge. :)

The steps required to get the containers up and running can be found in the `Dockerfile`.

It is purposely self-contained in only two files at this point. If desired, the setup can (and should) be expanded to include, among other things, a full configuration file for the ssmtp tool with an improved relay host setup, even less manual labor for the initial setup (potentially by providing an out-of-the-box account that doesn't require a manual in-browser setup), and automatically run database migrations.

But it's a start. What do you think? I'll happily work on it some more if there's interest. I could also work on a version that's deployable via [Tutum](https://www.tutum.co) for example.