### PR TITLE
Use a universal shebang in the cron script

### DIFF
--- a/extras/cron/cron
+++ b/extras/cron/cron
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd `dirname $0`/../../
 source ./extras/cron/config
 


### PR DESCRIPTION
Same could be used in config or it could simply be removed as it's unnecessary