### PR TITLE
Update EOY top stories for 2015

### DIFF
--- a/webapp/plugins/insightsgenerator/insights/eoytopstories.php
+++ b/webapp/plugins/insightsgenerator/insights/eoytopstories.php
@@ -76,35 +76,32 @@ class EOYTopStoriesInsight extends InsightPluginParent implements InsightPlugin 
             );
 
             $topics = array(
-                'the Ice Bucket Challenge' => array('ice bucket','ALS Ice'),
-                'Robin Williams' => array('Robin Williams'),
-                'the Super Bowl' => array('Super Bowl','Superbowl'),
-                'MH370' => array('MH370','MH 370', 'Malaysia Airlines'),
-                'the World Cup' => array("World Cup"),
-                'the Sochi Olympics' => array('Sochi','Olympics'),
-                'LeBron James' => array('lebron'),
-                'Derek Jeter' => array('jeter'),
-                'Floyd Wayweather Jr.' => array('mayweather'),
-                'Carmelo Anthony' => array('carmelo'),
-                'Cristiano Ronaldo' => array('ronaldo'),
-                'Dale Earnhardt Jr.' => array('earnhardt'),
-                'Dale Earnhardt Jr.' => array('earnhardt'),
-                'Beyoncé' => array('beyonce'),
-                'Pharrell' => array('pharrell'),
-                'Nicki Minaj' => array('minaj'),
-                'Taylor Swift' => array('Taylor Swift'),
-                'Sam Smith' => array('Sam Smith'),
-                'Jimmy Fallon' => array('fallon'),
-                'Kim Kardashian' => array('kardashian'),
-                'Game of Thrones' => array('game of thrones'),
-                'Orange is the New Black' => array('Orange is the New Black','oitnb'),
+                'the U.S. Presidential election' => array('trump','clinton', 'sanders', 'jeb bush'),
+                'the Syrian refugee crisis' => array('Syria', 'refugee'),
+                'terror attacks' => array('ISIS', 'daesh', 'ISIL', 'Paris', 'hebdo', 'jesuischarlie'),
+                'the Nepal earthquake' => array('Nepal', 'earthquake'),
+                'marriage equality' => array('marriage equality', 'gay marriage', 'obergefell', 'lovewins'),
+                'the Planned Parenthood attack' => array('planned parenthood', 'abortion', 'colorado springs'),
+                '#BlackLivesMatter' => array('Freddie Gray', 'Baltimore', 'blacklivesmatter'),
+                'Charleston' => array('Charleston', 'confederate', 'emanuel'),
+                'Ahmed Mohamed' => array('Ahmed Mohamed', 'istandwithahmed'),
+                'Floyd Mayweather, Jr.' => array('mayweather'),
+                'Manny Pacquiao' => array('pacquiao'),
+                'Ronda Rousey' => array('ronda', 'rousey'),
+                'Tom Brady' => array('tom brady'),
+                'Stephen Curry' => array('stephen curry'),
+                'Serena Williams' => array('serena'),
+                'Ed Sheeran' => array('sheeran'),
+                'Taylor Swift' => array('taylor swift'),
+                'Kanye West' => array('kanye'),
+                'Caitlyn Jenner' => array('jenner'),
+                'Star Wars' => array('star wars', 'force awakens', 'episode vii', 'episode 7'),
+                'Avengers: Age of Ultron' => array('avengers'),
+                'Mad Max: Fury Road' => array('mad max', 'fury road', 'imperator', 'furiosa'),
+                'Magic Mike XXL' => array('magic mike'),
+                'Game of Thrones' => array('game of thrones', 'jon snow'),
                 'The Walking Dead' => array('walking dead'),
-                'Downton Abbey' => array('downton'),
-                'True Detective' => array('True Detective'),
-                //'Frozen' => array('Frozen'),
-                'Guardians of the Galaxy' => array('Guardians of the Galaxy'),
-                'The Lego Movie' => array('lego movie'),
-                'Gone Girl' => array('Gone Girl'),
+
             );
 
             $matches = array();
@@ -132,16 +129,16 @@ class EOYTopStoriesInsight extends InsightPluginParent implements InsightPlugin 
                         $qualified_year = " (at least since ".$since.")";
                     }
                 }
-                $headline = $this->username." didn't rehash 2014's top news on Facebook";
-                $insight_text = "No Ice Bucket Challenge, Robin Williams, or Malaysia Airlines here. "
-                    . $this->username." broke away from the herd and avoided talking about 2014's biggest stories "
+                $headline = $this->username." didn't rehash 2015's top news on Facebook";
+                $insight_text = "No Trump or Syrian refugee crisis here. "
+                    . $this->username." broke away from the herd and avoided talking about 2015's biggest stories "
                     ."on Facebook this year" . $qualified_year. '.';
                 $posts = null;
                 //Show avatar if there are no posts
                 $insight->header_image = $user->avatar;
                 //Show button if there are no posts
                 $insight->setButton(array(
-                    'url' => 'http://newsroom.fb.com/news/2014/12/2014-year-in-review/',
+                    'url' => 'http://newsroom.fb.com/news/2015/12/2015-year-in-review/',
                     'label' => "See Facebook's Year in Review"
                 ));
             } else {
@@ -161,8 +158,8 @@ class EOYTopStoriesInsight extends InsightPluginParent implements InsightPlugin 
                 $mention_string = join($num==2?' ':', ', $mentioned);
                 $thatwas = $num == 1 ? 'That was one' : 'Those were some';
                 $insight_text = $this->username."'s $year included $mention_string. $thatwas of "
-                    . '<a href="http://newsroom.fb.com/news/2014/12/2014-year-in-review/">Facebook\'s top topics of '
-                    . "the year</a> &mdash; that's so $year!";
+                    . '<a href="http://newsroom.fb.com/news/2015/12/2015-year-in-review/">Facebook\'s top topics of '
+                    . "the year</a>.";
             }
 
             $insight->instance_id = $instance->id;

--- a/webapp/plugins/insightsgenerator/tests/TestOfEOYTopStoriesInsight.php
+++ b/webapp/plugins/insightsgenerator/tests/TestOfEOYTopStoriesInsight.php
@@ -61,8 +61,8 @@ class TestOfEOYTopStoriesInsight extends ThinkUpInsightUnitTestCase {
         $result = $insight_dao->getInsight($insight_plugin->slug, $this->instance->id, $day);
         $this->assertNotNull($result);
         $this->assertEqual($result->headline, "Anderson Cooper didn't rehash $year's top news on Facebook");
-        $this->assertEqual($result->text, "No Ice Bucket Challenge, Robin Williams, or Malaysia Airlines here. ".
-            "Anderson Cooper broke away from the herd and avoided talking about 2014's biggest stories on Facebook ".
+        $this->assertEqual($result->text, "No Trump or Syrian refugee crisis here. ".
+            "Anderson Cooper broke away from the herd and avoided talking about 2015's biggest stories on Facebook ".
             "this year.");
         $data = unserialize($result->related_data);
         $this->assertNull($data['posts']);
@@ -89,8 +89,8 @@ class TestOfEOYTopStoriesInsight extends ThinkUpInsightUnitTestCase {
         $this->assertNotNull($result);
 
         $this->assertEqual($result->headline, "Anderson Cooper didn't rehash $year's top news on Facebook");
-        $this->assertEqual($result->text, "No Ice Bucket Challenge, Robin Williams, or Malaysia Airlines here. ".
-            "Anderson Cooper broke away from the herd and avoided talking about 2014's biggest stories on Facebook ".
+        $this->assertEqual($result->text, "No Trump or Syrian refugee crisis here. ".
+            "Anderson Cooper broke away from the herd and avoided talking about 2015's biggest stories on Facebook ".
             "this year (at least since June).");
         $data = unserialize($result->related_data);
         $this->assertNull($data['posts']);
@@ -105,7 +105,7 @@ class TestOfEOYTopStoriesInsight extends ThinkUpInsightUnitTestCase {
             array(
                 'pub_date' => $year.'-02-01', 'post_id' => 1, 'author_username' => $this->instance->network_username,
                 'author_user_id' => $this->instance->network_user_id, 'network' => $this->instance->network,
-                'post_text' => 'Are you ready for the Super Bowl?',
+                'post_text' => 'What did you think about Charleston?',
             )
         );
         $insight_plugin = new EOYTopStoriesInsight();
@@ -116,9 +116,9 @@ class TestOfEOYTopStoriesInsight extends ThinkUpInsightUnitTestCase {
         $this->assertNotNull($result);
 
         $this->assertEqual($result->headline, "Anderson Cooper was part of $year's biggest trends");
-        $this->assertEqual($result->text, "Anderson Cooper's $year included the Super Bowl. That was one of "
-            . '<a href="http://newsroom.fb.com/news/2014/12/2014-year-in-review/">Facebook\'s top topics of the year'
-            . '</a> &mdash; that\'s so '.$year.'!');
+        $this->assertEqual($result->text, "Anderson Cooper's $year included Charleston. That was one of "
+            . '<a href="http://newsroom.fb.com/news/2015/12/2015-year-in-review/">Facebook\'s top topics of the year'
+            . '</a>.');
         $data = unserialize($result->related_data);
         $this->assertEqual(1, count($data['posts']));
 
@@ -132,21 +132,21 @@ class TestOfEOYTopStoriesInsight extends ThinkUpInsightUnitTestCase {
             array(
                 'pub_date' => "$year-02-01", 'post_id' => 1, 'author_username' => $this->instance->network_username,
                 'author_user_id' => $this->instance->network_user_id, 'network' => $this->instance->network,
-                'post_text' => 'I wonder if the gang will survive on walking dead.',
+                'post_text' => 'I wonder what will happen next year.',
             )
         );
         $builders[] = FixtureBuilder::build('posts',
             array(
                 'pub_date' => "$year-02-05", 'post_id' => 2, 'author_username' => $this->instance->network_username,
                 'author_user_id' => $this->instance->network_user_id, 'network' => $this->instance->network,
-                'post_text' => 'I am really sad about Robin Williams.',
+                'post_text' => 'I am really sad about the Paris attacks.',
             )
         );
         $builders[] = FixtureBuilder::build('posts',
             array(
                 'pub_date' => "$year-01-02", 'post_id' => 3, 'author_username' => $this->instance->network_username,
                 'author_user_id' => $this->instance->network_user_id, 'network' => $this->instance->network,
-                'post_text' => 'The Walking Dead is my favorite show!',
+                'post_text' => 'Let us not forget Freddie Gray',
             )
         );
         $insight_plugin = new EOYTopStoriesInsight();
@@ -157,13 +157,13 @@ class TestOfEOYTopStoriesInsight extends ThinkUpInsightUnitTestCase {
         $this->assertNotNull($result);
 
         $this->assertEqual($result->headline, "Anderson Cooper was part of $year's biggest trends");
-        $this->assertEqual($result->text, "Anderson Cooper's $year included The Walking Dead and "
-            . "Robin Williams. Those were some of <a href=\"http://newsroom.fb.com/news/2014/12/2014-year-in-"
-            . "review/\">Facebook's top topics of the year</a> &mdash; that's so $year!");
+        $this->assertEqual($result->text, "Anderson Cooper's $year included #BlackLivesMatter and "
+            . "terror attacks. Those were some of <a href=\"http://newsroom.fb.com/news/2015/12/2015-year-in-"
+            . "review/\">Facebook's top topics of the year</a>.");
         $data = unserialize($result->related_data);
         $this->assertEqual(2, count($data['posts']));
-        $this->assertEqual($data['posts'][0]->post_text, 'The Walking Dead is my favorite show!');
-        $this->assertEqual($data['posts'][1]->post_text, 'I am really sad about Robin Williams.');
+        $this->assertEqual($data['posts'][0]->post_text, 'Let us not forget Freddie Gray');
+        $this->assertEqual($data['posts'][1]->post_text, 'I am really sad about the Paris attacks.');
 
         $this->dumpRenderedInsight($result, $this->instance, "Two Topics");
     }
@@ -173,23 +173,23 @@ class TestOfEOYTopStoriesInsight extends ThinkUpInsightUnitTestCase {
         $builders = array();
         $builders[] = FixtureBuilder::build('posts',
             array(
+                'pub_date' => "$year-01-01", 'post_id' => 3, 'author_username' => $this->instance->network_username,
+                'author_user_id' => $this->instance->network_user_id, 'network' => $this->instance->network,
+                'post_text' => 'Syria is still missing.',
+            )
+        );
+        $builders[] = FixtureBuilder::build('posts',
+            array(
                 'pub_date' => "$year-02-01", 'post_id' => 1, 'author_username' => $this->instance->network_username,
                 'author_user_id' => $this->instance->network_user_id, 'network' => $this->instance->network,
-                'post_text' => 'The World Cup is a soccer thing, I guess.',
+                'post_text' => 'Baltimore needs our help.',
             )
         );
         $builders[] = FixtureBuilder::build('posts',
             array(
                 'pub_date' => "$year-04-05", 'post_id' => 2, 'author_username' => $this->instance->network_username,
                 'author_user_id' => $this->instance->network_user_id, 'network' => $this->instance->network,
-                'post_text' => 'I just poured an Ice Bucket on my head.',
-            )
-        );
-        $builders[] = FixtureBuilder::build('posts',
-            array(
-                'pub_date' => "$year-01-01", 'post_id' => 3, 'author_username' => $this->instance->network_username,
-                'author_user_id' => $this->instance->network_user_id, 'network' => $this->instance->network,
-                'post_text' => 'MH370 is still missing.',
+                'post_text' => 'I hate Trump.',
             )
         );
         $insight_plugin = new EOYTopStoriesInsight();
@@ -200,14 +200,15 @@ class TestOfEOYTopStoriesInsight extends ThinkUpInsightUnitTestCase {
         $this->assertNotNull($result);
 
         $this->assertEqual($result->headline, "Anderson Cooper was part of $year's biggest trends");
-        $this->assertEqual($result->text, "Anderson Cooper's $year included MH370, the World Cup, and the Ice "
-            . "Bucket Challenge. Those were some of <a href=\"http://newsroom.fb.com/news/2014/12/2014-year-in-"
-            . "review/\">Facebook's top topics of the year</a> &mdash; that's so $year!");
+        $this->assertEqual($result->text, "Anderson Cooper's $year included the Syrian refugee crisis, "
+            . "#BlackLivesMatter, and the U.S. Presidential election. Those were some of "
+            . "<a href=\"http://newsroom.fb.com/news/2015/12/2015-year-in-"
+            . "review/\">Facebook's top topics of the year</a>.");
         $data = unserialize($result->related_data);
         $this->assertEqual(3, count($data['posts']));
-        $this->assertEqual($data['posts'][0]->post_text, 'MH370 is still missing.');
-        $this->assertEqual($data['posts'][1]->post_text, 'The World Cup is a soccer thing, I guess.');
-        $this->assertEqual($data['posts'][2]->post_text, 'I just poured an Ice Bucket on my head.');
+        $this->assertEqual($data['posts'][0]->post_text, 'Syria is still missing.');
+        $this->assertEqual($data['posts'][1]->post_text, 'Baltimore needs our help.');
+        $this->assertEqual($data['posts'][2]->post_text, 'I hate Trump.');
 
         $this->dumpRenderedInsight($result, $this->instance, "Three Topics");
     }
@@ -219,28 +220,28 @@ class TestOfEOYTopStoriesInsight extends ThinkUpInsightUnitTestCase {
             array(
                 'pub_date' => "$year-02-01", 'post_id' => 1, 'author_username' => $this->instance->network_username,
                 'author_user_id' => $this->instance->network_user_id, 'network' => $this->instance->network,
-                'post_text' => 'World Cup!!!!',
+                'post_text' => 'Oh no, Paris.',
             )
         );
         $builders[] = FixtureBuilder::build('posts',
             array(
                 'pub_date' => "$year-03-01", 'post_id' => 2, 'author_username' => $this->instance->network_username,
                 'author_user_id' => $this->instance->network_user_id, 'network' => $this->instance->network,
-                'post_text' => 'Super Bowl!!!!',
+                'post_text' => 'Let in the refugees.',
             )
         );
         $builders[] = FixtureBuilder::build('posts',
             array(
                 'pub_date' => "$year-04-05", 'post_id' => 3, 'author_username' => $this->instance->network_username,
                 'author_user_id' => $this->instance->network_user_id, 'network' => $this->instance->network,
-                'post_text' => 'Robin Williams. ;(',
+                'post_text' => 'I stand for gay marriage.',
             )
         );
         $builders[] = FixtureBuilder::build('posts',
             array(
                 'pub_date' => "$year-01-01", 'post_id' => 4, 'author_username' => $this->instance->network_username,
                 'author_user_id' => $this->instance->network_user_id, 'network' => $this->instance->network,
-                'post_text' => 'MH370?',
+                'post_text' => 'istandwithahmed?',
             )
         );
         $insight_plugin = new EOYTopStoriesInsight();
@@ -251,14 +252,15 @@ class TestOfEOYTopStoriesInsight extends ThinkUpInsightUnitTestCase {
         $this->assertNotNull($result);
 
         $this->assertEqual($result->headline, "Anderson Cooper was part of $year's biggest trends");
-        $this->assertEqual($result->text, "Anderson Cooper's $year included MH370, the World Cup, the Super Bowl, and "
-            . "Robin Williams. Those were some of <a href=\"http://newsroom.fb.com/news/2014/12/2014-year-in-"
-            . "review/\">Facebook's top topics of the year</a> &mdash; that's so $year!");
+        $this->assertEqual($result->text, "Anderson Cooper's $year included Ahmed Mohamed, terror attacks,"
+            . " the Syrian refugee crisis, and marriage equality. "
+            . "Those were some of <a href=\"http://newsroom.fb.com/news/2015/12/2015-year-in-"
+            . "review/\">Facebook's top topics of the year</a>.");
         $data = unserialize($result->related_data);
         $this->assertEqual(3, count($data['posts']));
-        $this->assertEqual($data['posts'][0]->post_text, 'MH370?');
-        $this->assertEqual($data['posts'][1]->post_text, 'World Cup!!!!');
-        $this->assertEqual($data['posts'][2]->post_text, 'Super Bowl!!!!');
+        $this->assertEqual($data['posts'][0]->post_text, 'istandwithahmed?');
+        $this->assertEqual($data['posts'][1]->post_text, 'Oh no, Paris.');
+        $this->assertEqual($data['posts'][2]->post_text, 'Let in the refugees.');
 
         $this->dumpRenderedInsight($result, $this->instance, "Four Topics (three posts)");
     }
@@ -270,14 +272,14 @@ class TestOfEOYTopStoriesInsight extends ThinkUpInsightUnitTestCase {
             array(
                 'pub_date' => "$year-02-01", 'post_id' => 1, 'author_username' => $this->instance->network_username,
                 'author_user_id' => $this->instance->network_user_id, 'network' => $this->instance->network,
-                'post_text' => 'Super Bowl!!!',
+                'post_text' => 'Nepal. :(',
             )
         );
         $builders[] = FixtureBuilder::build('posts',
             array(
                 'pub_date' => "$year-01-11", 'post_id' => 2, 'author_username' => $this->instance->network_username,
                 'author_user_id' => $this->instance->network_user_id, 'network' => $this->instance->network,
-                'post_text' => 'Super bowl, tomorrow!',
+                'post_text' => 'Sad about the earthquake.',
             )
         );
         $insight_plugin = new EOYTopStoriesInsight();
@@ -288,12 +290,12 @@ class TestOfEOYTopStoriesInsight extends ThinkUpInsightUnitTestCase {
         $this->assertNotNull($result);
 
         $this->assertEqual($result->headline, "Anderson Cooper was part of $year's biggest trends");
-        $this->assertEqual($result->text, "Anderson Cooper's $year included the Super Bowl. That was one of "
-            . "<a href=\"http://newsroom.fb.com/news/2014/12/2014-year-in-review/\">Facebook's top topics of the "
-            . "year</a> &mdash; that's so $year!");
+        $this->assertEqual($result->text, "Anderson Cooper's $year included the Nepal earthquake. That was one of "
+            . "<a href=\"http://newsroom.fb.com/news/2015/12/2015-year-in-review/\">Facebook's top topics of the "
+            . "year</a>.");
         $data = unserialize($result->related_data);
         $this->assertEqual(1, count($data['posts']));
-        $this->assertEqual($data['posts'][0]->post_text, 'Super bowl, tomorrow!');
+        $this->assertEqual($data['posts'][0]->post_text, 'Sad about the earthquake.');
 
         $this->dumpRenderedInsight($result, $this->instance, "One Topic, Mentioned multiple times");
     }


### PR DESCRIPTION
Use Facebook's 2015 Year in Review topics

* the U.S. Presidential election
* the Syrian refugee crisis
* terror attacks
* the Nepal earthquake
* marriage equality
* the Planned Parenthood attack
* #BlackLivesMatter
* Charleston
* Ahmed Mohamed
* Floyd Mayweather, Jr.
* Manny Pacquiao
* Ronda Rousey
* Tom Brady
* Stephen Curry
* Serena Williams
* Ed Sheeran
* Taylor Swift
* Kanye West
* Caitlyn Jenner
* Star Wars
* Avengers
* Mad Max
* Magic Mike
* Game of Thrones
* Walking Dead

These are mostly super fucking depressing.